### PR TITLE
Latin & Cyrillic small fixes

### DIFF
--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -14,8 +14,6 @@
     <string>Google Sans</string>
     <key>guidelines</key>
     <array/>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -62,6 +60,8 @@
       <integer>542</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/D_hook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/D_hook.glif
@@ -41,8 +41,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>=Bhook</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=D</string>
     </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/F_ivethousand-roman.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/F_ivethousand-roman.glif
@@ -30,24 +30,24 @@
       <point x="237" y="61" type="line"/>
     </contour>
     <contour>
-      <point x="207" y="197" type="line"/>
-      <point x="337" y="197" type="line" smooth="yes"/>
-      <point x="430" y="197"/>
-      <point x="498" y="253"/>
-      <point x="498" y="358" type="curve" smooth="yes"/>
-      <point x="498" y="463"/>
-      <point x="430" y="521"/>
-      <point x="337" y="521" type="curve" smooth="yes"/>
-      <point x="207" y="521" type="line"/>
-      <point x="207" y="462" type="line"/>
-      <point x="342" y="462" type="line" smooth="yes"/>
-      <point x="398" y="462"/>
-      <point x="435" y="432"/>
-      <point x="435" y="358" type="curve" smooth="yes"/>
-      <point x="435" y="283"/>
-      <point x="398" y="256"/>
-      <point x="342" y="256" type="curve" smooth="yes"/>
-      <point x="207" y="256" type="line"/>
+      <point x="207" y="196" type="line"/>
+      <point x="337" y="196" type="line" smooth="yes"/>
+      <point x="430" y="196"/>
+      <point x="498" y="252"/>
+      <point x="498" y="357" type="curve" smooth="yes"/>
+      <point x="498" y="462"/>
+      <point x="430" y="520"/>
+      <point x="337" y="520" type="curve" smooth="yes"/>
+      <point x="207" y="520" type="line"/>
+      <point x="207" y="461" type="line"/>
+      <point x="342" y="461" type="line" smooth="yes"/>
+      <point x="398" y="461"/>
+      <point x="435" y="431"/>
+      <point x="435" y="357" type="curve" smooth="yes"/>
+      <point x="435" y="282"/>
+      <point x="398" y="255"/>
+      <point x="342" y="255" type="curve" smooth="yes"/>
+      <point x="207" y="255" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="785"/>
   <unicode hex="0132"/>
-  <anchor x="676" y="716" name="top.UC_2"/>
   <anchor x="124" y="716" name="top.UC.1"/>
+  <anchor x="676" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="89" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_u-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/I_u-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iu-cy" format="2">
-  <advance width="1005"/>
+  <advance width="1009"/>
   <unicode hex="042E"/>
   <anchor x="503" y="716" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_open.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/O_open.glif
@@ -39,6 +39,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=|C</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|C</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/T_enthousand-roman.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/T_enthousand-roman.glif
@@ -31,20 +31,20 @@
       <point x="533" y="655" type="line"/>
     </contour>
     <contour>
-      <point x="697" y="198" type="line" smooth="yes"/>
-      <point x="793" y="198"/>
-      <point x="858" y="253"/>
-      <point x="858" y="358" type="curve" smooth="yes"/>
-      <point x="858" y="463"/>
-      <point x="793" y="520"/>
-      <point x="697" y="520" type="curve"/>
-      <point x="432" y="520" type="line" smooth="yes"/>
-      <point x="336" y="520"/>
-      <point x="271" y="463"/>
-      <point x="271" y="358" type="curve" smooth="yes"/>
-      <point x="271" y="253"/>
-      <point x="336" y="198"/>
-      <point x="432" y="198" type="curve"/>
+      <point x="697" y="197" type="line" smooth="yes"/>
+      <point x="793" y="197"/>
+      <point x="858" y="252"/>
+      <point x="858" y="357" type="curve" smooth="yes"/>
+      <point x="858" y="462"/>
+      <point x="793" y="519"/>
+      <point x="697" y="519" type="curve"/>
+      <point x="432" y="519" type="line" smooth="yes"/>
+      <point x="336" y="519"/>
+      <point x="271" y="462"/>
+      <point x="271" y="357" type="curve" smooth="yes"/>
+      <point x="271" y="252"/>
+      <point x="336" y="197"/>
+      <point x="432" y="197" type="curve"/>
     </contour>
     <contour>
       <point x="432" y="253" type="line" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
@@ -40,16 +40,16 @@
       <point x="170" y="32"/>
     </contour>
     <contour>
-      <point x="-20" y="607" type="line"/>
-      <point x="620" y="607" type="line"/>
-      <point x="620" y="679" type="line"/>
-      <point x="-20" y="679" type="line"/>
-    </contour>
-    <contour>
       <point x="465" y="-77" type="line"/>
       <point x="546" y="-53" type="line"/>
       <point x="483" y="118" type="line"/>
       <point x="414" y="88" type="line"/>
+    </contour>
+    <contour>
+      <point x="-20" y="607" type="line"/>
+      <point x="620" y="607" type="line"/>
+      <point x="620" y="679" type="line"/>
+      <point x="-20" y="679" type="line"/>
     </contour>
     <component base="uMatra-deva" xOffset="109" yOffset="-31"/>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="634" y="315" type="line"/>
+      <point x="651" y="315" type="line" smooth="yes"/>
+      <point x="803" y="315"/>
+      <point x="892" y="414"/>
+      <point x="892" y="543" type="curve" smooth="yes"/>
+      <point x="892" y="662"/>
+      <point x="817" y="751"/>
+      <point x="696" y="751" type="curve" smooth="yes"/>
+      <point x="600" y="751"/>
+      <point x="516" y="689"/>
+      <point x="516" y="584" type="curve" smooth="yes"/>
+      <point x="516" y="512"/>
+      <point x="555" y="465"/>
+      <point x="612" y="465" type="curve" smooth="yes"/>
+      <point x="653" y="465"/>
+      <point x="687" y="495"/>
+      <point x="687" y="537" type="curve" smooth="yes"/>
+      <point x="687" y="579"/>
+      <point x="658" y="609"/>
+      <point x="620" y="609" type="curve" smooth="yes"/>
+      <point x="599" y="609"/>
+      <point x="579" y="600"/>
+      <point x="568" y="577" type="curve"/>
+      <point x="583" y="576" type="line"/>
+      <point x="583" y="586" type="line" smooth="yes"/>
+      <point x="583" y="651"/>
+      <point x="638" y="686"/>
+      <point x="695" y="686" type="curve" smooth="yes"/>
+      <point x="774" y="686"/>
+      <point x="820" y="627"/>
+      <point x="820" y="542" type="curve" smooth="yes"/>
+      <point x="820" y="446"/>
+      <point x="754" y="379"/>
+      <point x="651" y="379" type="curve" smooth="yes"/>
+      <point x="634" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="577" y="-250" type="line"/>
       <point x="647" y="-250" type="line"/>
       <point x="647" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="553" y="-12"/>
       <point x="574" y="16" type="curve"/>
       <point x="577" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="156" y="505" type="curve" smooth="yes"/>
+      <point x="138" y="505"/>
+      <point x="125" y="519"/>
+      <point x="125" y="537" type="curve" smooth="yes"/>
+      <point x="125" y="555"/>
+      <point x="138" y="569"/>
+      <point x="156" y="569" type="curve" smooth="yes"/>
+      <point x="173" y="569"/>
+      <point x="185" y="555"/>
+      <point x="185" y="537" type="curve" smooth="yes"/>
+      <point x="185" y="519"/>
+      <point x="173" y="505"/>
     </contour>
     <contour>
       <point x="174" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="294" y="379"/>
       <point x="191" y="379" type="curve" smooth="yes"/>
       <point x="174" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="156" y="505" type="curve" smooth="yes"/>
-      <point x="138" y="505"/>
-      <point x="125" y="519"/>
-      <point x="125" y="537" type="curve" smooth="yes"/>
-      <point x="125" y="555"/>
-      <point x="138" y="569"/>
-      <point x="156" y="569" type="curve" smooth="yes"/>
-      <point x="173" y="569"/>
-      <point x="185" y="555"/>
-      <point x="185" y="537" type="curve" smooth="yes"/>
-      <point x="185" y="519"/>
-      <point x="173" y="505"/>
-    </contour>
-    <contour>
-      <point x="634" y="315" type="line"/>
-      <point x="651" y="315" type="line" smooth="yes"/>
-      <point x="803" y="315"/>
-      <point x="892" y="414"/>
-      <point x="892" y="543" type="curve" smooth="yes"/>
-      <point x="892" y="662"/>
-      <point x="817" y="751"/>
-      <point x="696" y="751" type="curve" smooth="yes"/>
-      <point x="600" y="751"/>
-      <point x="516" y="689"/>
-      <point x="516" y="584" type="curve" smooth="yes"/>
-      <point x="516" y="512"/>
-      <point x="555" y="465"/>
-      <point x="612" y="465" type="curve" smooth="yes"/>
-      <point x="653" y="465"/>
-      <point x="687" y="495"/>
-      <point x="687" y="537" type="curve" smooth="yes"/>
-      <point x="687" y="579"/>
-      <point x="658" y="609"/>
-      <point x="620" y="609" type="curve" smooth="yes"/>
-      <point x="599" y="609"/>
-      <point x="579" y="600"/>
-      <point x="568" y="577" type="curve"/>
-      <point x="583" y="576" type="line"/>
-      <point x="583" y="586" type="line" smooth="yes"/>
-      <point x="583" y="651"/>
-      <point x="638" y="686"/>
-      <point x="695" y="686" type="curve" smooth="yes"/>
-      <point x="774" y="686"/>
-      <point x="820" y="627"/>
-      <point x="820" y="542" type="curve" smooth="yes"/>
-      <point x="820" y="446"/>
-      <point x="754" y="379"/>
-      <point x="651" y="379" type="curve" smooth="yes"/>
-      <point x="634" y="379" type="line"/>
     </contour>
     <contour>
       <point x="616" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="174" y="-250" type="line"/>
-      <point x="191" y="-250" type="line" smooth="yes"/>
-      <point x="343" y="-250"/>
-      <point x="432" y="-151"/>
-      <point x="432" y="-22" type="curve" smooth="yes"/>
-      <point x="432" y="97"/>
-      <point x="357" y="186"/>
-      <point x="236" y="186" type="curve" smooth="yes"/>
-      <point x="140" y="186"/>
-      <point x="56" y="124"/>
-      <point x="56" y="19" type="curve" smooth="yes"/>
-      <point x="56" y="-53"/>
-      <point x="95" y="-100"/>
-      <point x="152" y="-100" type="curve" smooth="yes"/>
-      <point x="193" y="-100"/>
-      <point x="227" y="-70"/>
-      <point x="227" y="-28" type="curve" smooth="yes"/>
-      <point x="227" y="14"/>
-      <point x="198" y="44"/>
-      <point x="160" y="44" type="curve" smooth="yes"/>
-      <point x="139" y="44"/>
-      <point x="119" y="35"/>
-      <point x="108" y="12" type="curve"/>
-      <point x="123" y="11" type="line"/>
-      <point x="123" y="21" type="line" smooth="yes"/>
-      <point x="123" y="86"/>
-      <point x="178" y="121"/>
-      <point x="235" y="121" type="curve" smooth="yes"/>
-      <point x="314" y="121"/>
-      <point x="360" y="62"/>
-      <point x="360" y="-23" type="curve" smooth="yes"/>
-      <point x="360" y="-119"/>
-      <point x="294" y="-186"/>
-      <point x="191" y="-186" type="curve" smooth="yes"/>
-      <point x="174" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="156" y="-60" type="curve" smooth="yes"/>
-      <point x="138" y="-60"/>
-      <point x="125" y="-46"/>
-      <point x="125" y="-28" type="curve" smooth="yes"/>
-      <point x="125" y="-10"/>
-      <point x="138" y="4"/>
-      <point x="156" y="4" type="curve" smooth="yes"/>
-      <point x="173" y="4"/>
-      <point x="185" y="-10"/>
-      <point x="185" y="-28" type="curve" smooth="yes"/>
-      <point x="185" y="-46"/>
-      <point x="173" y="-60"/>
-    </contour>
-    <contour>
       <point x="634" y="-250" type="line"/>
       <point x="651" y="-250" type="line" smooth="yes"/>
       <point x="803" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="754" y="-186"/>
       <point x="651" y="-186" type="curve" smooth="yes"/>
       <point x="634" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="156" y="-60" type="curve" smooth="yes"/>
+      <point x="138" y="-60"/>
+      <point x="125" y="-46"/>
+      <point x="125" y="-28" type="curve" smooth="yes"/>
+      <point x="125" y="-10"/>
+      <point x="138" y="4"/>
+      <point x="156" y="4" type="curve" smooth="yes"/>
+      <point x="173" y="4"/>
+      <point x="185" y="-10"/>
+      <point x="185" y="-28" type="curve" smooth="yes"/>
+      <point x="185" y="-46"/>
+      <point x="173" y="-60"/>
+    </contour>
+    <contour>
+      <point x="174" y="-250" type="line"/>
+      <point x="191" y="-250" type="line" smooth="yes"/>
+      <point x="343" y="-250"/>
+      <point x="432" y="-151"/>
+      <point x="432" y="-22" type="curve" smooth="yes"/>
+      <point x="432" y="97"/>
+      <point x="357" y="186"/>
+      <point x="236" y="186" type="curve" smooth="yes"/>
+      <point x="140" y="186"/>
+      <point x="56" y="124"/>
+      <point x="56" y="19" type="curve" smooth="yes"/>
+      <point x="56" y="-53"/>
+      <point x="95" y="-100"/>
+      <point x="152" y="-100" type="curve" smooth="yes"/>
+      <point x="193" y="-100"/>
+      <point x="227" y="-70"/>
+      <point x="227" y="-28" type="curve" smooth="yes"/>
+      <point x="227" y="14"/>
+      <point x="198" y="44"/>
+      <point x="160" y="44" type="curve" smooth="yes"/>
+      <point x="139" y="44"/>
+      <point x="119" y="35"/>
+      <point x="108" y="12" type="curve"/>
+      <point x="123" y="11" type="line"/>
+      <point x="123" y="21" type="line" smooth="yes"/>
+      <point x="123" y="86"/>
+      <point x="178" y="121"/>
+      <point x="235" y="121" type="curve" smooth="yes"/>
+      <point x="314" y="121"/>
+      <point x="360" y="62"/>
+      <point x="360" y="-23" type="curve" smooth="yes"/>
+      <point x="360" y="-119"/>
+      <point x="294" y="-186"/>
+      <point x="191" y="-186" type="curve" smooth="yes"/>
+      <point x="174" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="616" y="-60" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="520"/>
   <unicode hex="025B"/>
-  <anchor x="343" y="0" name="ogonek"/>
   <anchor x="251" y="0" name="bottom"/>
+  <anchor x="343" y="0" name="ogonek"/>
   <anchor x="260" y="526" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="964"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="676" y="0" name="bottom_2"/>
-  <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
+  <anchor x="323" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="689"/>
   <anchor x="320" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="316"/>
     <component base="flig2"/>
+    <component base="f" xOffset="316"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1280"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="996" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
-  <advance width="1256"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="970" y="0" name="bottom_3"/>
+  <advance width="1255"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="908"/>
+  <anchor x="162" y="0" name="bottom_1"/>
+  <anchor x="478" y="0" name="bottom_2"/>
+  <anchor x="794" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
+  <anchor x="219" y="734" name="top_1"/>
+  <anchor x="535" y="734" name="top_2"/>
+  <anchor x="794" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="i" xOffset="680"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="535" y="734" name="top_2"/>
   <anchor x="794" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="j" xOffset="680"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1178"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="946" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="997"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="860" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="836" y="670" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig2" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
-  <advance width="940"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="654" y="0" name="bottom_2"/>
+  <advance width="939"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="362"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="862"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="630" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="593"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="681"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="544" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="520" y="670" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="321"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
@@ -1,48 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="789"/>
+  <advance width="799"/>
   <unicode hex="044E"/>
-  <anchor x="395" y="526" name="top"/>
+  <anchor x="400" y="526" name="top"/>
   <outline>
     <contour>
-      <point x="502" y="-16" type="curve" smooth="yes"/>
-      <point x="653" y="-16"/>
-      <point x="747" y="98"/>
-      <point x="747" y="263" type="curve" smooth="yes"/>
-      <point x="747" y="428"/>
-      <point x="653" y="542"/>
-      <point x="502" y="542" type="curve" smooth="yes"/>
-      <point x="364" y="542"/>
-      <point x="255" y="438"/>
-      <point x="255" y="266" type="curve" smooth="yes"/>
-      <point x="255" y="90"/>
-      <point x="362" y="-16"/>
+      <point x="507" y="-16" type="curve" smooth="yes"/>
+      <point x="658" y="-16"/>
+      <point x="752" y="98"/>
+      <point x="752" y="263" type="curve" smooth="yes"/>
+      <point x="752" y="428"/>
+      <point x="658" y="542"/>
+      <point x="507" y="542" type="curve" smooth="yes"/>
+      <point x="369" y="542"/>
+      <point x="261" y="438"/>
+      <point x="260" y="266" type="curve" smooth="yes"/>
+      <point x="259" y="90"/>
+      <point x="367" y="-16"/>
     </contour>
     <contour>
-      <point x="77" y="0" type="line"/>
-      <point x="142" y="0" type="line"/>
-      <point x="142" y="526" type="line"/>
-      <point x="77" y="526" type="line"/>
+      <point x="83" y="0" type="line"/>
+      <point x="147" y="0" type="line"/>
+      <point x="147" y="526" type="line"/>
+      <point x="83" y="526" type="line"/>
     </contour>
     <contour>
-      <point x="117" y="237" type="line"/>
-      <point x="298" y="237" type="line"/>
-      <point x="298" y="296" type="line"/>
-      <point x="117" y="296" type="line"/>
+      <point x="122" y="237" type="line"/>
+      <point x="303" y="237" type="line"/>
+      <point x="303" y="294" type="line"/>
+      <point x="122" y="294" type="line"/>
     </contour>
     <contour>
-      <point x="502" y="43" type="curve" smooth="yes"/>
-      <point x="395" y="43"/>
-      <point x="316" y="123"/>
-      <point x="316" y="263" type="curve" smooth="yes"/>
-      <point x="316" y="402"/>
-      <point x="395" y="483"/>
-      <point x="502" y="483" type="curve" smooth="yes"/>
-      <point x="609" y="483"/>
-      <point x="685" y="402"/>
-      <point x="685" y="263" type="curve" smooth="yes"/>
-      <point x="685" y="123"/>
-      <point x="609" y="43"/>
+      <point x="507" y="43" type="curve" smooth="yes"/>
+      <point x="400" y="43"/>
+      <point x="321" y="123"/>
+      <point x="321" y="263" type="curve" smooth="yes"/>
+      <point x="321" y="402"/>
+      <point x="400" y="483"/>
+      <point x="507" y="483" type="curve" smooth="yes"/>
+      <point x="614" y="483"/>
+      <point x="690" y="402"/>
+      <point x="690" y="263" type="curve" smooth="yes"/>
+      <point x="690" y="123"/>
+      <point x="614" y="43"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="395" y="526" name="top"/>
   <outline>
     <contour>
+      <point x="83" y="0" type="line"/>
+      <point x="146" y="0" type="line"/>
+      <point x="146" y="776" type="line"/>
+      <point x="83" y="776" type="line"/>
+    </contour>
+    <contour>
       <point x="502" y="-16" type="curve" smooth="yes"/>
       <point x="643" y="-16"/>
       <point x="742" y="98"/>
@@ -12,22 +18,10 @@
       <point x="643" y="542"/>
       <point x="502" y="542" type="curve" smooth="yes"/>
       <point x="374" y="542"/>
-      <point x="261" y="449"/>
+      <point x="262" y="449"/>
       <point x="261" y="267" type="curve" smooth="yes"/>
-      <point x="261" y="82"/>
+      <point x="260" y="82"/>
       <point x="372" y="-16"/>
-    </contour>
-    <contour>
-      <point x="117" y="235" type="line"/>
-      <point x="297" y="235" type="line"/>
-      <point x="297" y="296" type="line"/>
-      <point x="117" y="296" type="line"/>
-    </contour>
-    <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="146" y="0" type="line"/>
-      <point x="146" y="776" type="line"/>
-      <point x="81" y="776" type="line"/>
     </contour>
     <contour>
       <point x="502" y="51" type="curve" smooth="yes"/>
@@ -35,13 +29,19 @@
       <point x="324" y="125"/>
       <point x="324" y="263" type="curve" smooth="yes"/>
       <point x="324" y="401"/>
-      <point x="397" y="475"/>
+      <point x="397" y="474"/>
       <point x="502" y="475" type="curve" smooth="yes"/>
-      <point x="607" y="475"/>
+      <point x="607" y="476"/>
       <point x="678" y="401"/>
       <point x="678" y="263" type="curve" smooth="yes"/>
       <point x="678" y="125"/>
       <point x="607" y="51"/>
+    </contour>
+    <contour>
+      <point x="117" y="235" type="line"/>
+      <point x="297" y="235" type="line"/>
+      <point x="297" y="296" type="line"/>
+      <point x="117" y="296" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
@@ -1,47 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.sc" format="2">
-  <advance width="835"/>
-  <anchor x="418" y="580" name="top"/>
+  <advance width="828"/>
+  <anchor x="413" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="528" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="785" y="110"/>
-      <point x="785" y="290" type="curve" smooth="yes"/>
-      <point x="785" y="471"/>
-      <point x="683" y="596"/>
-      <point x="528" y="596" type="curve" smooth="yes"/>
-      <point x="386" y="596"/>
-      <point x="271" y="481"/>
-      <point x="271" y="289" type="curve" smooth="yes"/>
-      <point x="271" y="97"/>
-      <point x="381" y="-16"/>
+      <point x="523" y="-16" type="curve" smooth="yes"/>
+      <point x="678" y="-16"/>
+      <point x="780" y="110"/>
+      <point x="780" y="290" type="curve" smooth="yes"/>
+      <point x="780" y="471"/>
+      <point x="678" y="596"/>
+      <point x="523" y="596" type="curve" smooth="yes"/>
+      <point x="381" y="596"/>
+      <point x="266" y="481"/>
+      <point x="266" y="289" type="curve" smooth="yes"/>
+      <point x="266" y="97"/>
+      <point x="376" y="-16"/>
     </contour>
     <contour>
-      <point x="83" y="0" type="line"/>
-      <point x="148" y="0" type="line"/>
-      <point x="148" y="580" type="line"/>
-      <point x="83" y="580" type="line"/>
+      <point x="78" y="0" type="line"/>
+      <point x="143" y="0" type="line"/>
+      <point x="143" y="580" type="line"/>
+      <point x="78" y="580" type="line"/>
     </contour>
     <contour>
-      <point x="118" y="268" type="line"/>
-      <point x="306" y="268" type="line"/>
-      <point x="306" y="326" type="line"/>
-      <point x="118" y="326" type="line"/>
+      <point x="113" y="268" type="line"/>
+      <point x="301" y="268" type="line"/>
+      <point x="301" y="326" type="line"/>
+      <point x="113" y="326" type="line"/>
     </contour>
     <contour>
-      <point x="528" y="43" type="curve" smooth="yes"/>
-      <point x="415" y="43"/>
-      <point x="334" y="127"/>
-      <point x="334" y="290" type="curve" smooth="yes"/>
-      <point x="334" y="453"/>
-      <point x="415" y="537"/>
-      <point x="528" y="537" type="curve" smooth="yes"/>
-      <point x="640" y="537"/>
-      <point x="722" y="453"/>
-      <point x="722" y="290" type="curve" smooth="yes"/>
-      <point x="722" y="127"/>
-      <point x="640" y="43"/>
+      <point x="523" y="43" type="curve" smooth="yes"/>
+      <point x="410" y="43"/>
+      <point x="329" y="127"/>
+      <point x="329" y="290" type="curve" smooth="yes"/>
+      <point x="329" y="453"/>
+      <point x="410" y="537"/>
+      <point x="523" y="537" type="curve" smooth="yes"/>
+      <point x="635" y="537"/>
+      <point x="717" y="453"/>
+      <point x="717" y="290" type="curve" smooth="yes"/>
+      <point x="717" y="127"/>
+      <point x="635" y="43"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="716" y="226" type="curve"/>
     </contour>
     <contour>
-      <point x="439" y="-369" type="curve" smooth="yes"/>
-      <point x="406" y="-369"/>
-      <point x="390" y="-347"/>
-      <point x="390" y="-302" type="curve" smooth="yes"/>
-      <point x="390" y="-257"/>
-      <point x="406" y="-235"/>
-      <point x="439" y="-235" type="curve" smooth="yes"/>
-      <point x="469" y="-235"/>
-      <point x="484" y="-257"/>
-      <point x="484" y="-302" type="curve" smooth="yes"/>
-      <point x="484" y="-347"/>
-      <point x="469" y="-369"/>
-    </contour>
-    <contour>
-      <point x="441" y="-437" type="curve" smooth="yes"/>
-      <point x="517" y="-437"/>
-      <point x="560" y="-388"/>
-      <point x="560" y="-302" type="curve" smooth="yes"/>
-      <point x="560" y="-218"/>
-      <point x="517" y="-167"/>
-      <point x="446" y="-167" type="curve" smooth="yes"/>
-      <point x="377" y="-167"/>
-      <point x="322" y="-234"/>
-      <point x="322" y="-318" type="curve" smooth="yes"/>
-      <point x="322" y="-394"/>
-      <point x="366" y="-437"/>
-    </contour>
-    <contour>
       <point x="602" y="-421" type="line"/>
       <point x="682" y="-421" type="line"/>
       <point x="682" y="253" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="549" y="-75"/>
       <point x="602" y="-131"/>
       <point x="602" y="-224" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="441" y="-437" type="curve" smooth="yes"/>
+      <point x="517" y="-437"/>
+      <point x="560" y="-388"/>
+      <point x="560" y="-302" type="curve" smooth="yes"/>
+      <point x="560" y="-218"/>
+      <point x="517" y="-167"/>
+      <point x="446" y="-167" type="curve" smooth="yes"/>
+      <point x="377" y="-167"/>
+      <point x="322" y="-234"/>
+      <point x="322" y="-318" type="curve" smooth="yes"/>
+      <point x="322" y="-394"/>
+      <point x="366" y="-437"/>
+    </contour>
+    <contour>
+      <point x="439" y="-369" type="curve" smooth="yes"/>
+      <point x="406" y="-369"/>
+      <point x="390" y="-347"/>
+      <point x="390" y="-302" type="curve" smooth="yes"/>
+      <point x="390" y="-257"/>
+      <point x="406" y="-235"/>
+      <point x="439" y="-235" type="curve" smooth="yes"/>
+      <point x="469" y="-235"/>
+      <point x="484" y="-257"/>
+      <point x="484" y="-302" type="curve" smooth="yes"/>
+      <point x="484" y="-347"/>
+      <point x="469" y="-369"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ngo-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ngo-khmer.glif
@@ -38,7 +38,7 @@
       <point x="253" y="366" type="curve" smooth="yes"/>
       <point x="296" y="366"/>
       <point x="330" y="379"/>
-      <point x="383" y="407" type="curve" name="8.1 ⛔️"/>
+      <point x="383" y="407" type="curve"/>
       <point x="416" y="429"/>
       <point x="472" y="449"/>
       <point x="472" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nine.ss03.glif
@@ -10,8 +10,8 @@
       <point x="471" y="341"/>
       <point x="508" y="404"/>
       <point x="508" y="493" type="curve" smooth="yes"/>
-      <point x="508" y="617.9657085313349"/>
-      <point x="421.5444224069248" y="732"/>
+      <point x="508" y="617.966"/>
+      <point x="421.544" y="732"/>
       <point x="280" y="732" type="curve" smooth="yes"/>
       <point x="149" y="732"/>
       <point x="53" y="623"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/oopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/oopen.glif
@@ -35,4 +35,10 @@
       <point x="407" y="542"/>
     </contour>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>o</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/oopen.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/oopen.sc.glif
@@ -38,6 +38,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>c.sc</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>c.sc</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/percent.glif
@@ -1,10 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="864"/>
+  <advance width="866"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="428" yOffset="-394"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-394"/>
     <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="866"/>
   <outline>
     <contour>
-      <point x="220" y="0" type="line"/>
-      <point x="702" y="716" type="line"/>
-      <point x="642" y="716" type="line"/>
-      <point x="159" y="0" type="line"/>
+      <point x="222" y="0" type="line"/>
+      <point x="704" y="716" type="line"/>
+      <point x="644" y="716" type="line"/>
+      <point x="162" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1424"/>
+  <advance width="1422"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-394"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="428" yOffset="-394"/>
-    <component base="zeropercent" xOffset="703" yOffset="-394"/>
-    <component base="zeropercent" xOffset="979" yOffset="-394"/>
+    <component base="zeropercent" xOffset="705" yOffset="-394"/>
+    <component base="zeropercent" xOffset="983" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1144"/>
+  <advance width="1140"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="428" yOffset="-394"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-394"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="708" yOffset="-394"/>
+    <component base="zeropercent" xOffset="701" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="90" y="495" type="line"/>
-      <point x="147" y="495" type="line" name="hr00"/>
+      <point x="147" y="495" type="line"/>
       <point x="147" y="716" type="line"/>
       <point x="90" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/r_f.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
-  <advance width="752"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="328" y="0" name="caret_1"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="748" name="top_2"/>
+  <advance width="749"/>
+  <anchor x="325" y="0" name="caret_1"/>
   <outline>
-    <component base="rlig"/>
-    <component base="f" xOffset="379"/>
+    <component base="rlig" xOffset="-3"/>
+    <component base="f" xOffset="376"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1068"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="857" y="0" name="bottom_3"/>
   <anchor x="328" y="0" name="caret_1"/>
   <anchor x="699" y="0" name="caret_2"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="734" name="top_2"/>
-  <anchor x="914" y="734" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/r_t.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
-  <advance width="749"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="612" y="0" name="bottom_2"/>
-  <anchor x="330" y="0" name="caret_1"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="588" y="670" name="top_2"/>
+  <advance width="752"/>
+  <anchor x="333" y="0" name="caret_1"/>
   <outline>
-    <component base="r.alt"/>
-    <component base="t" xOffset="389"/>
+    <component base="r.alt" xOffset="3"/>
+    <component base="t" xOffset="392"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="515" y="373" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="540" y="-169" type="curve" smooth="yes"/>
-      <point x="502" y="-169"/>
-      <point x="484" y="-145"/>
-      <point x="484" y="-97" type="curve" smooth="yes"/>
-      <point x="484" y="-46"/>
-      <point x="500" y="-25"/>
-      <point x="540" y="-25" type="curve" smooth="yes"/>
-      <point x="575" y="-25"/>
-      <point x="592" y="-49"/>
-      <point x="592" y="-97" type="curve" smooth="yes"/>
-      <point x="592" y="-145"/>
-      <point x="575" y="-169"/>
-    </contour>
-    <contour>
-      <point x="542" y="-237" type="curve" smooth="yes"/>
-      <point x="622" y="-237"/>
-      <point x="668" y="-186"/>
-      <point x="668" y="-97" type="curve" smooth="yes"/>
-      <point x="668" y="-10"/>
-      <point x="622" y="43"/>
-      <point x="547" y="43" type="curve" smooth="yes"/>
-      <point x="468" y="43"/>
-      <point x="418" y="-32"/>
-      <point x="418" y="-126" type="curve" smooth="yes"/>
-      <point x="418" y="-194"/>
-      <point x="464" y="-237"/>
-    </contour>
-    <contour>
       <point x="397" y="69" type="line"/>
       <point x="397" y="140" type="line"/>
       <point x="311" y="189" type="line"/>
@@ -102,6 +74,34 @@
       <point x="362" y="36" type="curve" smooth="yes"/>
       <point x="362" y="-33"/>
       <point x="401" y="-85"/>
+    </contour>
+    <contour>
+      <point x="542" y="-237" type="curve" smooth="yes"/>
+      <point x="622" y="-237"/>
+      <point x="668" y="-186"/>
+      <point x="668" y="-97" type="curve" smooth="yes"/>
+      <point x="668" y="-10"/>
+      <point x="622" y="43"/>
+      <point x="547" y="43" type="curve" smooth="yes"/>
+      <point x="468" y="43"/>
+      <point x="418" y="-32"/>
+      <point x="418" y="-126" type="curve" smooth="yes"/>
+      <point x="418" y="-194"/>
+      <point x="464" y="-237"/>
+    </contour>
+    <contour>
+      <point x="540" y="-169" type="curve" smooth="yes"/>
+      <point x="502" y="-169"/>
+      <point x="484" y="-145"/>
+      <point x="484" y="-97" type="curve" smooth="yes"/>
+      <point x="484" y="-46"/>
+      <point x="500" y="-25"/>
+      <point x="540" y="-25" type="curve" smooth="yes"/>
+      <point x="575" y="-25"/>
+      <point x="592" y="-49"/>
+      <point x="592" y="-97" type="curve" smooth="yes"/>
+      <point x="592" y="-145"/>
+      <point x="575" y="-169"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/six.ss03.glif
@@ -24,8 +24,8 @@
       <point x="91" y="374"/>
       <point x="53" y="313"/>
       <point x="53" y="223" type="curve" smooth="yes"/>
-      <point x="53" y="109.35636456605349"/>
-      <point x="118.26930998597106" y="-16"/>
+      <point x="53" y="109.356"/>
+      <point x="118.269" y="-16"/>
     </contour>
     <contour>
       <point x="281" y="25" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="684"/>
-  <anchor x="171" y="0" name="bottom_1"/>
-  <anchor x="473" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="180" y="255" name="center_1"/>
-  <anchor x="493" y="255" name="center_2"/>
-  <anchor x="199" y="670" name="top_1"/>
-  <anchor x="530" y="734" name="top_2"/>
-  <anchor x="265" y="526" name="topright_1"/>
-  <anchor x="581" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="311"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="676"/>
-  <anchor x="223" y="0" name="bottom_1"/>
-  <anchor x="539" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="168" y="263" name="center_1"/>
-  <anchor x="506" y="263" name="center_2"/>
-  <anchor x="199" y="670" name="top_1"/>
-  <anchor x="515" y="670" name="top_2"/>
-  <anchor x="265" y="526" name="topright_1"/>
-  <anchor x="581" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/yhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/yhook.glif
@@ -44,7 +44,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=y</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>=whook+36</string>
+      <string>=whook</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
-      <point x="218" y="378" type="curve" smooth="yes"/>
-      <point x="316" y="378"/>
-      <point x="388" y="449"/>
-      <point x="388" y="555" type="curve" smooth="yes"/>
-      <point x="388" y="661"/>
-      <point x="316" y="732"/>
-      <point x="218" y="732" type="curve" smooth="yes"/>
-      <point x="120" y="732"/>
-      <point x="48" y="661"/>
-      <point x="48" y="555" type="curve" smooth="yes"/>
-      <point x="48" y="449"/>
-      <point x="120" y="378"/>
+      <point x="220" y="378" type="curve" smooth="yes"/>
+      <point x="315" y="378"/>
+      <point x="385" y="449"/>
+      <point x="385" y="555" type="curve" smooth="yes"/>
+      <point x="385" y="661"/>
+      <point x="315" y="732"/>
+      <point x="220" y="732" type="curve" smooth="yes"/>
+      <point x="125" y="732"/>
+      <point x="55" y="661"/>
+      <point x="55" y="555" type="curve" smooth="yes"/>
+      <point x="55" y="449"/>
+      <point x="125" y="378"/>
     </contour>
     <contour>
-      <point x="218" y="434" type="curve" smooth="yes"/>
-      <point x="151" y="434"/>
-      <point x="105" y="479"/>
-      <point x="105" y="555" type="curve" smooth="yes"/>
-      <point x="105" y="631"/>
-      <point x="151" y="676"/>
-      <point x="218" y="676" type="curve" smooth="yes"/>
-      <point x="285" y="676"/>
-      <point x="331" y="631"/>
-      <point x="331" y="555" type="curve" smooth="yes"/>
-      <point x="331" y="479"/>
-      <point x="285" y="434"/>
+      <point x="220" y="434" type="curve" smooth="yes"/>
+      <point x="156" y="434"/>
+      <point x="112" y="479"/>
+      <point x="112" y="555" type="curve" smooth="yes"/>
+      <point x="112" y="631"/>
+      <point x="156" y="676"/>
+      <point x="220" y="676" type="curve" smooth="yes"/>
+      <point x="284" y="676"/>
+      <point x="328" y="631"/>
+      <point x="328" y="555" type="curve" smooth="yes"/>
+      <point x="328" y="479"/>
+      <point x="284" y="434"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -67,8 +67,6 @@
         <integer>413</integer>
       </dict>
     </array>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -115,6 +113,8 @@
       <integer>542</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/D_hook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/D_hook.glif
@@ -41,8 +41,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>=Bhook</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=D</string>
     </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="785"/>
   <unicode hex="0132"/>
-  <anchor x="676" y="716" name="top.UC_2"/>
   <anchor x="127" y="716" name="top.UC.1"/>
+  <anchor x="676" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="84" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -40,16 +40,16 @@
       <point x="170" y="32"/>
     </contour>
     <contour>
-      <point x="-20" y="607" type="line"/>
-      <point x="620" y="607" type="line"/>
-      <point x="620" y="679" type="line"/>
-      <point x="-20" y="679" type="line"/>
-    </contour>
-    <contour>
       <point x="465" y="-77" type="line"/>
       <point x="546" y="-53" type="line"/>
       <point x="483" y="118" type="line"/>
       <point x="414" y="88" type="line"/>
+    </contour>
+    <contour>
+      <point x="-20" y="607" type="line"/>
+      <point x="620" y="607" type="line"/>
+      <point x="620" y="679" type="line"/>
+      <point x="-20" y="679" type="line"/>
     </contour>
     <component base="uMatra-deva" xOffset="109" yOffset="-31"/>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="634" y="315" type="line"/>
+      <point x="651" y="315" type="line" smooth="yes"/>
+      <point x="803" y="315"/>
+      <point x="892" y="414"/>
+      <point x="892" y="543" type="curve" smooth="yes"/>
+      <point x="892" y="662"/>
+      <point x="817" y="751"/>
+      <point x="696" y="751" type="curve" smooth="yes"/>
+      <point x="600" y="751"/>
+      <point x="516" y="689"/>
+      <point x="516" y="584" type="curve" smooth="yes"/>
+      <point x="516" y="512"/>
+      <point x="555" y="465"/>
+      <point x="612" y="465" type="curve" smooth="yes"/>
+      <point x="653" y="465"/>
+      <point x="687" y="495"/>
+      <point x="687" y="537" type="curve" smooth="yes"/>
+      <point x="687" y="579"/>
+      <point x="658" y="609"/>
+      <point x="620" y="609" type="curve" smooth="yes"/>
+      <point x="599" y="609"/>
+      <point x="579" y="600"/>
+      <point x="568" y="577" type="curve"/>
+      <point x="583" y="576" type="line"/>
+      <point x="583" y="586" type="line" smooth="yes"/>
+      <point x="583" y="651"/>
+      <point x="638" y="686"/>
+      <point x="695" y="686" type="curve" smooth="yes"/>
+      <point x="774" y="686"/>
+      <point x="820" y="627"/>
+      <point x="820" y="542" type="curve" smooth="yes"/>
+      <point x="820" y="446"/>
+      <point x="754" y="379"/>
+      <point x="651" y="379" type="curve" smooth="yes"/>
+      <point x="634" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="577" y="-250" type="line"/>
       <point x="647" y="-250" type="line"/>
       <point x="647" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="553" y="-12"/>
       <point x="574" y="16" type="curve"/>
       <point x="577" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="156" y="505" type="curve" smooth="yes"/>
+      <point x="138" y="505"/>
+      <point x="125" y="519"/>
+      <point x="125" y="537" type="curve" smooth="yes"/>
+      <point x="125" y="555"/>
+      <point x="138" y="569"/>
+      <point x="156" y="569" type="curve" smooth="yes"/>
+      <point x="173" y="569"/>
+      <point x="185" y="555"/>
+      <point x="185" y="537" type="curve" smooth="yes"/>
+      <point x="185" y="519"/>
+      <point x="173" y="505"/>
     </contour>
     <contour>
       <point x="174" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="294" y="379"/>
       <point x="191" y="379" type="curve" smooth="yes"/>
       <point x="174" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="156" y="505" type="curve" smooth="yes"/>
-      <point x="138" y="505"/>
-      <point x="125" y="519"/>
-      <point x="125" y="537" type="curve" smooth="yes"/>
-      <point x="125" y="555"/>
-      <point x="138" y="569"/>
-      <point x="156" y="569" type="curve" smooth="yes"/>
-      <point x="173" y="569"/>
-      <point x="185" y="555"/>
-      <point x="185" y="537" type="curve" smooth="yes"/>
-      <point x="185" y="519"/>
-      <point x="173" y="505"/>
-    </contour>
-    <contour>
-      <point x="634" y="315" type="line"/>
-      <point x="651" y="315" type="line" smooth="yes"/>
-      <point x="803" y="315"/>
-      <point x="892" y="414"/>
-      <point x="892" y="543" type="curve" smooth="yes"/>
-      <point x="892" y="662"/>
-      <point x="817" y="751"/>
-      <point x="696" y="751" type="curve" smooth="yes"/>
-      <point x="600" y="751"/>
-      <point x="516" y="689"/>
-      <point x="516" y="584" type="curve" smooth="yes"/>
-      <point x="516" y="512"/>
-      <point x="555" y="465"/>
-      <point x="612" y="465" type="curve" smooth="yes"/>
-      <point x="653" y="465"/>
-      <point x="687" y="495"/>
-      <point x="687" y="537" type="curve" smooth="yes"/>
-      <point x="687" y="579"/>
-      <point x="658" y="609"/>
-      <point x="620" y="609" type="curve" smooth="yes"/>
-      <point x="599" y="609"/>
-      <point x="579" y="600"/>
-      <point x="568" y="577" type="curve"/>
-      <point x="583" y="576" type="line"/>
-      <point x="583" y="586" type="line" smooth="yes"/>
-      <point x="583" y="651"/>
-      <point x="638" y="686"/>
-      <point x="695" y="686" type="curve" smooth="yes"/>
-      <point x="774" y="686"/>
-      <point x="820" y="627"/>
-      <point x="820" y="542" type="curve" smooth="yes"/>
-      <point x="820" y="446"/>
-      <point x="754" y="379"/>
-      <point x="651" y="379" type="curve" smooth="yes"/>
-      <point x="634" y="379" type="line"/>
     </contour>
     <contour>
       <point x="616" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="174" y="-250" type="line"/>
-      <point x="191" y="-250" type="line" smooth="yes"/>
-      <point x="343" y="-250"/>
-      <point x="432" y="-151"/>
-      <point x="432" y="-22" type="curve" smooth="yes"/>
-      <point x="432" y="97"/>
-      <point x="357" y="186"/>
-      <point x="236" y="186" type="curve" smooth="yes"/>
-      <point x="140" y="186"/>
-      <point x="56" y="124"/>
-      <point x="56" y="19" type="curve" smooth="yes"/>
-      <point x="56" y="-53"/>
-      <point x="95" y="-100"/>
-      <point x="152" y="-100" type="curve" smooth="yes"/>
-      <point x="193" y="-100"/>
-      <point x="227" y="-70"/>
-      <point x="227" y="-28" type="curve" smooth="yes"/>
-      <point x="227" y="14"/>
-      <point x="198" y="44"/>
-      <point x="160" y="44" type="curve" smooth="yes"/>
-      <point x="139" y="44"/>
-      <point x="119" y="35"/>
-      <point x="108" y="12" type="curve"/>
-      <point x="123" y="11" type="line"/>
-      <point x="123" y="21" type="line" smooth="yes"/>
-      <point x="123" y="86"/>
-      <point x="178" y="121"/>
-      <point x="235" y="121" type="curve" smooth="yes"/>
-      <point x="314" y="121"/>
-      <point x="360" y="62"/>
-      <point x="360" y="-23" type="curve" smooth="yes"/>
-      <point x="360" y="-119"/>
-      <point x="294" y="-186"/>
-      <point x="191" y="-186" type="curve" smooth="yes"/>
-      <point x="174" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="156" y="-60" type="curve" smooth="yes"/>
-      <point x="138" y="-60"/>
-      <point x="125" y="-46"/>
-      <point x="125" y="-28" type="curve" smooth="yes"/>
-      <point x="125" y="-10"/>
-      <point x="138" y="4"/>
-      <point x="156" y="4" type="curve" smooth="yes"/>
-      <point x="173" y="4"/>
-      <point x="185" y="-10"/>
-      <point x="185" y="-28" type="curve" smooth="yes"/>
-      <point x="185" y="-46"/>
-      <point x="173" y="-60"/>
-    </contour>
-    <contour>
       <point x="634" y="-250" type="line"/>
       <point x="651" y="-250" type="line" smooth="yes"/>
       <point x="803" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="754" y="-186"/>
       <point x="651" y="-186" type="curve" smooth="yes"/>
       <point x="634" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="156" y="-60" type="curve" smooth="yes"/>
+      <point x="138" y="-60"/>
+      <point x="125" y="-46"/>
+      <point x="125" y="-28" type="curve" smooth="yes"/>
+      <point x="125" y="-10"/>
+      <point x="138" y="4"/>
+      <point x="156" y="4" type="curve" smooth="yes"/>
+      <point x="173" y="4"/>
+      <point x="185" y="-10"/>
+      <point x="185" y="-28" type="curve" smooth="yes"/>
+      <point x="185" y="-46"/>
+      <point x="173" y="-60"/>
+    </contour>
+    <contour>
+      <point x="174" y="-250" type="line"/>
+      <point x="191" y="-250" type="line" smooth="yes"/>
+      <point x="343" y="-250"/>
+      <point x="432" y="-151"/>
+      <point x="432" y="-22" type="curve" smooth="yes"/>
+      <point x="432" y="97"/>
+      <point x="357" y="186"/>
+      <point x="236" y="186" type="curve" smooth="yes"/>
+      <point x="140" y="186"/>
+      <point x="56" y="124"/>
+      <point x="56" y="19" type="curve" smooth="yes"/>
+      <point x="56" y="-53"/>
+      <point x="95" y="-100"/>
+      <point x="152" y="-100" type="curve" smooth="yes"/>
+      <point x="193" y="-100"/>
+      <point x="227" y="-70"/>
+      <point x="227" y="-28" type="curve" smooth="yes"/>
+      <point x="227" y="14"/>
+      <point x="198" y="44"/>
+      <point x="160" y="44" type="curve" smooth="yes"/>
+      <point x="139" y="44"/>
+      <point x="119" y="35"/>
+      <point x="108" y="12" type="curve"/>
+      <point x="123" y="11" type="line"/>
+      <point x="123" y="21" type="line" smooth="yes"/>
+      <point x="123" y="86"/>
+      <point x="178" y="121"/>
+      <point x="235" y="121" type="curve" smooth="yes"/>
+      <point x="314" y="121"/>
+      <point x="360" y="62"/>
+      <point x="360" y="-23" type="curve" smooth="yes"/>
+      <point x="360" y="-119"/>
+      <point x="294" y="-186"/>
+      <point x="191" y="-186" type="curve" smooth="yes"/>
+      <point x="174" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="616" y="-60" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="520"/>
   <unicode hex="025B"/>
-  <anchor x="343" y="0" name="ogonek"/>
   <anchor x="251" y="0" name="bottom"/>
+  <anchor x="343" y="0" name="ogonek"/>
   <anchor x="260" y="526" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="964"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="676" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="689"/>
   <anchor x="320" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="316"/>
     <component base="flig2"/>
+    <component base="f" xOffset="316"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1280"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="996" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1256"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="970" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="908"/>
+  <anchor x="162" y="0" name="bottom_1"/>
+  <anchor x="478" y="0" name="bottom_2"/>
+  <anchor x="794" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
+  <anchor x="219" y="734" name="top_1"/>
+  <anchor x="535" y="734" name="top_2"/>
+  <anchor x="794" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="i" xOffset="680"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="535" y="734" name="top_2"/>
   <anchor x="794" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="j" xOffset="680"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1178"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="946" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="997"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="860" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="836" y="670" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig2" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="940"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="654" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="862"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="630" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="593"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="681"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="544" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="520" y="670" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="321"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/iu-cy.glif
@@ -13,9 +13,9 @@
       <point x="653" y="542"/>
       <point x="502" y="542" type="curve" smooth="yes"/>
       <point x="364" y="542"/>
-      <point x="255" y="438"/>
+      <point x="256" y="438"/>
       <point x="255" y="266" type="curve" smooth="yes"/>
-      <point x="255" y="90"/>
+      <point x="254" y="90"/>
       <point x="362" y="-16"/>
     </contour>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="395" y="526" name="top"/>
   <outline>
     <contour>
+      <point x="73" y="0" type="line"/>
+      <point x="157" y="0" type="line"/>
+      <point x="157" y="776" type="line"/>
+      <point x="73" y="776" type="line"/>
+    </contour>
+    <contour>
       <point x="502" y="-16" type="curve" smooth="yes"/>
       <point x="653" y="-16"/>
       <point x="747" y="98"/>
@@ -12,22 +18,10 @@
       <point x="653" y="542"/>
       <point x="502" y="542" type="curve" smooth="yes"/>
       <point x="364" y="542"/>
-      <point x="256" y="449"/>
+      <point x="257" y="449"/>
       <point x="256" y="267" type="curve" smooth="yes"/>
-      <point x="256" y="82"/>
+      <point x="255" y="82"/>
       <point x="362" y="-16"/>
-    </contour>
-    <contour>
-      <point x="117" y="227" type="line"/>
-      <point x="297" y="227" type="line"/>
-      <point x="297" y="304" type="line"/>
-      <point x="117" y="304" type="line"/>
-    </contour>
-    <contour>
-      <point x="73" y="0" type="line"/>
-      <point x="157" y="0" type="line"/>
-      <point x="157" y="776" type="line"/>
-      <point x="73" y="776" type="line"/>
     </contour>
     <contour>
       <point x="502" y="61" type="curve" smooth="yes"/>
@@ -42,6 +36,12 @@
       <point x="663" y="263" type="curve" smooth="yes"/>
       <point x="663" y="135"/>
       <point x="597" y="61"/>
+    </contour>
+    <contour>
+      <point x="117" y="227" type="line"/>
+      <point x="297" y="227" type="line"/>
+      <point x="297" y="304" type="line"/>
+      <point x="117" y="304" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="716" y="226" type="curve"/>
     </contour>
     <contour>
-      <point x="439" y="-369" type="curve" smooth="yes"/>
-      <point x="406" y="-369"/>
-      <point x="390" y="-347"/>
-      <point x="390" y="-302" type="curve" smooth="yes"/>
-      <point x="390" y="-257"/>
-      <point x="406" y="-235"/>
-      <point x="439" y="-235" type="curve" smooth="yes"/>
-      <point x="469" y="-235"/>
-      <point x="484" y="-257"/>
-      <point x="484" y="-302" type="curve" smooth="yes"/>
-      <point x="484" y="-347"/>
-      <point x="469" y="-369"/>
-    </contour>
-    <contour>
-      <point x="441" y="-437" type="curve" smooth="yes"/>
-      <point x="517" y="-437"/>
-      <point x="560" y="-388"/>
-      <point x="560" y="-302" type="curve" smooth="yes"/>
-      <point x="560" y="-218"/>
-      <point x="517" y="-167"/>
-      <point x="446" y="-167" type="curve" smooth="yes"/>
-      <point x="377" y="-167"/>
-      <point x="322" y="-234"/>
-      <point x="322" y="-318" type="curve" smooth="yes"/>
-      <point x="322" y="-394"/>
-      <point x="366" y="-437"/>
-    </contour>
-    <contour>
       <point x="602" y="-421" type="line"/>
       <point x="682" y="-421" type="line"/>
       <point x="682" y="253" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="549" y="-75"/>
       <point x="602" y="-131"/>
       <point x="602" y="-224" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="441" y="-437" type="curve" smooth="yes"/>
+      <point x="517" y="-437"/>
+      <point x="560" y="-388"/>
+      <point x="560" y="-302" type="curve" smooth="yes"/>
+      <point x="560" y="-218"/>
+      <point x="517" y="-167"/>
+      <point x="446" y="-167" type="curve" smooth="yes"/>
+      <point x="377" y="-167"/>
+      <point x="322" y="-234"/>
+      <point x="322" y="-318" type="curve" smooth="yes"/>
+      <point x="322" y="-394"/>
+      <point x="366" y="-437"/>
+    </contour>
+    <contour>
+      <point x="439" y="-369" type="curve" smooth="yes"/>
+      <point x="406" y="-369"/>
+      <point x="390" y="-347"/>
+      <point x="390" y="-302" type="curve" smooth="yes"/>
+      <point x="390" y="-257"/>
+      <point x="406" y="-235"/>
+      <point x="439" y="-235" type="curve" smooth="yes"/>
+      <point x="469" y="-235"/>
+      <point x="484" y="-257"/>
+      <point x="484" y="-302" type="curve" smooth="yes"/>
+      <point x="484" y="-347"/>
+      <point x="469" y="-369"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ngo-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ngo-khmer.glif
@@ -38,7 +38,7 @@
       <point x="253" y="366" type="curve" smooth="yes"/>
       <point x="296" y="366"/>
       <point x="330" y="379"/>
-      <point x="383" y="407" type="curve" name="8.1 ⛔️"/>
+      <point x="383" y="407" type="curve"/>
       <point x="416" y="429"/>
       <point x="472" y="449"/>
       <point x="472" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/percent.glif
@@ -1,10 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="864"/>
+  <advance width="866"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="428" yOffset="-394"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-394"/>
     <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="866"/>
   <outline>
     <contour>
       <point x="230" y="0" type="line"/>
-      <point x="712" y="716" type="line"/>
-      <point x="635" y="716" type="line"/>
-      <point x="152" y="0" type="line"/>
+      <point x="713" y="716" type="line"/>
+      <point x="636" y="716" type="line"/>
+      <point x="153" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1424"/>
+  <advance width="1410"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="percentbar"/>
-    <component base="zeropercent" xOffset="428" yOffset="-394"/>
-    <component base="zeropercent" xOffset="703" yOffset="-394"/>
-    <component base="zeropercent" xOffset="979" yOffset="-394"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-394"/>
+    <component base="percentbar" xOffset="-1"/>
+    <component base="zeropercent" xOffset="699" yOffset="-394"/>
+    <component base="zeropercent" xOffset="971" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1144"/>
+  <advance width="1140"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="428" yOffset="-394"/>
-    <component base="percentbar"/>
-    <component base="zeropercent" xOffset="708" yOffset="-394"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-394"/>
+    <component base="percentbar" xOffset="-1"/>
+    <component base="zeropercent" xOffset="701" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="80" y="495" type="line"/>
-      <point x="157" y="495" type="line" name="hr00"/>
+      <point x="157" y="495" type="line"/>
       <point x="157" y="716" type="line"/>
       <point x="80" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="752"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
   <anchor x="328" y="0" name="caret_1"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="748" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1068"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="857" y="0" name="bottom_3"/>
   <anchor x="328" y="0" name="caret_1"/>
   <anchor x="699" y="0" name="caret_2"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="734" name="top_2"/>
-  <anchor x="914" y="734" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="749"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="612" y="0" name="bottom_2"/>
   <anchor x="330" y="0" name="caret_1"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="588" y="670" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="389"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="515" y="373" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="540" y="-169" type="curve" smooth="yes"/>
-      <point x="502" y="-169"/>
-      <point x="484" y="-145"/>
-      <point x="484" y="-97" type="curve" smooth="yes"/>
-      <point x="484" y="-46"/>
-      <point x="500" y="-25"/>
-      <point x="540" y="-25" type="curve" smooth="yes"/>
-      <point x="575" y="-25"/>
-      <point x="592" y="-49"/>
-      <point x="592" y="-97" type="curve" smooth="yes"/>
-      <point x="592" y="-145"/>
-      <point x="575" y="-169"/>
-    </contour>
-    <contour>
-      <point x="542" y="-237" type="curve" smooth="yes"/>
-      <point x="622" y="-237"/>
-      <point x="668" y="-186"/>
-      <point x="668" y="-97" type="curve" smooth="yes"/>
-      <point x="668" y="-10"/>
-      <point x="622" y="43"/>
-      <point x="547" y="43" type="curve" smooth="yes"/>
-      <point x="468" y="43"/>
-      <point x="418" y="-32"/>
-      <point x="418" y="-126" type="curve" smooth="yes"/>
-      <point x="418" y="-194"/>
-      <point x="464" y="-237"/>
-    </contour>
-    <contour>
       <point x="397" y="69" type="line"/>
       <point x="397" y="140" type="line"/>
       <point x="311" y="189" type="line"/>
@@ -102,6 +74,34 @@
       <point x="362" y="36" type="curve" smooth="yes"/>
       <point x="362" y="-33"/>
       <point x="401" y="-85"/>
+    </contour>
+    <contour>
+      <point x="542" y="-237" type="curve" smooth="yes"/>
+      <point x="622" y="-237"/>
+      <point x="668" y="-186"/>
+      <point x="668" y="-97" type="curve" smooth="yes"/>
+      <point x="668" y="-10"/>
+      <point x="622" y="43"/>
+      <point x="547" y="43" type="curve" smooth="yes"/>
+      <point x="468" y="43"/>
+      <point x="418" y="-32"/>
+      <point x="418" y="-126" type="curve" smooth="yes"/>
+      <point x="418" y="-194"/>
+      <point x="464" y="-237"/>
+    </contour>
+    <contour>
+      <point x="540" y="-169" type="curve" smooth="yes"/>
+      <point x="502" y="-169"/>
+      <point x="484" y="-145"/>
+      <point x="484" y="-97" type="curve" smooth="yes"/>
+      <point x="484" y="-46"/>
+      <point x="500" y="-25"/>
+      <point x="540" y="-25" type="curve" smooth="yes"/>
+      <point x="575" y="-25"/>
+      <point x="592" y="-49"/>
+      <point x="592" y="-97" type="curve" smooth="yes"/>
+      <point x="592" y="-145"/>
+      <point x="575" y="-169"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/schwa.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/schwa.sc.glif
@@ -4,12 +4,4 @@
   <outline>
     <component base="schwa-cy.sc"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>schwa-cy.sc</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>schwa-cy.sc</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="684"/>
-  <anchor x="171" y="0" name="bottom_1"/>
-  <anchor x="473" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="180" y="255" name="center_1"/>
-  <anchor x="493" y="255" name="center_2"/>
-  <anchor x="199" y="670" name="top_1"/>
-  <anchor x="530" y="734" name="top_2"/>
-  <anchor x="265" y="526" name="topright_1"/>
-  <anchor x="581" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="311"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="676"/>
-  <anchor x="223" y="0" name="bottom_1"/>
-  <anchor x="539" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="168" y="263" name="center_1"/>
-  <anchor x="506" y="263" name="center_2"/>
-  <anchor x="199" y="670" name="top_1"/>
-  <anchor x="515" y="670" name="top_2"/>
-  <anchor x="265" y="526" name="topright_1"/>
-  <anchor x="581" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
-      <point x="218" y="378" type="curve" smooth="yes"/>
-      <point x="318" y="378"/>
-      <point x="392" y="449"/>
-      <point x="392" y="555" type="curve" smooth="yes"/>
-      <point x="392" y="661"/>
-      <point x="318" y="732"/>
-      <point x="218" y="732" type="curve" smooth="yes"/>
-      <point x="118" y="732"/>
-      <point x="44" y="661"/>
-      <point x="44" y="555" type="curve" smooth="yes"/>
-      <point x="44" y="449"/>
-      <point x="118" y="378"/>
+      <point x="220" y="378" type="curve" smooth="yes"/>
+      <point x="320" y="378"/>
+      <point x="394" y="449"/>
+      <point x="394" y="555" type="curve" smooth="yes"/>
+      <point x="394" y="661"/>
+      <point x="320" y="732"/>
+      <point x="220" y="732" type="curve" smooth="yes"/>
+      <point x="120" y="732"/>
+      <point x="46" y="661"/>
+      <point x="46" y="555" type="curve" smooth="yes"/>
+      <point x="46" y="449"/>
+      <point x="120" y="378"/>
     </contour>
     <contour>
-      <point x="218" y="448" type="curve" smooth="yes"/>
-      <point x="160" y="448"/>
-      <point x="120" y="487"/>
-      <point x="120" y="555" type="curve" smooth="yes"/>
-      <point x="120" y="623"/>
-      <point x="160" y="662"/>
-      <point x="218" y="662" type="curve" smooth="yes"/>
-      <point x="276" y="662"/>
-      <point x="316" y="623"/>
-      <point x="316" y="555" type="curve" smooth="yes"/>
-      <point x="316" y="487"/>
-      <point x="276" y="448"/>
+      <point x="220" y="448" type="curve" smooth="yes"/>
+      <point x="162" y="448"/>
+      <point x="122" y="487"/>
+      <point x="122" y="555" type="curve" smooth="yes"/>
+      <point x="122" y="623"/>
+      <point x="162" y="662"/>
+      <point x="220" y="662" type="curve" smooth="yes"/>
+      <point x="278" y="662"/>
+      <point x="318" y="623"/>
+      <point x="318" y="555" type="curve" smooth="yes"/>
+      <point x="318" y="487"/>
+      <point x="278" y="448"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -14,8 +14,6 @@
     <string>Google Sans</string>
     <key>guidelines</key>
     <array/>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -62,6 +60,8 @@
       <integer>542</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/D_hook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/D_hook.glif
@@ -41,8 +41,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>=Bhook</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=D</string>
     </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_u-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/I_u-cy.glif
@@ -1,48 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iu-cy" format="2">
-  <advance width="1005"/>
+  <advance width="1002"/>
   <unicode hex="042E"/>
-  <anchor x="503" y="716" name="top"/>
+  <anchor x="500" y="716" name="top"/>
   <outline>
     <contour>
-      <point x="631" y="-16" type="curve" smooth="yes"/>
-      <point x="827" y="-16"/>
-      <point x="967" y="135"/>
-      <point x="967" y="358" type="curve" smooth="yes"/>
-      <point x="967" y="581"/>
-      <point x="818" y="732"/>
-      <point x="631" y="732" type="curve" smooth="yes"/>
-      <point x="450" y="732"/>
-      <point x="294" y="594"/>
-      <point x="294" y="361" type="curve" smooth="yes"/>
-      <point x="294" y="120"/>
-      <point x="443" y="-16"/>
+      <point x="628" y="-16" type="curve" smooth="yes"/>
+      <point x="824" y="-16"/>
+      <point x="964" y="135"/>
+      <point x="964" y="358" type="curve" smooth="yes"/>
+      <point x="964" y="581"/>
+      <point x="815" y="732"/>
+      <point x="628" y="732" type="curve" smooth="yes"/>
+      <point x="447" y="732"/>
+      <point x="291" y="594"/>
+      <point x="291" y="361" type="curve" smooth="yes"/>
+      <point x="291" y="120"/>
+      <point x="440" y="-16"/>
     </contour>
     <contour>
-      <point x="74" y="0" type="line"/>
-      <point x="199" y="0" type="line"/>
-      <point x="199" y="716" type="line"/>
-      <point x="74" y="716" type="line"/>
+      <point x="71" y="0" type="line"/>
+      <point x="196" y="0" type="line"/>
+      <point x="196" y="716" type="line"/>
+      <point x="71" y="716" type="line"/>
     </contour>
     <contour>
-      <point x="129" y="306" type="line"/>
-      <point x="346" y="306" type="line"/>
-      <point x="346" y="422" type="line"/>
-      <point x="129" y="422" type="line"/>
+      <point x="126" y="306" type="line"/>
+      <point x="343" y="306" type="line"/>
+      <point x="343" y="422" type="line"/>
+      <point x="126" y="422" type="line"/>
     </contour>
     <contour>
-      <point x="631" y="100" type="curve" smooth="yes"/>
-      <point x="504" y="100"/>
-      <point x="420" y="178"/>
-      <point x="420" y="358" type="curve" smooth="yes"/>
-      <point x="420" y="538"/>
-      <point x="505" y="616"/>
-      <point x="631" y="616" type="curve" smooth="yes"/>
-      <point x="756" y="616"/>
-      <point x="842" y="540"/>
-      <point x="842" y="358" type="curve" smooth="yes"/>
-      <point x="842" y="176"/>
-      <point x="757" y="100"/>
+      <point x="628" y="100" type="curve" smooth="yes"/>
+      <point x="501" y="100"/>
+      <point x="417" y="178"/>
+      <point x="417" y="358" type="curve" smooth="yes"/>
+      <point x="417" y="538"/>
+      <point x="502" y="616"/>
+      <point x="628" y="616" type="curve" smooth="yes"/>
+      <point x="753" y="616"/>
+      <point x="839" y="540"/>
+      <point x="839" y="358" type="curve" smooth="yes"/>
+      <point x="839" y="176"/>
+      <point x="754" y="100"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/K_aiS_ymbol.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/K_aiS_ymbol.glif
@@ -28,6 +28,10 @@
   </outline>
   <lib>
     <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=K</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=K</string>
       <key>com.schriftgestaltung.Glyphs.leftMetricsKey</key>
       <string>=K</string>
       <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/baht.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/baht.glif
@@ -13,10 +13,10 @@
       <point x="551" y="353"/>
       <point x="473" y="378" type="curve"/>
       <point x="473" y="382" type="line"/>
-      <point x="536.9999999999999" y="410"/>
+      <point x="537" y="410"/>
       <point x="578" y="459"/>
       <point x="578" y="545" type="curve" smooth="yes"/>
-      <point x="578" y="648.0000000000001"/>
+      <point x="578" y="648"/>
       <point x="489" y="716"/>
       <point x="372" y="716" type="curve" smooth="yes"/>
       <point x="74" y="716" type="line"/>
@@ -26,7 +26,7 @@
       <point x="189" y="606" type="line"/>
       <point x="356" y="606" type="line" smooth="yes"/>
       <point x="421" y="606"/>
-      <point x="465" y="601.9999999999999"/>
+      <point x="465" y="602"/>
       <point x="465" y="521" type="curve" smooth="yes"/>
       <point x="465" y="441"/>
       <point x="420" y="432"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
@@ -40,16 +40,16 @@
       <point x="170" y="32"/>
     </contour>
     <contour>
-      <point x="-20" y="607" type="line"/>
-      <point x="620" y="607" type="line"/>
-      <point x="620" y="679" type="line"/>
-      <point x="-20" y="679" type="line"/>
-    </contour>
-    <contour>
       <point x="465" y="-77" type="line"/>
       <point x="546" y="-53" type="line"/>
       <point x="483" y="118" type="line"/>
       <point x="414" y="88" type="line"/>
+    </contour>
+    <contour>
+      <point x="-20" y="607" type="line"/>
+      <point x="620" y="607" type="line"/>
+      <point x="620" y="679" type="line"/>
+      <point x="-20" y="679" type="line"/>
     </contour>
     <component base="uMatra-deva" xOffset="109" yOffset="-31"/>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="634" y="315" type="line"/>
+      <point x="651" y="315" type="line" smooth="yes"/>
+      <point x="803" y="315"/>
+      <point x="892" y="414"/>
+      <point x="892" y="543" type="curve" smooth="yes"/>
+      <point x="892" y="662"/>
+      <point x="817" y="751"/>
+      <point x="696" y="751" type="curve" smooth="yes"/>
+      <point x="600" y="751"/>
+      <point x="516" y="689"/>
+      <point x="516" y="584" type="curve" smooth="yes"/>
+      <point x="516" y="512"/>
+      <point x="555" y="465"/>
+      <point x="612" y="465" type="curve" smooth="yes"/>
+      <point x="653" y="465"/>
+      <point x="687" y="495"/>
+      <point x="687" y="537" type="curve" smooth="yes"/>
+      <point x="687" y="579"/>
+      <point x="658" y="609"/>
+      <point x="620" y="609" type="curve" smooth="yes"/>
+      <point x="599" y="609"/>
+      <point x="579" y="600"/>
+      <point x="568" y="577" type="curve"/>
+      <point x="583" y="576" type="line"/>
+      <point x="583" y="586" type="line" smooth="yes"/>
+      <point x="583" y="651"/>
+      <point x="638" y="686"/>
+      <point x="695" y="686" type="curve" smooth="yes"/>
+      <point x="774" y="686"/>
+      <point x="820" y="627"/>
+      <point x="820" y="542" type="curve" smooth="yes"/>
+      <point x="820" y="446"/>
+      <point x="754" y="379"/>
+      <point x="651" y="379" type="curve" smooth="yes"/>
+      <point x="634" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="577" y="-250" type="line"/>
       <point x="647" y="-250" type="line"/>
       <point x="647" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="553" y="-12"/>
       <point x="574" y="16" type="curve"/>
       <point x="577" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="156" y="505" type="curve" smooth="yes"/>
+      <point x="138" y="505"/>
+      <point x="125" y="519"/>
+      <point x="125" y="537" type="curve" smooth="yes"/>
+      <point x="125" y="555"/>
+      <point x="138" y="569"/>
+      <point x="156" y="569" type="curve" smooth="yes"/>
+      <point x="173" y="569"/>
+      <point x="185" y="555"/>
+      <point x="185" y="537" type="curve" smooth="yes"/>
+      <point x="185" y="519"/>
+      <point x="173" y="505"/>
     </contour>
     <contour>
       <point x="174" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="294" y="379"/>
       <point x="191" y="379" type="curve" smooth="yes"/>
       <point x="174" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="156" y="505" type="curve" smooth="yes"/>
-      <point x="138" y="505"/>
-      <point x="125" y="519"/>
-      <point x="125" y="537" type="curve" smooth="yes"/>
-      <point x="125" y="555"/>
-      <point x="138" y="569"/>
-      <point x="156" y="569" type="curve" smooth="yes"/>
-      <point x="173" y="569"/>
-      <point x="185" y="555"/>
-      <point x="185" y="537" type="curve" smooth="yes"/>
-      <point x="185" y="519"/>
-      <point x="173" y="505"/>
-    </contour>
-    <contour>
-      <point x="634" y="315" type="line"/>
-      <point x="651" y="315" type="line" smooth="yes"/>
-      <point x="803" y="315"/>
-      <point x="892" y="414"/>
-      <point x="892" y="543" type="curve" smooth="yes"/>
-      <point x="892" y="662"/>
-      <point x="817" y="751"/>
-      <point x="696" y="751" type="curve" smooth="yes"/>
-      <point x="600" y="751"/>
-      <point x="516" y="689"/>
-      <point x="516" y="584" type="curve" smooth="yes"/>
-      <point x="516" y="512"/>
-      <point x="555" y="465"/>
-      <point x="612" y="465" type="curve" smooth="yes"/>
-      <point x="653" y="465"/>
-      <point x="687" y="495"/>
-      <point x="687" y="537" type="curve" smooth="yes"/>
-      <point x="687" y="579"/>
-      <point x="658" y="609"/>
-      <point x="620" y="609" type="curve" smooth="yes"/>
-      <point x="599" y="609"/>
-      <point x="579" y="600"/>
-      <point x="568" y="577" type="curve"/>
-      <point x="583" y="576" type="line"/>
-      <point x="583" y="586" type="line" smooth="yes"/>
-      <point x="583" y="651"/>
-      <point x="638" y="686"/>
-      <point x="695" y="686" type="curve" smooth="yes"/>
-      <point x="774" y="686"/>
-      <point x="820" y="627"/>
-      <point x="820" y="542" type="curve" smooth="yes"/>
-      <point x="820" y="446"/>
-      <point x="754" y="379"/>
-      <point x="651" y="379" type="curve" smooth="yes"/>
-      <point x="634" y="379" type="line"/>
     </contour>
     <contour>
       <point x="616" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="174" y="-250" type="line"/>
-      <point x="191" y="-250" type="line" smooth="yes"/>
-      <point x="343" y="-250"/>
-      <point x="432" y="-151"/>
-      <point x="432" y="-22" type="curve" smooth="yes"/>
-      <point x="432" y="97"/>
-      <point x="357" y="186"/>
-      <point x="236" y="186" type="curve" smooth="yes"/>
-      <point x="140" y="186"/>
-      <point x="56" y="124"/>
-      <point x="56" y="19" type="curve" smooth="yes"/>
-      <point x="56" y="-53"/>
-      <point x="95" y="-100"/>
-      <point x="152" y="-100" type="curve" smooth="yes"/>
-      <point x="193" y="-100"/>
-      <point x="227" y="-70"/>
-      <point x="227" y="-28" type="curve" smooth="yes"/>
-      <point x="227" y="14"/>
-      <point x="198" y="44"/>
-      <point x="160" y="44" type="curve" smooth="yes"/>
-      <point x="139" y="44"/>
-      <point x="119" y="35"/>
-      <point x="108" y="12" type="curve"/>
-      <point x="123" y="11" type="line"/>
-      <point x="123" y="21" type="line" smooth="yes"/>
-      <point x="123" y="86"/>
-      <point x="178" y="121"/>
-      <point x="235" y="121" type="curve" smooth="yes"/>
-      <point x="314" y="121"/>
-      <point x="360" y="62"/>
-      <point x="360" y="-23" type="curve" smooth="yes"/>
-      <point x="360" y="-119"/>
-      <point x="294" y="-186"/>
-      <point x="191" y="-186" type="curve" smooth="yes"/>
-      <point x="174" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="156" y="-60" type="curve" smooth="yes"/>
-      <point x="138" y="-60"/>
-      <point x="125" y="-46"/>
-      <point x="125" y="-28" type="curve" smooth="yes"/>
-      <point x="125" y="-10"/>
-      <point x="138" y="4"/>
-      <point x="156" y="4" type="curve" smooth="yes"/>
-      <point x="173" y="4"/>
-      <point x="185" y="-10"/>
-      <point x="185" y="-28" type="curve" smooth="yes"/>
-      <point x="185" y="-46"/>
-      <point x="173" y="-60"/>
-    </contour>
-    <contour>
       <point x="634" y="-250" type="line"/>
       <point x="651" y="-250" type="line" smooth="yes"/>
       <point x="803" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="754" y="-186"/>
       <point x="651" y="-186" type="curve" smooth="yes"/>
       <point x="634" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="156" y="-60" type="curve" smooth="yes"/>
+      <point x="138" y="-60"/>
+      <point x="125" y="-46"/>
+      <point x="125" y="-28" type="curve" smooth="yes"/>
+      <point x="125" y="-10"/>
+      <point x="138" y="4"/>
+      <point x="156" y="4" type="curve" smooth="yes"/>
+      <point x="173" y="4"/>
+      <point x="185" y="-10"/>
+      <point x="185" y="-28" type="curve" smooth="yes"/>
+      <point x="185" y="-46"/>
+      <point x="173" y="-60"/>
+    </contour>
+    <contour>
+      <point x="174" y="-250" type="line"/>
+      <point x="191" y="-250" type="line" smooth="yes"/>
+      <point x="343" y="-250"/>
+      <point x="432" y="-151"/>
+      <point x="432" y="-22" type="curve" smooth="yes"/>
+      <point x="432" y="97"/>
+      <point x="357" y="186"/>
+      <point x="236" y="186" type="curve" smooth="yes"/>
+      <point x="140" y="186"/>
+      <point x="56" y="124"/>
+      <point x="56" y="19" type="curve" smooth="yes"/>
+      <point x="56" y="-53"/>
+      <point x="95" y="-100"/>
+      <point x="152" y="-100" type="curve" smooth="yes"/>
+      <point x="193" y="-100"/>
+      <point x="227" y="-70"/>
+      <point x="227" y="-28" type="curve" smooth="yes"/>
+      <point x="227" y="14"/>
+      <point x="198" y="44"/>
+      <point x="160" y="44" type="curve" smooth="yes"/>
+      <point x="139" y="44"/>
+      <point x="119" y="35"/>
+      <point x="108" y="12" type="curve"/>
+      <point x="123" y="11" type="line"/>
+      <point x="123" y="21" type="line" smooth="yes"/>
+      <point x="123" y="86"/>
+      <point x="178" y="121"/>
+      <point x="235" y="121" type="curve" smooth="yes"/>
+      <point x="314" y="121"/>
+      <point x="360" y="62"/>
+      <point x="360" y="-23" type="curve" smooth="yes"/>
+      <point x="360" y="-119"/>
+      <point x="294" y="-186"/>
+      <point x="191" y="-186" type="curve" smooth="yes"/>
+      <point x="174" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="616" y="-60" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/dhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/dhook.glif
@@ -56,8 +56,6 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=d</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>=|j</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="520"/>
   <unicode hex="025B"/>
-  <anchor x="343" y="0" name="ogonek"/>
   <anchor x="251" y="0" name="bottom"/>
+  <anchor x="343" y="0" name="ogonek"/>
   <anchor x="260" y="526" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="964"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="676" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="689"/>
   <anchor x="320" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="316"/>
     <component base="flig2"/>
+    <component base="f" xOffset="316"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1280"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="996" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1256"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="970" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="908"/>
+  <anchor x="162" y="0" name="bottom_1"/>
+  <anchor x="478" y="0" name="bottom_2"/>
+  <anchor x="794" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
+  <anchor x="219" y="734" name="top_1"/>
+  <anchor x="535" y="734" name="top_2"/>
+  <anchor x="794" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="i" xOffset="680"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="535" y="734" name="top_2"/>
   <anchor x="794" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="j" xOffset="680"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1178"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="946" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="794" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_f_t.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="997"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
-  <anchor x="860" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="636" y="0" name="caret_2"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="535" y="734" name="top_2"/>
-  <anchor x="836" y="670" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig2" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="940"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="654" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="862"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="630" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="593"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="478" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="478" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="363"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="681"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="544" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="219" y="734" name="top_1"/>
-  <anchor x="520" y="670" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="321"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.glif
@@ -1,22 +1,22 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="789"/>
+  <advance width="786"/>
   <unicode hex="044E"/>
   <anchor x="395" y="526" name="top"/>
   <outline>
     <contour>
       <point x="502" y="-16" type="curve" smooth="yes"/>
-      <point x="651" y="-16"/>
-      <point x="752" y="95"/>
+      <point x="658" y="-16"/>
+      <point x="751" y="94"/>
       <point x="752" y="263" type="curve" smooth="yes"/>
-      <point x="752" y="431"/>
-      <point x="653" y="542"/>
+      <point x="753" y="434"/>
+      <point x="659" y="542"/>
       <point x="502" y="542" type="curve" smooth="yes"/>
-      <point x="346" y="542"/>
-      <point x="241" y="432"/>
-      <point x="241" y="266" type="curve" smooth="yes"/>
-      <point x="241" y="96"/>
-      <point x="344" y="-16"/>
+      <point x="358" y="542"/>
+      <point x="251" y="445"/>
+      <point x="250" y="266" type="curve" smooth="yes"/>
+      <point x="249" y="83"/>
+      <point x="357" y="-16"/>
     </contour>
     <contour>
       <point x="63" y="0" type="line"/>
@@ -25,24 +25,24 @@
       <point x="63" y="526" type="line"/>
     </contour>
     <contour>
-      <point x="117" y="213" type="line"/>
-      <point x="298" y="213" type="line"/>
-      <point x="298" y="320" type="line"/>
-      <point x="117" y="320" type="line"/>
+      <point x="117" y="227" type="line"/>
+      <point x="298" y="227" type="line"/>
+      <point x="298" y="304" type="line"/>
+      <point x="117" y="304" type="line"/>
     </contour>
     <contour>
       <point x="502" y="91" type="curve" smooth="yes"/>
-      <point x="416" y="91"/>
-      <point x="359" y="160"/>
+      <point x="413" y="91"/>
+      <point x="359" y="139"/>
       <point x="359" y="263" type="curve" smooth="yes"/>
-      <point x="359" y="366"/>
-      <point x="416" y="435"/>
+      <point x="359" y="387"/>
+      <point x="412" y="435"/>
       <point x="502" y="435" type="curve" smooth="yes"/>
-      <point x="581" y="435"/>
-      <point x="634" y="366"/>
-      <point x="634" y="263" type="curve" smooth="yes"/>
-      <point x="634" y="160"/>
-      <point x="581" y="91"/>
+      <point x="593" y="435"/>
+      <point x="643" y="386"/>
+      <point x="643" y="263" type="curve" smooth="yes"/>
+      <point x="643" y="140"/>
+      <point x="592" y="91"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -1,28 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.loclBGR" format="2">
-  <advance width="789"/>
+  <advance width="791"/>
   <anchor x="395" y="526" name="top"/>
   <outline>
-    <contour>
-      <point x="502" y="-16" type="curve" smooth="yes"/>
-      <point x="651" y="-16"/>
-      <point x="752" y="95"/>
-      <point x="752" y="263" type="curve" smooth="yes"/>
-      <point x="752" y="431"/>
-      <point x="653" y="542"/>
-      <point x="502" y="542" type="curve" smooth="yes"/>
-      <point x="346" y="542"/>
-      <point x="241" y="432"/>
-      <point x="241" y="266" type="curve" smooth="yes"/>
-      <point x="241" y="96"/>
-      <point x="344" y="-16"/>
-    </contour>
-    <contour>
-      <point x="117" y="213" type="line"/>
-      <point x="298" y="213" type="line"/>
-      <point x="298" y="320" type="line"/>
-      <point x="117" y="320" type="line"/>
-    </contour>
     <contour>
       <point x="63" y="0" type="line"/>
       <point x="177" y="0" type="line"/>
@@ -30,18 +10,38 @@
       <point x="63" y="776" type="line"/>
     </contour>
     <contour>
+      <point x="502" y="-16" type="curve" smooth="yes"/>
+      <point x="660" y="-16"/>
+      <point x="757" y="98"/>
+      <point x="757" y="263" type="curve" smooth="yes"/>
+      <point x="757" y="428"/>
+      <point x="660" y="542"/>
+      <point x="502" y="542" type="curve" smooth="yes"/>
+      <point x="343" y="542"/>
+      <point x="247" y="449"/>
+      <point x="246" y="267" type="curve" smooth="yes"/>
+      <point x="245" y="82"/>
+      <point x="343" y="-16"/>
+    </contour>
+    <contour>
       <point x="502" y="91" type="curve" smooth="yes"/>
-      <point x="416" y="91"/>
-      <point x="359" y="160"/>
+      <point x="407" y="91"/>
+      <point x="359" y="145"/>
       <point x="359" y="263" type="curve" smooth="yes"/>
-      <point x="359" y="366"/>
-      <point x="416" y="435"/>
+      <point x="359" y="381"/>
+      <point x="407" y="435"/>
       <point x="502" y="435" type="curve" smooth="yes"/>
-      <point x="581" y="435"/>
-      <point x="634" y="366"/>
-      <point x="634" y="263" type="curve" smooth="yes"/>
-      <point x="634" y="160"/>
-      <point x="581" y="91"/>
+      <point x="597" y="435"/>
+      <point x="643" y="381"/>
+      <point x="643" y="263" type="curve" smooth="yes"/>
+      <point x="643" y="145"/>
+      <point x="597" y="91"/>
+    </contour>
+    <contour>
+      <point x="117" y="212" type="line"/>
+      <point x="297" y="212" type="line"/>
+      <point x="297" y="319" type="line"/>
+      <point x="117" y="319" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
@@ -24,10 +24,10 @@
       <point x="63" y="580" type="line"/>
     </contour>
     <contour>
-      <point x="118" y="244" type="line"/>
-      <point x="306" y="244" type="line"/>
-      <point x="306" y="352" type="line"/>
-      <point x="118" y="352" type="line"/>
+      <point x="118" y="248" type="line"/>
+      <point x="306" y="248" type="line"/>
+      <point x="306" y="346" type="line"/>
+      <point x="118" y="346" type="line"/>
     </contour>
     <contour>
       <point x="528" y="93" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="716" y="226" type="curve"/>
     </contour>
     <contour>
-      <point x="439" y="-369" type="curve" smooth="yes"/>
-      <point x="406" y="-369"/>
-      <point x="390" y="-347"/>
-      <point x="390" y="-302" type="curve" smooth="yes"/>
-      <point x="390" y="-257"/>
-      <point x="406" y="-235"/>
-      <point x="439" y="-235" type="curve" smooth="yes"/>
-      <point x="469" y="-235"/>
-      <point x="484" y="-257"/>
-      <point x="484" y="-302" type="curve" smooth="yes"/>
-      <point x="484" y="-347"/>
-      <point x="469" y="-369"/>
-    </contour>
-    <contour>
-      <point x="441" y="-437" type="curve" smooth="yes"/>
-      <point x="517" y="-437"/>
-      <point x="560" y="-388"/>
-      <point x="560" y="-302" type="curve" smooth="yes"/>
-      <point x="560" y="-218"/>
-      <point x="517" y="-167"/>
-      <point x="446" y="-167" type="curve" smooth="yes"/>
-      <point x="377" y="-167"/>
-      <point x="322" y="-234"/>
-      <point x="322" y="-318" type="curve" smooth="yes"/>
-      <point x="322" y="-394"/>
-      <point x="366" y="-437"/>
-    </contour>
-    <contour>
       <point x="602" y="-421" type="line"/>
       <point x="682" y="-421" type="line"/>
       <point x="682" y="253" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="549" y="-75"/>
       <point x="602" y="-131"/>
       <point x="602" y="-224" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="441" y="-437" type="curve" smooth="yes"/>
+      <point x="517" y="-437"/>
+      <point x="560" y="-388"/>
+      <point x="560" y="-302" type="curve" smooth="yes"/>
+      <point x="560" y="-218"/>
+      <point x="517" y="-167"/>
+      <point x="446" y="-167" type="curve" smooth="yes"/>
+      <point x="377" y="-167"/>
+      <point x="322" y="-234"/>
+      <point x="322" y="-318" type="curve" smooth="yes"/>
+      <point x="322" y="-394"/>
+      <point x="366" y="-437"/>
+    </contour>
+    <contour>
+      <point x="439" y="-369" type="curve" smooth="yes"/>
+      <point x="406" y="-369"/>
+      <point x="390" y="-347"/>
+      <point x="390" y="-302" type="curve" smooth="yes"/>
+      <point x="390" y="-257"/>
+      <point x="406" y="-235"/>
+      <point x="439" y="-235" type="curve" smooth="yes"/>
+      <point x="469" y="-235"/>
+      <point x="484" y="-257"/>
+      <point x="484" y="-302" type="curve" smooth="yes"/>
+      <point x="484" y="-347"/>
+      <point x="469" y="-369"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ngo-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ngo-khmer.glif
@@ -38,7 +38,7 @@
       <point x="253" y="366" type="curve" smooth="yes"/>
       <point x="296" y="366"/>
       <point x="330" y="379"/>
-      <point x="383" y="407" type="curve" name="8.1 ⛔️"/>
+      <point x="383" y="407" type="curve"/>
       <point x="416" y="429"/>
       <point x="472" y="449"/>
       <point x="472" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/percent.glif
@@ -1,10 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="864"/>
+  <advance width="866"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="428" yOffset="-377"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-368"/>
     <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/percentbar.glif
@@ -3,10 +3,10 @@
   <advance width="826"/>
   <outline>
     <contour>
-      <point x="244" y="0" type="line"/>
-      <point x="726" y="716" type="line"/>
-      <point x="621" y="716" type="line"/>
-      <point x="138" y="0" type="line"/>
+      <point x="243" y="0" type="line"/>
+      <point x="725" y="716" type="line"/>
+      <point x="620" y="716" type="line"/>
+      <point x="137" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1424"/>
+  <advance width="1422"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-368"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="428" yOffset="-374"/>
-    <component base="zeropercent" xOffset="703" yOffset="-374"/>
-    <component base="zeropercent" xOffset="979" yOffset="-374"/>
+    <component base="zeropercent" xOffset="705" yOffset="-368"/>
+    <component base="zeropercent" xOffset="983" yOffset="-368"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1144"/>
+  <advance width="1140"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="428" yOffset="-374"/>
+    <component base="zeropercent" xOffset="-1"/>
+    <component base="zeropercent" xOffset="427" yOffset="-368"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="708" yOffset="-374"/>
+    <component base="zeropercent" xOffset="701" yOffset="-368"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="62" y="495" type="line"/>
-      <point x="175" y="495" type="line" name="hr00"/>
+      <point x="175" y="495" type="line"/>
       <point x="175" y="716" type="line"/>
       <point x="62" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/r_f.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
-  <advance width="752"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="328" y="0" name="caret_1"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="748" name="top_2"/>
+  <advance width="751"/>
+  <anchor x="327" y="0" name="caret_1"/>
   <outline>
-    <component base="rlig"/>
-    <component base="f" xOffset="379"/>
+    <component base="rlig" xOffset="-1"/>
+    <component base="f" xOffset="378"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1068"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="857" y="0" name="bottom_3"/>
   <anchor x="328" y="0" name="caret_1"/>
   <anchor x="699" y="0" name="caret_2"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="734" name="top_2"/>
-  <anchor x="914" y="734" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="749"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="612" y="0" name="bottom_2"/>
   <anchor x="330" y="0" name="caret_1"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="588" y="670" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="389"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="515" y="373" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="540" y="-169" type="curve" smooth="yes"/>
-      <point x="502" y="-169"/>
-      <point x="484" y="-145"/>
-      <point x="484" y="-97" type="curve" smooth="yes"/>
-      <point x="484" y="-46"/>
-      <point x="500" y="-25"/>
-      <point x="540" y="-25" type="curve" smooth="yes"/>
-      <point x="575" y="-25"/>
-      <point x="592" y="-49"/>
-      <point x="592" y="-97" type="curve" smooth="yes"/>
-      <point x="592" y="-145"/>
-      <point x="575" y="-169"/>
-    </contour>
-    <contour>
-      <point x="542" y="-237" type="curve" smooth="yes"/>
-      <point x="622" y="-237"/>
-      <point x="668" y="-186"/>
-      <point x="668" y="-97" type="curve" smooth="yes"/>
-      <point x="668" y="-10"/>
-      <point x="622" y="43"/>
-      <point x="547" y="43" type="curve" smooth="yes"/>
-      <point x="468" y="43"/>
-      <point x="418" y="-32"/>
-      <point x="418" y="-126" type="curve" smooth="yes"/>
-      <point x="418" y="-194"/>
-      <point x="464" y="-237"/>
-    </contour>
-    <contour>
       <point x="397" y="69" type="line"/>
       <point x="397" y="140" type="line"/>
       <point x="311" y="189" type="line"/>
@@ -102,6 +74,34 @@
       <point x="362" y="36" type="curve" smooth="yes"/>
       <point x="362" y="-33"/>
       <point x="401" y="-85"/>
+    </contour>
+    <contour>
+      <point x="542" y="-237" type="curve" smooth="yes"/>
+      <point x="622" y="-237"/>
+      <point x="668" y="-186"/>
+      <point x="668" y="-97" type="curve" smooth="yes"/>
+      <point x="668" y="-10"/>
+      <point x="622" y="43"/>
+      <point x="547" y="43" type="curve" smooth="yes"/>
+      <point x="468" y="43"/>
+      <point x="418" y="-32"/>
+      <point x="418" y="-126" type="curve" smooth="yes"/>
+      <point x="418" y="-194"/>
+      <point x="464" y="-237"/>
+    </contour>
+    <contour>
+      <point x="540" y="-169" type="curve" smooth="yes"/>
+      <point x="502" y="-169"/>
+      <point x="484" y="-145"/>
+      <point x="484" y="-97" type="curve" smooth="yes"/>
+      <point x="484" y="-46"/>
+      <point x="500" y="-25"/>
+      <point x="540" y="-25" type="curve" smooth="yes"/>
+      <point x="575" y="-25"/>
+      <point x="592" y="-49"/>
+      <point x="592" y="-97" type="curve" smooth="yes"/>
+      <point x="592" y="-145"/>
+      <point x="575" y="-169"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/schwa.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/schwa.sc.glif
@@ -4,12 +4,4 @@
   <outline>
     <component base="schwa-cy.sc"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>schwa-cy.sc</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>schwa-cy.sc</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="684"/>
-  <anchor x="171" y="0" name="bottom_1"/>
-  <anchor x="473" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="180" y="255" name="center_1"/>
-  <anchor x="493" y="255" name="center_2"/>
-  <anchor x="199" y="670" name="top_1"/>
-  <anchor x="530" y="734" name="top_2"/>
-  <anchor x="265" y="526" name="topright_1"/>
-  <anchor x="581" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="311"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="676"/>
-  <anchor x="223" y="0" name="bottom_1"/>
-  <anchor x="539" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="168" y="263" name="center_1"/>
-  <anchor x="506" y="263" name="center_2"/>
-  <anchor x="199" y="670" name="top_1"/>
-  <anchor x="515" y="670" name="top_2"/>
-  <anchor x="265" y="526" name="topright_1"/>
-  <anchor x="581" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="316"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/yhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/yhook.glif
@@ -43,6 +43,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=whook</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
-      <point x="218" y="356" type="curve" smooth="yes"/>
-      <point x="328" y="356"/>
-      <point x="408" y="432"/>
-      <point x="408" y="546" type="curve" smooth="yes"/>
-      <point x="408" y="659"/>
-      <point x="328" y="735"/>
-      <point x="218" y="735" type="curve" smooth="yes"/>
-      <point x="108" y="735"/>
-      <point x="28" y="659"/>
-      <point x="28" y="546" type="curve" smooth="yes"/>
-      <point x="28" y="432"/>
-      <point x="108" y="356"/>
+      <point x="220" y="352" type="curve" smooth="yes"/>
+      <point x="329" y="352"/>
+      <point x="409" y="428"/>
+      <point x="409" y="542" type="curve" smooth="yes"/>
+      <point x="409" y="656"/>
+      <point x="329" y="732"/>
+      <point x="220" y="732" type="curve" smooth="yes"/>
+      <point x="111" y="732"/>
+      <point x="31" y="656"/>
+      <point x="31" y="542" type="curve" smooth="yes"/>
+      <point x="31" y="428"/>
+      <point x="111" y="352"/>
     </contour>
     <contour>
-      <point x="218" y="456" type="curve" smooth="yes"/>
-      <point x="169" y="456"/>
-      <point x="133" y="488"/>
-      <point x="133" y="546" type="curve" smooth="yes"/>
-      <point x="133" y="604"/>
-      <point x="169" y="636"/>
-      <point x="218" y="636" type="curve" smooth="yes"/>
-      <point x="267" y="636"/>
-      <point x="303" y="604"/>
-      <point x="303" y="546" type="curve" smooth="yes"/>
-      <point x="303" y="488"/>
-      <point x="267" y="456"/>
+      <point x="220" y="452" type="curve" smooth="yes"/>
+      <point x="172" y="452"/>
+      <point x="136" y="484"/>
+      <point x="136" y="542" type="curve" smooth="yes"/>
+      <point x="136" y="600"/>
+      <point x="172" y="632"/>
+      <point x="220" y="632" type="curve" smooth="yes"/>
+      <point x="268" y="632"/>
+      <point x="304" y="600"/>
+      <point x="304" y="542" type="curve" smooth="yes"/>
+      <point x="304" y="484"/>
+      <point x="268" y="452"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -65,8 +65,6 @@
         <integer>413</integer>
       </dict>
     </array>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -113,6 +111,8 @@
       <integer>542</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="885"/>
   <unicode hex="0132"/>
-  <anchor x="750" y="716" name="top.UC_2"/>
   <anchor x="155" y="716" name="top.UC.1"/>
+  <anchor x="750" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="88" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/I_u-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/I_u-cy.glif
@@ -13,9 +13,9 @@
       <point x="899" y="732"/>
       <point x="693" y="732" type="curve" smooth="yes"/>
       <point x="487" y="732"/>
-      <point x="355" y="583"/>
+      <point x="360" y="583"/>
       <point x="355" y="361" type="curve" smooth="yes"/>
-      <point x="355" y="139"/>
+      <point x="350" y="139"/>
       <point x="488" y="-16"/>
     </contour>
     <contour>
@@ -26,8 +26,8 @@
     </contour>
     <contour>
       <point x="162" y="302" type="line"/>
-      <point x="428" y="302" type="line"/>
-      <point x="428" y="430" type="line"/>
+      <point x="429" y="302" type="line"/>
+      <point x="427" y="430" type="line"/>
       <point x="162" y="430" type="line"/>
     </contour>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -40,16 +40,16 @@
       <point x="173" y="30"/>
     </contour>
     <contour>
-      <point x="-20" y="595" type="line"/>
-      <point x="648" y="595" type="line"/>
-      <point x="648" y="690" type="line"/>
-      <point x="-20" y="690" type="line"/>
-    </contour>
-    <contour>
       <point x="468" y="-82" type="line"/>
       <point x="571" y="-63" type="line"/>
       <point x="502" y="125" type="line"/>
       <point x="424" y="80" type="line"/>
+    </contour>
+    <contour>
+      <point x="-20" y="595" type="line"/>
+      <point x="648" y="595" type="line"/>
+      <point x="648" y="690" type="line"/>
+      <point x="-20" y="690" type="line"/>
     </contour>
     <component base="uMatra-deva" xOffset="105" yOffset="-38"/>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,33 +4,6 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
-      <point x="574" y="-250" type="line"/>
-      <point x="684" y="-250" type="line"/>
-      <point x="684" y="197" type="line"/>
-      <point x="576" y="197" type="line"/>
-      <point x="576" y="165" type="line" smooth="yes"/>
-      <point x="576" y="94"/>
-      <point x="530" y="34"/>
-      <point x="471" y="34" type="curve" smooth="yes"/>
-      <point x="439" y="34"/>
-      <point x="422" y="51"/>
-      <point x="422" y="74" type="curve" smooth="yes"/>
-      <point x="422" y="96"/>
-      <point x="440" y="108"/>
-      <point x="468" y="108" type="curve"/>
-      <point x="468" y="197" type="line"/>
-      <point x="366" y="197"/>
-      <point x="312" y="153"/>
-      <point x="312" y="75" type="curve" smooth="yes"/>
-      <point x="312" y="-2"/>
-      <point x="368" y="-56"/>
-      <point x="450" y="-56" type="curve" smooth="yes"/>
-      <point x="508" y="-56"/>
-      <point x="545" y="-31"/>
-      <point x="569" y="-4" type="curve"/>
-      <point x="574" y="-4" type="line"/>
-    </contour>
-    <contour>
       <point x="695" y="330" type="line"/>
       <point x="705" y="330" type="line" smooth="yes"/>
       <point x="871" y="330"/>
@@ -66,6 +39,33 @@
       <point x="792" y="428"/>
       <point x="705" y="428" type="curve" smooth="yes"/>
       <point x="695" y="428" type="line"/>
+    </contour>
+    <contour>
+      <point x="574" y="-250" type="line"/>
+      <point x="684" y="-250" type="line"/>
+      <point x="684" y="197" type="line"/>
+      <point x="576" y="197" type="line"/>
+      <point x="576" y="165" type="line" smooth="yes"/>
+      <point x="576" y="94"/>
+      <point x="530" y="34"/>
+      <point x="471" y="34" type="curve" smooth="yes"/>
+      <point x="439" y="34"/>
+      <point x="422" y="51"/>
+      <point x="422" y="74" type="curve" smooth="yes"/>
+      <point x="422" y="96"/>
+      <point x="440" y="108"/>
+      <point x="468" y="108" type="curve"/>
+      <point x="468" y="197" type="line"/>
+      <point x="366" y="197"/>
+      <point x="312" y="153"/>
+      <point x="312" y="75" type="curve" smooth="yes"/>
+      <point x="312" y="-2"/>
+      <point x="368" y="-56"/>
+      <point x="450" y="-56" type="curve" smooth="yes"/>
+      <point x="508" y="-56"/>
+      <point x="545" y="-31"/>
+      <point x="569" y="-4" type="curve"/>
+      <point x="574" y="-4" type="line"/>
     </contour>
     <contour>
       <point x="166" y="518" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/dhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/dhook.glif
@@ -56,8 +56,6 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=d</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>=|j</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/dhook.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/dhook.sc.glif
@@ -40,8 +40,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>bhook.sc</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>d.sc</string>
     </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="532"/>
   <unicode hex="025B"/>
-  <anchor x="355" y="0" name="ogonek"/>
   <anchor x="275" y="0" name="bottom"/>
+  <anchor x="355" y="0" name="ogonek"/>
   <anchor x="275" y="526" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="1032"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="774" y="0" name="bottom_2"/>
-  <anchor x="516" y="0" name="caret_1"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
+  <anchor x="351" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="395"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="755"/>
   <anchor x="358" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="351"/>
     <component base="flig2"/>
+    <component base="f" xOffset="351"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1383"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="1071" y="0" name="bottom_3"/>
   <anchor x="358" y="0" name="caret_1"/>
   <anchor x="709" y="0" name="caret_2"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="591" y="734" name="top_2"/>
-  <anchor x="884" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="351"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1369"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="534" y="0" name="bottom_2"/>
-  <anchor x="1060" y="0" name="bottom_3"/>
   <anchor x="358" y="0" name="caret_1"/>
   <anchor x="709" y="0" name="caret_2"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="591" y="734" name="top_2"/>
-  <anchor x="884" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="351"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="1023"/>
+  <anchor x="182" y="0" name="bottom_1"/>
+  <anchor x="533" y="0" name="bottom_2"/>
+  <anchor x="884" y="0" name="bottom_3"/>
   <anchor x="358" y="0" name="caret_1"/>
   <anchor x="709" y="0" name="caret_2"/>
+  <anchor x="240" y="734" name="top_1"/>
+  <anchor x="591" y="734" name="top_2"/>
+  <anchor x="885" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="351"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="351"/>
     <component base="i" xOffset="745"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_j.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_j" format="2">
-  <advance width="1023"/>
+  <advance width="1024"/>
   <anchor x="182" y="0" name="bottom_1"/>
   <anchor x="533" y="0" name="bottom_2"/>
   <anchor x="884" y="-216" name="bottom_3"/>
@@ -10,8 +10,8 @@
   <anchor x="591" y="734" name="top_2"/>
   <anchor x="885" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="351"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="351"/>
     <component base="j" xOffset="749"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1317"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="1039" y="0" name="bottom_3"/>
   <anchor x="358" y="0" name="caret_1"/>
   <anchor x="709" y="0" name="caret_2"/>
-  <anchor x="240" y="716" name="top_1"/>
-  <anchor x="591" y="716" name="top_2"/>
-  <anchor x="885" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="351"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="1115"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="955" y="0" name="bottom_3"/>
   <anchor x="358" y="0" name="caret_1"/>
   <anchor x="709" y="0" name="caret_2"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="591" y="734" name="top_2"/>
-  <anchor x="950" y="670" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="351"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="351"/>
     <component base="t" xOffset="700"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="1018"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="709" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="533" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="395"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_j.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_j" format="2">
-  <advance width="672"/>
+  <advance width="673"/>
   <anchor x="184" y="0" name="bottom_1"/>
   <anchor x="534" y="-216" name="bottom_2"/>
   <anchor x="358" y="0" name="caret_1"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="966"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="688" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="533" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="395"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="673"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
   <anchor x="363" y="0" name="caret_1"/>
-  <anchor x="240" y="734" name="top_1"/>
-  <anchor x="533" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="394" yOffset="1"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="764"/>
-  <anchor x="182" y="0" name="bottom_1"/>
-  <anchor x="609" y="0" name="bottom_2"/>
   <anchor x="358" y="0" name="caret_1"/>
-  <anchor x="240" y="716" name="top_1"/>
-  <anchor x="599" y="670" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="349"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="423" y="526" name="top"/>
   <outline>
     <contour>
+      <point x="73" y="0" type="line"/>
+      <point x="204" y="0" type="line"/>
+      <point x="204" y="776" type="line"/>
+      <point x="73" y="776" type="line"/>
+    </contour>
+    <contour>
       <point x="536" y="-16" type="curve" smooth="yes"/>
       <point x="693" y="-16"/>
       <point x="791" y="99"/>
@@ -12,22 +18,10 @@
       <point x="693" y="542"/>
       <point x="536" y="542" type="curve" smooth="yes"/>
       <point x="379" y="542"/>
-      <point x="281" y="428"/>
+      <point x="285" y="428"/>
       <point x="281" y="267" type="curve" smooth="yes"/>
-      <point x="281" y="106"/>
+      <point x="277" y="106"/>
       <point x="379" y="-16"/>
-    </contour>
-    <contour>
-      <point x="154" y="216" type="line"/>
-      <point x="352" y="216" type="line"/>
-      <point x="352" y="328" type="line"/>
-      <point x="154" y="328" type="line"/>
-    </contour>
-    <contour>
-      <point x="73" y="0" type="line"/>
-      <point x="204" y="0" type="line"/>
-      <point x="204" y="776" type="line"/>
-      <point x="73" y="776" type="line"/>
     </contour>
     <contour>
       <point x="536" y="106" type="curve" smooth="yes"/>
@@ -42,6 +36,12 @@
       <point x="660" y="263" type="curve" smooth="yes"/>
       <point x="660" y="160"/>
       <point x="609" y="106"/>
+    </contour>
+    <contour>
+      <point x="154" y="216" type="line"/>
+      <point x="352" y="216" type="line"/>
+      <point x="352" y="328" type="line"/>
+      <point x="154" y="328" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="747" y="216" type="curve"/>
     </contour>
     <contour>
-      <point x="430" y="-370" type="curve" smooth="yes"/>
-      <point x="400" y="-370"/>
-      <point x="385" y="-351"/>
-      <point x="385" y="-314" type="curve" smooth="yes"/>
-      <point x="385" y="-274"/>
-      <point x="398" y="-257"/>
-      <point x="430" y="-257" type="curve" smooth="yes"/>
-      <point x="459" y="-257"/>
-      <point x="474" y="-276"/>
-      <point x="474" y="-314" type="curve" smooth="yes"/>
-      <point x="474" y="-351"/>
-      <point x="459" y="-370"/>
-    </contour>
-    <contour>
-      <point x="436" y="-449" type="curve" smooth="yes"/>
-      <point x="517" y="-449"/>
-      <point x="564" y="-400"/>
-      <point x="564" y="-314" type="curve" smooth="yes"/>
-      <point x="564" y="-229"/>
-      <point x="519" y="-178"/>
-      <point x="444" y="-178" type="curve" smooth="yes"/>
-      <point x="369" y="-178"/>
-      <point x="309" y="-244"/>
-      <point x="309" y="-327" type="curve" smooth="yes"/>
-      <point x="309" y="-404"/>
-      <point x="356" y="-449"/>
-    </contour>
-    <contour>
       <point x="601" y="-431" type="line"/>
       <point x="700" y="-431" type="line"/>
       <point x="700" y="244" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="555" y="-84"/>
       <point x="601" y="-139"/>
       <point x="601" y="-228" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="436" y="-449" type="curve" smooth="yes"/>
+      <point x="517" y="-449"/>
+      <point x="564" y="-400"/>
+      <point x="564" y="-314" type="curve" smooth="yes"/>
+      <point x="564" y="-229"/>
+      <point x="519" y="-178"/>
+      <point x="444" y="-178" type="curve" smooth="yes"/>
+      <point x="369" y="-178"/>
+      <point x="309" y="-244"/>
+      <point x="309" y="-327" type="curve" smooth="yes"/>
+      <point x="309" y="-404"/>
+      <point x="356" y="-449"/>
+    </contour>
+    <contour>
+      <point x="430" y="-370" type="curve" smooth="yes"/>
+      <point x="400" y="-370"/>
+      <point x="385" y="-351"/>
+      <point x="385" y="-314" type="curve" smooth="yes"/>
+      <point x="385" y="-274"/>
+      <point x="398" y="-257"/>
+      <point x="430" y="-257" type="curve" smooth="yes"/>
+      <point x="459" y="-257"/>
+      <point x="474" y="-276"/>
+      <point x="474" y="-314" type="curve" smooth="yes"/>
+      <point x="474" y="-351"/>
+      <point x="459" y="-370"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/percent.glif
@@ -1,10 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="923"/>
+  <advance width="914"/>
   <unicode hex="0025"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="474" yOffset="-395"/>
+    <component base="zeropercent" xOffset="474" yOffset="-394"/>
     <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="923"/>
+  <advance width="914"/>
   <outline>
     <contour>
-      <point x="279" y="0" type="line"/>
-      <point x="759" y="716" type="line"/>
-      <point x="644" y="716" type="line"/>
-      <point x="164" y="0" type="line"/>
+      <point x="275" y="0" type="line"/>
+      <point x="754" y="716" type="line"/>
+      <point x="639" y="716" type="line"/>
+      <point x="160" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1429"/>
+  <advance width="1422"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="474" yOffset="-394"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="474" yOffset="-395"/>
-    <component base="zeropercent" xOffset="728" yOffset="-395"/>
-    <component base="zeropercent" xOffset="981" yOffset="-395"/>
+    <component base="zeropercent" xOffset="728" yOffset="-394"/>
+    <component base="zeropercent" xOffset="982" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1176"/>
+  <advance width="1170"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="474" yOffset="-395"/>
+    <component base="zeropercent" xOffset="474" yOffset="-394"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="728" yOffset="-395"/>
+    <component base="zeropercent" xOffset="730" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="52" y="490" type="line"/>
-      <point x="171" y="490" type="line" name="hr00"/>
+      <point x="171" y="490" type="line"/>
       <point x="171" y="716" type="line"/>
       <point x="52" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="826"/>
-  <anchor x="138" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
   <anchor x="371" y="0" name="caret_1"/>
-  <anchor x="239" y="526" name="top_1"/>
-  <anchor x="662" y="734" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="422"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1177"/>
-  <anchor x="138" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
-  <anchor x="955" y="0" name="bottom_3"/>
   <anchor x="371" y="0" name="caret_1"/>
   <anchor x="780" y="0" name="caret_2"/>
-  <anchor x="239" y="526" name="top_1"/>
-  <anchor x="662" y="734" name="top_2"/>
-  <anchor x="1013" y="734" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="422"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="847"/>
-  <anchor x="138" y="0" name="bottom_1"/>
-  <anchor x="692" y="0" name="bottom_2"/>
   <anchor x="377" y="0" name="caret_1"/>
-  <anchor x="239" y="526" name="top_1"/>
-  <anchor x="682" y="670" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="432"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="516" y="369" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="551" y="-170" type="curve" smooth="yes"/>
-      <point x="516" y="-170"/>
-      <point x="500" y="-149"/>
-      <point x="500" y="-108" type="curve" smooth="yes"/>
-      <point x="500" y="-63"/>
-      <point x="514" y="-46"/>
-      <point x="551" y="-46" type="curve" smooth="yes"/>
-      <point x="584" y="-46"/>
-      <point x="600" y="-67"/>
-      <point x="600" y="-108" type="curve" smooth="yes"/>
-      <point x="600" y="-149"/>
-      <point x="584" y="-170"/>
-    </contour>
-    <contour>
-      <point x="556" y="-249" type="curve" smooth="yes"/>
-      <point x="640" y="-249"/>
-      <point x="689" y="-198"/>
-      <point x="689" y="-108" type="curve" smooth="yes"/>
-      <point x="689" y="-20"/>
-      <point x="642" y="33"/>
-      <point x="566" y="33" type="curve" smooth="yes"/>
-      <point x="487" y="33"/>
-      <point x="426" y="-41"/>
-      <point x="426" y="-134" type="curve" smooth="yes"/>
-      <point x="426" y="-205"/>
-      <point x="475" y="-249"/>
-    </contour>
-    <contour>
       <point x="409" y="63" type="line"/>
       <point x="409" y="151" type="line"/>
       <point x="313" y="205" type="line"/>
@@ -102,6 +74,34 @@
       <point x="362" y="43" type="curve" smooth="yes"/>
       <point x="362" y="-30"/>
       <point x="400" y="-79"/>
+    </contour>
+    <contour>
+      <point x="556" y="-249" type="curve" smooth="yes"/>
+      <point x="640" y="-249"/>
+      <point x="689" y="-198"/>
+      <point x="689" y="-108" type="curve" smooth="yes"/>
+      <point x="689" y="-20"/>
+      <point x="642" y="33"/>
+      <point x="566" y="33" type="curve" smooth="yes"/>
+      <point x="487" y="33"/>
+      <point x="426" y="-41"/>
+      <point x="426" y="-134" type="curve" smooth="yes"/>
+      <point x="426" y="-205"/>
+      <point x="475" y="-249"/>
+    </contour>
+    <contour>
+      <point x="551" y="-170" type="curve" smooth="yes"/>
+      <point x="516" y="-170"/>
+      <point x="500" y="-149"/>
+      <point x="500" y="-108" type="curve" smooth="yes"/>
+      <point x="500" y="-63"/>
+      <point x="514" y="-46"/>
+      <point x="551" y="-46" type="curve" smooth="yes"/>
+      <point x="584" y="-46"/>
+      <point x="600" y="-67"/>
+      <point x="600" y="-108" type="curve" smooth="yes"/>
+      <point x="600" y="-149"/>
+      <point x="584" y="-170"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/schwa.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/schwa.sc.glif
@@ -4,12 +4,4 @@
   <outline>
     <component base="schwa-cy.sc"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>schwa-cy.sc</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>schwa-cy.sc</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="757"/>
-  <anchor x="260" y="0" name="bottom_1"/>
-  <anchor x="535" y="0" name="bottom_2"/>
   <anchor x="373" y="0" name="caret_1"/>
-  <anchor x="211" y="255" name="center_1"/>
-  <anchor x="562" y="255" name="center_2"/>
-  <anchor x="250" y="670" name="top_1"/>
-  <anchor x="593" y="734" name="top_2"/>
-  <anchor x="352" y="526" name="topright_1"/>
-  <anchor x="721" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="353"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="766"/>
-  <anchor x="259" y="0" name="bottom_1"/>
-  <anchor x="611" y="0" name="bottom_2"/>
   <anchor x="373" y="0" name="caret_1"/>
-  <anchor x="211" y="255" name="center_1"/>
-  <anchor x="562" y="255" name="center_2"/>
-  <anchor x="250" y="670" name="top_1"/>
-  <anchor x="601" y="670" name="top_2"/>
-  <anchor x="352" y="526" name="topright_1"/>
-  <anchor x="703" y="526" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="351"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/yhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/yhook.glif
@@ -43,6 +43,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=whook</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="449"/>
+  <advance width="440"/>
   <outline>
     <contour>
-      <point x="225" y="378" type="curve" smooth="yes"/>
-      <point x="338" y="378"/>
-      <point x="405" y="458"/>
-      <point x="405" y="555" type="curve" smooth="yes"/>
-      <point x="405" y="652"/>
-      <point x="338" y="732"/>
-      <point x="225" y="732" type="curve" smooth="yes"/>
-      <point x="112" y="732"/>
-      <point x="44" y="652"/>
-      <point x="44" y="555" type="curve" smooth="yes"/>
-      <point x="44" y="458"/>
-      <point x="112" y="378"/>
+      <point x="220" y="378" type="curve" smooth="yes"/>
+      <point x="333" y="378"/>
+      <point x="401" y="458"/>
+      <point x="401" y="555" type="curve" smooth="yes"/>
+      <point x="401" y="652"/>
+      <point x="333" y="732"/>
+      <point x="220" y="732" type="curve" smooth="yes"/>
+      <point x="107" y="732"/>
+      <point x="40" y="652"/>
+      <point x="39" y="555" type="curve" smooth="yes"/>
+      <point x="40" y="458"/>
+      <point x="107" y="378"/>
     </contour>
     <contour>
-      <point x="225" y="476" type="curve" smooth="yes"/>
-      <point x="185" y="476"/>
-      <point x="152" y="504"/>
-      <point x="152" y="555" type="curve" smooth="yes"/>
-      <point x="152" y="606"/>
-      <point x="185" y="634"/>
-      <point x="225" y="634" type="curve" smooth="yes"/>
-      <point x="266" y="634"/>
-      <point x="297" y="606"/>
-      <point x="297" y="555" type="curve" smooth="yes"/>
-      <point x="297" y="504"/>
-      <point x="266" y="476"/>
+      <point x="220" y="476" type="curve" smooth="yes"/>
+      <point x="180" y="476"/>
+      <point x="148" y="504"/>
+      <point x="148" y="555" type="curve" smooth="yes"/>
+      <point x="148" y="606"/>
+      <point x="180" y="634"/>
+      <point x="220" y="634" type="curve" smooth="yes"/>
+      <point x="261" y="634"/>
+      <point x="293" y="606"/>
+      <point x="293" y="555" type="curve" smooth="yes"/>
+      <point x="293" y="504"/>
+      <point x="261" y="476"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -14,8 +14,6 @@
     <string>Google Sans</string>
     <key>guidelines</key>
     <array/>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -62,6 +60,8 @@
       <integer>526</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/F_ivethousand-roman.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/F_ivethousand-roman.glif
@@ -30,24 +30,24 @@
       <point x="226" y="61" type="line"/>
     </contour>
     <contour>
-      <point x="196" y="213" type="line"/>
-      <point x="282" y="213" type="line" smooth="yes"/>
-      <point x="375" y="213"/>
-      <point x="447" y="285"/>
-      <point x="447" y="374" type="curve" smooth="yes"/>
-      <point x="447" y="463"/>
-      <point x="375" y="537"/>
-      <point x="282" y="537" type="curve" smooth="yes"/>
-      <point x="196" y="537" type="line"/>
-      <point x="196" y="478" type="line"/>
-      <point x="287" y="478" type="line" smooth="yes"/>
-      <point x="343" y="478"/>
-      <point x="384" y="437"/>
-      <point x="384" y="374" type="curve" smooth="yes"/>
-      <point x="384" y="311"/>
-      <point x="343" y="272"/>
-      <point x="287" y="272" type="curve" smooth="yes"/>
-      <point x="196" y="272" type="line"/>
+      <point x="196" y="196" type="line"/>
+      <point x="282" y="196" type="line" smooth="yes"/>
+      <point x="375" y="196"/>
+      <point x="447" y="268"/>
+      <point x="447" y="357" type="curve" smooth="yes"/>
+      <point x="447" y="446"/>
+      <point x="375" y="520"/>
+      <point x="282" y="520" type="curve" smooth="yes"/>
+      <point x="196" y="520" type="line"/>
+      <point x="196" y="461" type="line"/>
+      <point x="287" y="461" type="line" smooth="yes"/>
+      <point x="343" y="461"/>
+      <point x="384" y="420"/>
+      <point x="384" y="357" type="curve" smooth="yes"/>
+      <point x="384" y="294"/>
+      <point x="343" y="255"/>
+      <point x="287" y="255" type="curve" smooth="yes"/>
+      <point x="196" y="255" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="775"/>
   <unicode hex="0132"/>
-  <anchor x="665" y="716" name="top.UC_2"/>
   <anchor x="118" y="716" name="top.UC.1"/>
+  <anchor x="665" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="85" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_u-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/I_u-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iu-cy" format="2">
-  <advance width="1063"/>
+  <advance width="1067"/>
   <unicode hex="042E"/>
   <anchor x="523" y="716" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/T_enthousand-roman.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/T_enthousand-roman.glif
@@ -47,20 +47,20 @@
       <point x="445" y="198" type="curve"/>
     </contour>
     <contour>
-      <point x="442" y="253" type="line" smooth="yes"/>
-      <point x="387" y="253"/>
-      <point x="340" y="299"/>
-      <point x="340" y="358" type="curve" smooth="yes"/>
-      <point x="340" y="418"/>
-      <point x="387" y="465"/>
-      <point x="442" y="465" type="curve"/>
-      <point x="625" y="465" type="line" smooth="yes"/>
-      <point x="681" y="465"/>
-      <point x="727" y="418"/>
-      <point x="727" y="358" type="curve" smooth="yes"/>
-      <point x="727" y="299"/>
-      <point x="681" y="253"/>
-      <point x="625" y="253" type="curve"/>
+      <point x="442" y="252" type="line" smooth="yes"/>
+      <point x="387" y="252"/>
+      <point x="340" y="298"/>
+      <point x="340" y="357" type="curve" smooth="yes"/>
+      <point x="340" y="417"/>
+      <point x="387" y="464"/>
+      <point x="442" y="464" type="curve"/>
+      <point x="625" y="464" type="line" smooth="yes"/>
+      <point x="681" y="464"/>
+      <point x="727" y="417"/>
+      <point x="727" y="357" type="curve" smooth="yes"/>
+      <point x="727" y="298"/>
+      <point x="681" y="252"/>
+      <point x="625" y="252" type="curve"/>
     </contour>
     <contour>
       <point x="565" y="655" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="624" y="315" type="line"/>
+      <point x="643" y="315" type="line" smooth="yes"/>
+      <point x="801" y="315"/>
+      <point x="893" y="414"/>
+      <point x="893" y="543" type="curve" smooth="yes"/>
+      <point x="893" y="662"/>
+      <point x="816" y="751"/>
+      <point x="689" y="751" type="curve" smooth="yes"/>
+      <point x="590" y="751"/>
+      <point x="503" y="689"/>
+      <point x="503" y="584" type="curve" smooth="yes"/>
+      <point x="503" y="512"/>
+      <point x="543" y="465"/>
+      <point x="602" y="465" type="curve" smooth="yes"/>
+      <point x="645" y="465"/>
+      <point x="680" y="495"/>
+      <point x="680" y="537" type="curve" smooth="yes"/>
+      <point x="680" y="579"/>
+      <point x="650" y="609"/>
+      <point x="611" y="609" type="curve" smooth="yes"/>
+      <point x="587" y="609"/>
+      <point x="567" y="599"/>
+      <point x="556" y="577" type="curve"/>
+      <point x="571" y="576" type="line"/>
+      <point x="571" y="586" type="line" smooth="yes"/>
+      <point x="571" y="651"/>
+      <point x="629" y="686"/>
+      <point x="688" y="686" type="curve" smooth="yes"/>
+      <point x="772" y="686"/>
+      <point x="820" y="627"/>
+      <point x="820" y="542" type="curve" smooth="yes"/>
+      <point x="820" y="446"/>
+      <point x="751" y="379"/>
+      <point x="643" y="379" type="curve" smooth="yes"/>
+      <point x="624" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="578" y="-250" type="line"/>
       <point x="649" y="-250" type="line"/>
       <point x="649" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="553" y="-12"/>
       <point x="574" y="16" type="curve"/>
       <point x="578" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="506" type="curve" smooth="yes"/>
+      <point x="129" y="506"/>
+      <point x="116" y="521"/>
+      <point x="116" y="537" type="curve" smooth="yes"/>
+      <point x="116" y="553"/>
+      <point x="129" y="569"/>
+      <point x="146" y="569" type="curve" smooth="yes"/>
+      <point x="163" y="569"/>
+      <point x="176" y="554"/>
+      <point x="176" y="537" type="curve" smooth="yes"/>
+      <point x="176" y="521"/>
+      <point x="163" y="506"/>
     </contour>
     <contour>
       <point x="164" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="291" y="379"/>
       <point x="183" y="379" type="curve" smooth="yes"/>
       <point x="164" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="146" y="506" type="curve" smooth="yes"/>
-      <point x="129" y="506"/>
-      <point x="116" y="521"/>
-      <point x="116" y="537" type="curve" smooth="yes"/>
-      <point x="116" y="553"/>
-      <point x="129" y="569"/>
-      <point x="146" y="569" type="curve" smooth="yes"/>
-      <point x="163" y="569"/>
-      <point x="176" y="554"/>
-      <point x="176" y="537" type="curve" smooth="yes"/>
-      <point x="176" y="521"/>
-      <point x="163" y="506"/>
-    </contour>
-    <contour>
-      <point x="624" y="315" type="line"/>
-      <point x="643" y="315" type="line" smooth="yes"/>
-      <point x="801" y="315"/>
-      <point x="893" y="414"/>
-      <point x="893" y="543" type="curve" smooth="yes"/>
-      <point x="893" y="662"/>
-      <point x="816" y="751"/>
-      <point x="689" y="751" type="curve" smooth="yes"/>
-      <point x="590" y="751"/>
-      <point x="503" y="689"/>
-      <point x="503" y="584" type="curve" smooth="yes"/>
-      <point x="503" y="512"/>
-      <point x="543" y="465"/>
-      <point x="602" y="465" type="curve" smooth="yes"/>
-      <point x="645" y="465"/>
-      <point x="680" y="495"/>
-      <point x="680" y="537" type="curve" smooth="yes"/>
-      <point x="680" y="579"/>
-      <point x="650" y="609"/>
-      <point x="611" y="609" type="curve" smooth="yes"/>
-      <point x="587" y="609"/>
-      <point x="567" y="599"/>
-      <point x="556" y="577" type="curve"/>
-      <point x="571" y="576" type="line"/>
-      <point x="571" y="586" type="line" smooth="yes"/>
-      <point x="571" y="651"/>
-      <point x="629" y="686"/>
-      <point x="688" y="686" type="curve" smooth="yes"/>
-      <point x="772" y="686"/>
-      <point x="820" y="627"/>
-      <point x="820" y="542" type="curve" smooth="yes"/>
-      <point x="820" y="446"/>
-      <point x="751" y="379"/>
-      <point x="643" y="379" type="curve" smooth="yes"/>
-      <point x="624" y="379" type="line"/>
     </contour>
     <contour>
       <point x="606" y="506" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="164" y="-250" type="line"/>
-      <point x="183" y="-250" type="line" smooth="yes"/>
-      <point x="341" y="-250"/>
-      <point x="433" y="-151"/>
-      <point x="433" y="-22" type="curve" smooth="yes"/>
-      <point x="433" y="97"/>
-      <point x="356" y="186"/>
-      <point x="229" y="186" type="curve" smooth="yes"/>
-      <point x="130" y="186"/>
-      <point x="43" y="124"/>
-      <point x="43" y="19" type="curve" smooth="yes"/>
-      <point x="43" y="-53"/>
-      <point x="83" y="-100"/>
-      <point x="142" y="-100" type="curve" smooth="yes"/>
-      <point x="185" y="-100"/>
-      <point x="220" y="-70"/>
-      <point x="220" y="-28" type="curve" smooth="yes"/>
-      <point x="220" y="14"/>
-      <point x="190" y="44"/>
-      <point x="151" y="44" type="curve" smooth="yes"/>
-      <point x="127" y="44"/>
-      <point x="107" y="34"/>
-      <point x="96" y="12" type="curve"/>
-      <point x="111" y="11" type="line"/>
-      <point x="111" y="21" type="line" smooth="yes"/>
-      <point x="111" y="86"/>
-      <point x="169" y="121"/>
-      <point x="228" y="121" type="curve" smooth="yes"/>
-      <point x="312" y="121"/>
-      <point x="360" y="62"/>
-      <point x="360" y="-23" type="curve" smooth="yes"/>
-      <point x="360" y="-119"/>
-      <point x="291" y="-186"/>
-      <point x="183" y="-186" type="curve" smooth="yes"/>
-      <point x="164" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="146" y="-59" type="curve" smooth="yes"/>
-      <point x="129" y="-59"/>
-      <point x="116" y="-44"/>
-      <point x="116" y="-28" type="curve" smooth="yes"/>
-      <point x="116" y="-12"/>
-      <point x="129" y="4"/>
-      <point x="146" y="4" type="curve" smooth="yes"/>
-      <point x="163" y="4"/>
-      <point x="176" y="-11"/>
-      <point x="176" y="-28" type="curve" smooth="yes"/>
-      <point x="176" y="-44"/>
-      <point x="163" y="-59"/>
-    </contour>
-    <contour>
       <point x="624" y="-250" type="line"/>
       <point x="643" y="-250" type="line" smooth="yes"/>
       <point x="801" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="751" y="-186"/>
       <point x="643" y="-186" type="curve" smooth="yes"/>
       <point x="624" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="-59" type="curve" smooth="yes"/>
+      <point x="129" y="-59"/>
+      <point x="116" y="-44"/>
+      <point x="116" y="-28" type="curve" smooth="yes"/>
+      <point x="116" y="-12"/>
+      <point x="129" y="4"/>
+      <point x="146" y="4" type="curve" smooth="yes"/>
+      <point x="163" y="4"/>
+      <point x="176" y="-11"/>
+      <point x="176" y="-28" type="curve" smooth="yes"/>
+      <point x="176" y="-44"/>
+      <point x="163" y="-59"/>
+    </contour>
+    <contour>
+      <point x="164" y="-250" type="line"/>
+      <point x="183" y="-250" type="line" smooth="yes"/>
+      <point x="341" y="-250"/>
+      <point x="433" y="-151"/>
+      <point x="433" y="-22" type="curve" smooth="yes"/>
+      <point x="433" y="97"/>
+      <point x="356" y="186"/>
+      <point x="229" y="186" type="curve" smooth="yes"/>
+      <point x="130" y="186"/>
+      <point x="43" y="124"/>
+      <point x="43" y="19" type="curve" smooth="yes"/>
+      <point x="43" y="-53"/>
+      <point x="83" y="-100"/>
+      <point x="142" y="-100" type="curve" smooth="yes"/>
+      <point x="185" y="-100"/>
+      <point x="220" y="-70"/>
+      <point x="220" y="-28" type="curve" smooth="yes"/>
+      <point x="220" y="14"/>
+      <point x="190" y="44"/>
+      <point x="151" y="44" type="curve" smooth="yes"/>
+      <point x="127" y="44"/>
+      <point x="107" y="34"/>
+      <point x="96" y="12" type="curve"/>
+      <point x="111" y="11" type="line"/>
+      <point x="111" y="21" type="line" smooth="yes"/>
+      <point x="111" y="86"/>
+      <point x="169" y="121"/>
+      <point x="228" y="121" type="curve" smooth="yes"/>
+      <point x="312" y="121"/>
+      <point x="360" y="62"/>
+      <point x="360" y="-23" type="curve" smooth="yes"/>
+      <point x="360" y="-119"/>
+      <point x="291" y="-186"/>
+      <point x="183" y="-186" type="curve" smooth="yes"/>
+      <point x="164" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="606" y="-59" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="480"/>
   <unicode hex="025B"/>
-  <anchor x="328" y="0" name="ogonek"/>
   <anchor x="236" y="0" name="bottom"/>
+  <anchor x="328" y="0" name="ogonek"/>
   <anchor x="245" y="510" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="978"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="677" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="677" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="696"/>
   <anchor x="323" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="317"/>
     <component base="flig2"/>
+    <component base="f" xOffset="317"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
@@ -1,18 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
-  <advance width="1296"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="994" y="0" name="bottom_3"/>
-  <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="798" y="716" name="top_3"/>
+  <advance width="1295"/>
+  <anchor x="322" y="0" name="caret_1"/>
+  <anchor x="638" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="1"/>
-    <component base="flig1" xOffset="318"/>
-    <component base="b" xOffset="694"/>
+    <component base="flig2"/>
+    <component base="flig1" xOffset="317"/>
+    <component base="b" xOffset="693"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
-  <advance width="1257"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="976" y="0" name="bottom_3"/>
+  <advance width="1256"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="798" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="317"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="910"/>
+  <anchor x="164" y="0" name="bottom_1"/>
+  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="797" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
+  <anchor x="164" y="716" name="top_1"/>
+  <anchor x="481" y="716" name="top_2"/>
+  <anchor x="797" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="i" xOffset="684"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="481" y="716" name="top_2"/>
   <anchor x="797" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="j" xOffset="684"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1198"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="954" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="797" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="317"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="1004"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="871" y="0" name="bottom_3"/>
   <anchor x="324" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="840" y="654" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="t" xOffset="638"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
-  <advance width="940"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="677" y="0" name="bottom_2"/>
+  <advance width="939"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="677" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="375"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_j.glif
@@ -2,7 +2,7 @@
 <glyph name="f_j" format="2">
   <advance width="594"/>
   <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="481" y="-216" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="164" y="716" name="top_1"/>
   <anchor x="481" y="716" name="top_2"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="881"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="638" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="587"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="688"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="556" y="0" name="bottom_2"/>
+  <advance width="687"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="524" y="654" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="322"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
@@ -1,48 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="786"/>
+  <advance width="796"/>
   <unicode hex="044E"/>
-  <anchor x="393" y="510" name="top"/>
+  <anchor x="398" y="510" name="top"/>
   <outline>
     <contour>
-      <point x="498" y="-16" type="curve" smooth="yes"/>
-      <point x="647" y="-16"/>
-      <point x="750" y="103"/>
-      <point x="750" y="255" type="curve" smooth="yes"/>
-      <point x="750" y="405"/>
-      <point x="645" y="526"/>
-      <point x="498" y="526" type="curve" smooth="yes"/>
-      <point x="351" y="526"/>
-      <point x="245" y="410"/>
-      <point x="245" y="256" type="curve" smooth="yes"/>
-      <point x="245" y="102"/>
-      <point x="349" y="-16"/>
+      <point x="503" y="-16" type="curve" smooth="yes"/>
+      <point x="652" y="-16"/>
+      <point x="755" y="103"/>
+      <point x="755" y="255" type="curve" smooth="yes"/>
+      <point x="755" y="405"/>
+      <point x="650" y="526"/>
+      <point x="503" y="526" type="curve" smooth="yes"/>
+      <point x="356" y="526"/>
+      <point x="251" y="410"/>
+      <point x="250" y="256" type="curve" smooth="yes"/>
+      <point x="249" y="102"/>
+      <point x="354" y="-16"/>
     </contour>
     <contour>
-      <point x="68" y="0" type="line"/>
-      <point x="133" y="0" type="line"/>
-      <point x="133" y="510" type="line"/>
-      <point x="68" y="510" type="line"/>
+      <point x="73" y="0" type="line"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="510" type="line"/>
+      <point x="73" y="510" type="line"/>
     </contour>
     <contour>
-      <point x="108" y="229" type="line"/>
-      <point x="291" y="229" type="line"/>
-      <point x="291" y="288" type="line"/>
-      <point x="108" y="288" type="line"/>
+      <point x="113" y="229" type="line"/>
+      <point x="296" y="229" type="line"/>
+      <point x="296" y="286" type="line"/>
+      <point x="113" y="286" type="line"/>
     </contour>
     <contour>
-      <point x="498" y="43" type="curve" smooth="yes"/>
-      <point x="398" y="43"/>
-      <point x="307" y="121"/>
-      <point x="307" y="255" type="curve" smooth="yes"/>
-      <point x="307" y="388"/>
-      <point x="398" y="467"/>
-      <point x="498" y="467" type="curve" smooth="yes"/>
-      <point x="597" y="467"/>
-      <point x="687" y="388"/>
-      <point x="687" y="255" type="curve" smooth="yes"/>
-      <point x="687" y="121"/>
-      <point x="597" y="43"/>
+      <point x="503" y="43" type="curve" smooth="yes"/>
+      <point x="403" y="43"/>
+      <point x="312" y="121"/>
+      <point x="312" y="255" type="curve" smooth="yes"/>
+      <point x="312" y="388"/>
+      <point x="403" y="467"/>
+      <point x="503" y="467" type="curve" smooth="yes"/>
+      <point x="602" y="467"/>
+      <point x="692" y="388"/>
+      <point x="692" y="255" type="curve" smooth="yes"/>
+      <point x="692" y="121"/>
+      <point x="602" y="43"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="393" y="510" name="top"/>
   <outline>
     <contour>
+      <point x="73" y="0" type="line"/>
+      <point x="137" y="0" type="line"/>
+      <point x="137" y="716" type="line"/>
+      <point x="73" y="716" type="line"/>
+    </contour>
+    <contour>
       <point x="498" y="-16" type="curve" smooth="yes"/>
       <point x="636" y="-16"/>
       <point x="745" y="103"/>
@@ -12,22 +18,10 @@
       <point x="636" y="526"/>
       <point x="498" y="526" type="curve" smooth="yes"/>
       <point x="374" y="526"/>
-      <point x="251" y="429"/>
+      <point x="252" y="429"/>
       <point x="251" y="262" type="curve" smooth="yes"/>
-      <point x="251" y="84"/>
+      <point x="250" y="84"/>
       <point x="372" y="-16"/>
-    </contour>
-    <contour>
-      <point x="108" y="227" type="line"/>
-      <point x="288" y="227" type="line"/>
-      <point x="288" y="288" type="line"/>
-      <point x="108" y="288" type="line"/>
-    </contour>
-    <contour>
-      <point x="72" y="0" type="line"/>
-      <point x="137" y="0" type="line"/>
-      <point x="137" y="716" type="line"/>
-      <point x="72" y="716" type="line"/>
     </contour>
     <contour>
       <point x="498" y="51" type="curve" smooth="yes"/>
@@ -35,13 +29,19 @@
       <point x="315" y="123"/>
       <point x="315" y="255" type="curve" smooth="yes"/>
       <point x="315" y="387"/>
-      <point x="400" y="459"/>
+      <point x="400" y="458"/>
       <point x="498" y="459" type="curve" smooth="yes"/>
-      <point x="595" y="459"/>
+      <point x="595" y="460"/>
       <point x="680" y="387"/>
       <point x="680" y="255" type="curve" smooth="yes"/>
       <point x="680" y="123"/>
       <point x="595" y="51"/>
+    </contour>
+    <contour>
+      <point x="108" y="227" type="line"/>
+      <point x="288" y="227" type="line"/>
+      <point x="288" y="288" type="line"/>
+      <point x="108" y="288" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
@@ -1,47 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.sc" format="2">
-  <advance width="874"/>
-  <anchor x="437" y="580" name="top"/>
+  <advance width="867"/>
+  <anchor x="432" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="548" y="-16" type="curve" smooth="yes"/>
-      <point x="711" y="-16"/>
-      <point x="828" y="122"/>
-      <point x="828" y="290" type="curve" smooth="yes"/>
-      <point x="828" y="458"/>
-      <point x="710" y="596"/>
-      <point x="548" y="596" type="curve" smooth="yes"/>
-      <point x="386" y="596"/>
-      <point x="267" y="458"/>
-      <point x="267" y="290" type="curve" smooth="yes"/>
-      <point x="267" y="122"/>
-      <point x="385" y="-16"/>
+      <point x="543" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="823" y="122"/>
+      <point x="823" y="290" type="curve" smooth="yes"/>
+      <point x="823" y="458"/>
+      <point x="705" y="596"/>
+      <point x="543" y="596" type="curve" smooth="yes"/>
+      <point x="381" y="596"/>
+      <point x="262" y="458"/>
+      <point x="262" y="290" type="curve" smooth="yes"/>
+      <point x="262" y="122"/>
+      <point x="380" y="-16"/>
     </contour>
     <contour>
-      <point x="83" y="0" type="line"/>
-      <point x="148" y="0" type="line"/>
-      <point x="148" y="580" type="line"/>
-      <point x="83" y="580" type="line"/>
+      <point x="78" y="0" type="line"/>
+      <point x="143" y="0" type="line"/>
+      <point x="143" y="580" type="line"/>
+      <point x="78" y="580" type="line"/>
     </contour>
     <contour>
-      <point x="120" y="267" type="line"/>
-      <point x="304" y="267" type="line"/>
-      <point x="304" y="326" type="line"/>
-      <point x="120" y="326" type="line"/>
+      <point x="115" y="267" type="line"/>
+      <point x="299" y="267" type="line"/>
+      <point x="299" y="326" type="line"/>
+      <point x="115" y="326" type="line"/>
     </contour>
     <contour>
-      <point x="548" y="43" type="curve" smooth="yes"/>
-      <point x="426" y="43"/>
-      <point x="331" y="138"/>
-      <point x="331" y="290" type="curve" smooth="yes"/>
-      <point x="331" y="442"/>
-      <point x="426" y="537"/>
-      <point x="548" y="537" type="curve" smooth="yes"/>
-      <point x="669" y="537"/>
-      <point x="765" y="442"/>
-      <point x="765" y="290" type="curve" smooth="yes"/>
-      <point x="765" y="138"/>
-      <point x="669" y="43"/>
+      <point x="543" y="43" type="curve" smooth="yes"/>
+      <point x="421" y="43"/>
+      <point x="326" y="138"/>
+      <point x="326" y="290" type="curve" smooth="yes"/>
+      <point x="326" y="442"/>
+      <point x="421" y="537"/>
+      <point x="543" y="537" type="curve" smooth="yes"/>
+      <point x="664" y="537"/>
+      <point x="760" y="442"/>
+      <point x="760" y="290" type="curve" smooth="yes"/>
+      <point x="760" y="138"/>
+      <point x="664" y="43"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/khook.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/khook.glif
@@ -40,6 +40,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>k</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>k</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="706" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="438" y="-393" type="curve" smooth="yes"/>
-      <point x="503" y="-393"/>
-      <point x="553" y="-343"/>
-      <point x="553" y="-276" type="curve" smooth="yes"/>
-      <point x="553" y="-209"/>
-      <point x="503" y="-159"/>
-      <point x="438" y="-159" type="curve" smooth="yes"/>
-      <point x="371" y="-159"/>
-      <point x="321" y="-209"/>
-      <point x="321" y="-276" type="curve" smooth="yes"/>
-      <point x="321" y="-344"/>
-      <point x="371" y="-393"/>
-    </contour>
-    <contour>
-      <point x="433" y="-325" type="curve" smooth="yes"/>
-      <point x="404" y="-325"/>
-      <point x="385" y="-305"/>
-      <point x="385" y="-276" type="curve" smooth="yes"/>
-      <point x="385" y="-247"/>
-      <point x="404" y="-227"/>
-      <point x="433" y="-227" type="curve" smooth="yes"/>
-      <point x="461" y="-227"/>
-      <point x="481" y="-247"/>
-      <point x="481" y="-276" type="curve" smooth="yes"/>
-      <point x="481" y="-305"/>
-      <point x="462" y="-325"/>
-    </contour>
-    <contour>
       <point x="587" y="-385" type="line"/>
       <point x="667" y="-385" type="line"/>
       <point x="667" y="213" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="537" y="-52"/>
       <point x="587" y="-102"/>
       <point x="587" y="-184" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="438" y="-393" type="curve" smooth="yes"/>
+      <point x="503" y="-393"/>
+      <point x="553" y="-343"/>
+      <point x="553" y="-276" type="curve" smooth="yes"/>
+      <point x="553" y="-209"/>
+      <point x="503" y="-159"/>
+      <point x="438" y="-159" type="curve" smooth="yes"/>
+      <point x="371" y="-159"/>
+      <point x="321" y="-209"/>
+      <point x="321" y="-276" type="curve" smooth="yes"/>
+      <point x="321" y="-344"/>
+      <point x="371" y="-393"/>
+    </contour>
+    <contour>
+      <point x="433" y="-325" type="curve" smooth="yes"/>
+      <point x="404" y="-325"/>
+      <point x="385" y="-305"/>
+      <point x="385" y="-276" type="curve" smooth="yes"/>
+      <point x="385" y="-247"/>
+      <point x="404" y="-227"/>
+      <point x="433" y="-227" type="curve" smooth="yes"/>
+      <point x="461" y="-227"/>
+      <point x="481" y="-247"/>
+      <point x="481" y="-276" type="curve" smooth="yes"/>
+      <point x="481" y="-305"/>
+      <point x="462" y="-325"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nine.ss03.glif
@@ -10,8 +10,8 @@
       <point x="468" y="323"/>
       <point x="509" y="390"/>
       <point x="509" y="471" type="curve" smooth="yes"/>
-      <point x="509" y="584.9657085313349"/>
-      <point x="419.5444224069248" y="700"/>
+      <point x="509" y="584.966"/>
+      <point x="419.544" y="700"/>
       <point x="277" y="700" type="curve" smooth="yes"/>
       <point x="148" y="700"/>
       <point x="46" y="593"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-7"/>
-    <component base="zeropercent" xOffset="663" yOffset="32"/>
+    <component base="zeropercent" xOffset="663"/>
     <component base="numero-bar" xOffset="-1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/oopen.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/oopen.sc.glif
@@ -38,6 +38,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>c.sc</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>c.sc</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/percent.glif
@@ -3,8 +3,14 @@
   <advance width="828"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="zeropercent" xOffset="408" yOffset="-374"/>
-    <component base="percentbar" xOffset="-19"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-406"/>
+    <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="828"/>
   <outline>
     <contour>
-      <point x="210" y="-9" type="line"/>
-      <point x="670" y="679" type="line"/>
-      <point x="630" y="719" type="line"/>
-      <point x="169" y="30" type="line"/>
+      <point x="203" y="-9" type="line"/>
+      <point x="668" y="685" type="line"/>
+      <point x="625" y="719" type="line"/>
+      <point x="160" y="25" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1389"/>
+  <advance width="1358"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent" yOffset="34"/>
-    <component base="percentbar" xOffset="-9" yOffset="2"/>
-    <component base="zeropercent" xOffset="408" yOffset="-372"/>
-    <component base="zeropercent" xOffset="676" yOffset="-372"/>
-    <component base="zeropercent" xOffset="946" yOffset="-374"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-406"/>
+    <component base="percentbar" xOffset="-7"/>
+    <component base="zeropercent" xOffset="673" yOffset="-406"/>
+    <component base="zeropercent" xOffset="938" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1108"/>
+  <advance width="1093"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="zeropercent" xOffset="408" yOffset="-374"/>
-    <component base="percentbar" xOffset="-9"/>
-    <component base="zeropercent" xOffset="688" yOffset="-374"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-406"/>
+    <component base="percentbar" xOffset="-7"/>
+    <component base="zeropercent" xOffset="673" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="61" y="495" type="line"/>
-      <point x="118" y="495" type="line" name="hr00"/>
+      <point x="118" y="495" type="line"/>
       <point x="118" y="716" type="line"/>
       <point x="61" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/r_f.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
-  <advance width="748"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="533" y="716" name="top_2"/>
+  <advance width="745"/>
+  <anchor x="317" y="0" name="caret_1"/>
   <outline>
-    <component base="rlig"/>
-    <component base="f" xOffset="369"/>
+    <component base="rlig" xOffset="-3"/>
+    <component base="f" xOffset="366"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1065"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="850" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="692" y="0" name="caret_2"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="533" y="716" name="top_2"/>
-  <anchor x="888" y="716" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/r_t.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
-  <advance width="745"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="613" y="0" name="bottom_2"/>
-  <anchor x="332" y="0" name="caret_1"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="581" y="654" name="top_2"/>
+  <advance width="747"/>
+  <anchor x="335" y="0" name="caret_1"/>
   <outline>
-    <component base="r.alt"/>
-    <component base="t" xOffset="379"/>
+    <component base="r.alt" xOffset="3"/>
+    <component base="t" xOffset="382"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="502" y="362" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="519" y="-202" type="curve" smooth="yes"/>
-      <point x="586" y="-202"/>
-      <point x="638" y="-151"/>
-      <point x="638" y="-83" type="curve" smooth="yes"/>
-      <point x="638" y="-15"/>
-      <point x="586" y="36"/>
-      <point x="519" y="36" type="curve" smooth="yes"/>
-      <point x="450" y="36"/>
-      <point x="398" y="-15"/>
-      <point x="398" y="-83" type="curve" smooth="yes"/>
-      <point x="398" y="-152"/>
-      <point x="450" y="-202"/>
-    </contour>
-    <contour>
-      <point x="514" y="-134" type="curve" smooth="yes"/>
-      <point x="483" y="-134"/>
-      <point x="462" y="-113"/>
-      <point x="462" y="-83" type="curve" smooth="yes"/>
-      <point x="462" y="-53"/>
-      <point x="483" y="-32"/>
-      <point x="514" y="-32" type="curve" smooth="yes"/>
-      <point x="544" y="-32"/>
-      <point x="566" y="-53"/>
-      <point x="566" y="-83" type="curve" smooth="yes"/>
-      <point x="566" y="-113"/>
-      <point x="545" y="-134"/>
-    </contour>
-    <contour>
       <point x="389" y="58" type="line"/>
       <point x="389" y="138" type="line"/>
       <point x="318" y="170" type="line"/>
@@ -102,6 +74,34 @@
       <point x="340" y="48" type="curve" smooth="yes"/>
       <point x="340" y="-15"/>
       <point x="374" y="-67"/>
+    </contour>
+    <contour>
+      <point x="519" y="-202" type="curve" smooth="yes"/>
+      <point x="586" y="-202"/>
+      <point x="638" y="-151"/>
+      <point x="638" y="-83" type="curve" smooth="yes"/>
+      <point x="638" y="-15"/>
+      <point x="586" y="36"/>
+      <point x="519" y="36" type="curve" smooth="yes"/>
+      <point x="450" y="36"/>
+      <point x="398" y="-15"/>
+      <point x="398" y="-83" type="curve" smooth="yes"/>
+      <point x="398" y="-152"/>
+      <point x="450" y="-202"/>
+    </contour>
+    <contour>
+      <point x="514" y="-134" type="curve" smooth="yes"/>
+      <point x="483" y="-134"/>
+      <point x="462" y="-113"/>
+      <point x="462" y="-83" type="curve" smooth="yes"/>
+      <point x="462" y="-53"/>
+      <point x="483" y="-32"/>
+      <point x="514" y="-32" type="curve" smooth="yes"/>
+      <point x="544" y="-32"/>
+      <point x="566" y="-53"/>
+      <point x="566" y="-83" type="curve" smooth="yes"/>
+      <point x="566" y="-113"/>
+      <point x="545" y="-134"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/schwa.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/schwa.sc.glif
@@ -4,12 +4,4 @@
   <outline>
     <component base="schwa-cy.sc"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>schwa-cy.sc</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>schwa-cy.sc</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.ss03.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/six.ss03.glif
@@ -24,8 +24,8 @@
       <point x="87" y="361"/>
       <point x="46" y="294"/>
       <point x="46" y="213" type="curve" smooth="yes"/>
-      <point x="46" y="100.35636456605349"/>
-      <point x="134.26930998597106" y="-16"/>
+      <point x="46" y="100.356"/>
+      <point x="134.269" y="-16"/>
     </contour>
     <contour>
       <point x="278" y="45" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="691"/>
-  <anchor x="234" y="0" name="bottom_1"/>
-  <anchor x="475" y="0" name="bottom_2"/>
+  <advance width="690"/>
   <anchor x="345" y="0" name="caret_1"/>
-  <anchor x="183" y="255" name="center_1"/>
-  <anchor x="478" y="255" name="center_2"/>
-  <anchor x="202" y="654" name="top_1"/>
-  <anchor x="474" y="716" name="top_2"/>
-  <anchor x="269" y="560" name="topright_1"/>
-  <anchor x="692" y="510" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="311"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="680"/>
-  <anchor x="234" y="0" name="bottom_1"/>
-  <anchor x="549" y="0" name="bottom_2"/>
+  <advance width="679"/>
   <anchor x="324" y="0" name="caret_1"/>
-  <anchor x="170" y="255" name="center_1"/>
-  <anchor x="511" y="255" name="center_2"/>
-  <anchor x="202" y="654" name="top_1"/>
-  <anchor x="516" y="654" name="top_2"/>
-  <anchor x="267" y="530" name="topright_1"/>
-  <anchor x="589" y="530" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="314"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="210" y="358" type="curve" smooth="yes"/>
-      <point x="303" y="358"/>
-      <point x="376" y="437"/>
-      <point x="376" y="529" type="curve" smooth="yes"/>
-      <point x="376" y="621"/>
-      <point x="303" y="700"/>
-      <point x="210" y="700" type="curve" smooth="yes"/>
-      <point x="118" y="700"/>
-      <point x="44" y="621"/>
-      <point x="44" y="529" type="curve" smooth="yes"/>
-      <point x="44" y="437"/>
-      <point x="118" y="358"/>
+      <point x="210" y="390" type="curve" smooth="yes"/>
+      <point x="303" y="390"/>
+      <point x="371" y="469"/>
+      <point x="371" y="561" type="curve" smooth="yes"/>
+      <point x="371" y="653"/>
+      <point x="303" y="732"/>
+      <point x="210" y="732" type="curve" smooth="yes"/>
+      <point x="117" y="732"/>
+      <point x="49" y="653"/>
+      <point x="49" y="561" type="curve" smooth="yes"/>
+      <point x="49" y="469"/>
+      <point x="117" y="390"/>
     </contour>
     <contour>
-      <point x="210" y="414" type="curve" smooth="yes"/>
-      <point x="148" y="414"/>
-      <point x="101" y="463"/>
-      <point x="101" y="529" type="curve" smooth="yes"/>
-      <point x="101" y="595"/>
-      <point x="148" y="644"/>
-      <point x="210" y="644" type="curve" smooth="yes"/>
-      <point x="273" y="644"/>
-      <point x="320" y="595"/>
-      <point x="320" y="529" type="curve" smooth="yes"/>
-      <point x="320" y="463"/>
-      <point x="273" y="414"/>
+      <point x="210" y="446" type="curve" smooth="yes"/>
+      <point x="146" y="446"/>
+      <point x="105" y="495"/>
+      <point x="106" y="561" type="curve" smooth="yes"/>
+      <point x="105" y="627"/>
+      <point x="146" y="676"/>
+      <point x="210" y="676" type="curve" smooth="yes"/>
+      <point x="274" y="676"/>
+      <point x="315" y="627"/>
+      <point x="315" y="561" type="curve" smooth="yes"/>
+      <point x="315" y="495"/>
+      <point x="274" y="446"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -67,8 +67,6 @@
         <integer>413</integer>
       </dict>
     </array>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -115,6 +113,8 @@
       <integer>526</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="775"/>
   <unicode hex="0132"/>
-  <anchor x="665" y="716" name="top.UC_2"/>
   <anchor x="122" y="716" name="top.UC.1"/>
+  <anchor x="665" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="80" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="624" y="315" type="line"/>
+      <point x="643" y="315" type="line" smooth="yes"/>
+      <point x="801" y="315"/>
+      <point x="893" y="414"/>
+      <point x="893" y="543" type="curve" smooth="yes"/>
+      <point x="893" y="662"/>
+      <point x="816" y="751"/>
+      <point x="689" y="751" type="curve" smooth="yes"/>
+      <point x="590" y="751"/>
+      <point x="503" y="689"/>
+      <point x="503" y="584" type="curve" smooth="yes"/>
+      <point x="503" y="512"/>
+      <point x="543" y="465"/>
+      <point x="602" y="465" type="curve" smooth="yes"/>
+      <point x="645" y="465"/>
+      <point x="680" y="495"/>
+      <point x="680" y="537" type="curve" smooth="yes"/>
+      <point x="680" y="579"/>
+      <point x="650" y="609"/>
+      <point x="611" y="609" type="curve" smooth="yes"/>
+      <point x="587" y="609"/>
+      <point x="567" y="599"/>
+      <point x="556" y="577" type="curve"/>
+      <point x="571" y="576" type="line"/>
+      <point x="571" y="586" type="line" smooth="yes"/>
+      <point x="571" y="651"/>
+      <point x="629" y="686"/>
+      <point x="688" y="686" type="curve" smooth="yes"/>
+      <point x="772" y="686"/>
+      <point x="820" y="627"/>
+      <point x="820" y="542" type="curve" smooth="yes"/>
+      <point x="820" y="446"/>
+      <point x="751" y="379"/>
+      <point x="643" y="379" type="curve" smooth="yes"/>
+      <point x="624" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="578" y="-250" type="line"/>
       <point x="649" y="-250" type="line"/>
       <point x="649" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="553" y="-12"/>
       <point x="574" y="16" type="curve"/>
       <point x="578" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="506" type="curve" smooth="yes"/>
+      <point x="129" y="506"/>
+      <point x="116" y="521"/>
+      <point x="116" y="537" type="curve" smooth="yes"/>
+      <point x="116" y="553"/>
+      <point x="129" y="569"/>
+      <point x="146" y="569" type="curve" smooth="yes"/>
+      <point x="163" y="569"/>
+      <point x="176" y="554"/>
+      <point x="176" y="537" type="curve" smooth="yes"/>
+      <point x="176" y="521"/>
+      <point x="163" y="506"/>
     </contour>
     <contour>
       <point x="164" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="291" y="379"/>
       <point x="183" y="379" type="curve" smooth="yes"/>
       <point x="164" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="146" y="506" type="curve" smooth="yes"/>
-      <point x="129" y="506"/>
-      <point x="116" y="521"/>
-      <point x="116" y="537" type="curve" smooth="yes"/>
-      <point x="116" y="553"/>
-      <point x="129" y="569"/>
-      <point x="146" y="569" type="curve" smooth="yes"/>
-      <point x="163" y="569"/>
-      <point x="176" y="554"/>
-      <point x="176" y="537" type="curve" smooth="yes"/>
-      <point x="176" y="521"/>
-      <point x="163" y="506"/>
-    </contour>
-    <contour>
-      <point x="624" y="315" type="line"/>
-      <point x="643" y="315" type="line" smooth="yes"/>
-      <point x="801" y="315"/>
-      <point x="893" y="414"/>
-      <point x="893" y="543" type="curve" smooth="yes"/>
-      <point x="893" y="662"/>
-      <point x="816" y="751"/>
-      <point x="689" y="751" type="curve" smooth="yes"/>
-      <point x="590" y="751"/>
-      <point x="503" y="689"/>
-      <point x="503" y="584" type="curve" smooth="yes"/>
-      <point x="503" y="512"/>
-      <point x="543" y="465"/>
-      <point x="602" y="465" type="curve" smooth="yes"/>
-      <point x="645" y="465"/>
-      <point x="680" y="495"/>
-      <point x="680" y="537" type="curve" smooth="yes"/>
-      <point x="680" y="579"/>
-      <point x="650" y="609"/>
-      <point x="611" y="609" type="curve" smooth="yes"/>
-      <point x="587" y="609"/>
-      <point x="567" y="599"/>
-      <point x="556" y="577" type="curve"/>
-      <point x="571" y="576" type="line"/>
-      <point x="571" y="586" type="line" smooth="yes"/>
-      <point x="571" y="651"/>
-      <point x="629" y="686"/>
-      <point x="688" y="686" type="curve" smooth="yes"/>
-      <point x="772" y="686"/>
-      <point x="820" y="627"/>
-      <point x="820" y="542" type="curve" smooth="yes"/>
-      <point x="820" y="446"/>
-      <point x="751" y="379"/>
-      <point x="643" y="379" type="curve" smooth="yes"/>
-      <point x="624" y="379" type="line"/>
     </contour>
     <contour>
       <point x="606" y="506" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="164" y="-250" type="line"/>
-      <point x="183" y="-250" type="line" smooth="yes"/>
-      <point x="341" y="-250"/>
-      <point x="433" y="-151"/>
-      <point x="433" y="-22" type="curve" smooth="yes"/>
-      <point x="433" y="97"/>
-      <point x="356" y="186"/>
-      <point x="229" y="186" type="curve" smooth="yes"/>
-      <point x="130" y="186"/>
-      <point x="43" y="124"/>
-      <point x="43" y="19" type="curve" smooth="yes"/>
-      <point x="43" y="-53"/>
-      <point x="83" y="-100"/>
-      <point x="142" y="-100" type="curve" smooth="yes"/>
-      <point x="185" y="-100"/>
-      <point x="220" y="-70"/>
-      <point x="220" y="-28" type="curve" smooth="yes"/>
-      <point x="220" y="14"/>
-      <point x="190" y="44"/>
-      <point x="151" y="44" type="curve" smooth="yes"/>
-      <point x="127" y="44"/>
-      <point x="107" y="34"/>
-      <point x="96" y="12" type="curve"/>
-      <point x="111" y="11" type="line"/>
-      <point x="111" y="21" type="line" smooth="yes"/>
-      <point x="111" y="86"/>
-      <point x="169" y="121"/>
-      <point x="228" y="121" type="curve" smooth="yes"/>
-      <point x="312" y="121"/>
-      <point x="360" y="62"/>
-      <point x="360" y="-23" type="curve" smooth="yes"/>
-      <point x="360" y="-119"/>
-      <point x="291" y="-186"/>
-      <point x="183" y="-186" type="curve" smooth="yes"/>
-      <point x="164" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="146" y="-59" type="curve" smooth="yes"/>
-      <point x="129" y="-59"/>
-      <point x="116" y="-44"/>
-      <point x="116" y="-28" type="curve" smooth="yes"/>
-      <point x="116" y="-12"/>
-      <point x="129" y="4"/>
-      <point x="146" y="4" type="curve" smooth="yes"/>
-      <point x="163" y="4"/>
-      <point x="176" y="-11"/>
-      <point x="176" y="-28" type="curve" smooth="yes"/>
-      <point x="176" y="-44"/>
-      <point x="163" y="-59"/>
-    </contour>
-    <contour>
       <point x="624" y="-250" type="line"/>
       <point x="643" y="-250" type="line" smooth="yes"/>
       <point x="801" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="751" y="-186"/>
       <point x="643" y="-186" type="curve" smooth="yes"/>
       <point x="624" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="-59" type="curve" smooth="yes"/>
+      <point x="129" y="-59"/>
+      <point x="116" y="-44"/>
+      <point x="116" y="-28" type="curve" smooth="yes"/>
+      <point x="116" y="-12"/>
+      <point x="129" y="4"/>
+      <point x="146" y="4" type="curve" smooth="yes"/>
+      <point x="163" y="4"/>
+      <point x="176" y="-11"/>
+      <point x="176" y="-28" type="curve" smooth="yes"/>
+      <point x="176" y="-44"/>
+      <point x="163" y="-59"/>
+    </contour>
+    <contour>
+      <point x="164" y="-250" type="line"/>
+      <point x="183" y="-250" type="line" smooth="yes"/>
+      <point x="341" y="-250"/>
+      <point x="433" y="-151"/>
+      <point x="433" y="-22" type="curve" smooth="yes"/>
+      <point x="433" y="97"/>
+      <point x="356" y="186"/>
+      <point x="229" y="186" type="curve" smooth="yes"/>
+      <point x="130" y="186"/>
+      <point x="43" y="124"/>
+      <point x="43" y="19" type="curve" smooth="yes"/>
+      <point x="43" y="-53"/>
+      <point x="83" y="-100"/>
+      <point x="142" y="-100" type="curve" smooth="yes"/>
+      <point x="185" y="-100"/>
+      <point x="220" y="-70"/>
+      <point x="220" y="-28" type="curve" smooth="yes"/>
+      <point x="220" y="14"/>
+      <point x="190" y="44"/>
+      <point x="151" y="44" type="curve" smooth="yes"/>
+      <point x="127" y="44"/>
+      <point x="107" y="34"/>
+      <point x="96" y="12" type="curve"/>
+      <point x="111" y="11" type="line"/>
+      <point x="111" y="21" type="line" smooth="yes"/>
+      <point x="111" y="86"/>
+      <point x="169" y="121"/>
+      <point x="228" y="121" type="curve" smooth="yes"/>
+      <point x="312" y="121"/>
+      <point x="360" y="62"/>
+      <point x="360" y="-23" type="curve" smooth="yes"/>
+      <point x="360" y="-119"/>
+      <point x="291" y="-186"/>
+      <point x="183" y="-186" type="curve" smooth="yes"/>
+      <point x="164" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="606" y="-59" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="480"/>
   <unicode hex="025B"/>
-  <anchor x="328" y="0" name="ogonek"/>
   <anchor x="236" y="0" name="bottom"/>
+  <anchor x="328" y="0" name="ogonek"/>
   <anchor x="245" y="510" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="978"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="677" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="677" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="696"/>
   <anchor x="323" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="317"/>
     <component base="flig2"/>
+    <component base="f" xOffset="317"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,18 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
-  <advance width="1296"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="994" y="0" name="bottom_3"/>
-  <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="798" y="716" name="top_3"/>
+  <advance width="1295"/>
+  <anchor x="322" y="0" name="caret_1"/>
+  <anchor x="638" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="1"/>
-    <component base="flig1" xOffset="318"/>
-    <component base="b" xOffset="694"/>
+    <component base="flig2"/>
+    <component base="flig1" xOffset="317"/>
+    <component base="b" xOffset="693"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1257"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="976" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="798" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="317"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="910"/>
+  <anchor x="164" y="0" name="bottom_1"/>
+  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="797" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
+  <anchor x="164" y="716" name="top_1"/>
+  <anchor x="481" y="716" name="top_2"/>
+  <anchor x="797" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="i" xOffset="684"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="481" y="716" name="top_2"/>
   <anchor x="797" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="j" xOffset="684"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1198"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="954" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="797" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="317"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
-  <advance width="1004"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="871" y="0" name="bottom_3"/>
+  <advance width="1003"/>
   <anchor x="324" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="840" y="654" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="t" xOffset="638"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="940"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="677" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="677" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_j.glif
@@ -2,7 +2,7 @@
 <glyph name="f_j" format="2">
   <advance width="594"/>
   <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="481" y="-216" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="164" y="716" name="top_1"/>
   <anchor x="481" y="716" name="top_2"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="881"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="638" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="587"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="688"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="556" y="0" name="bottom_2"/>
+  <advance width="687"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="524" y="654" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="322"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/iu-cy.glif
@@ -13,9 +13,9 @@
       <point x="645" y="526"/>
       <point x="498" y="526" type="curve" smooth="yes"/>
       <point x="351" y="526"/>
-      <point x="245" y="410"/>
+      <point x="246" y="410"/>
       <point x="245" y="256" type="curve" smooth="yes"/>
-      <point x="245" y="102"/>
+      <point x="244" y="102"/>
       <point x="349" y="-16"/>
     </contour>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="393" y="510" name="top"/>
   <outline>
     <contour>
+      <point x="63" y="0" type="line"/>
+      <point x="148" y="0" type="line"/>
+      <point x="148" y="716" type="line"/>
+      <point x="63" y="716" type="line"/>
+    </contour>
+    <contour>
       <point x="498" y="-16" type="curve" smooth="yes"/>
       <point x="646" y="-16"/>
       <point x="750" y="103"/>
@@ -12,22 +18,10 @@
       <point x="646" y="526"/>
       <point x="498" y="526" type="curve" smooth="yes"/>
       <point x="364" y="526"/>
-      <point x="246" y="429"/>
+      <point x="247" y="429"/>
       <point x="246" y="262" type="curve" smooth="yes"/>
-      <point x="246" y="84"/>
+      <point x="245" y="84"/>
       <point x="362" y="-16"/>
-    </contour>
-    <contour>
-      <point x="108" y="219" type="line"/>
-      <point x="288" y="219" type="line"/>
-      <point x="288" y="296" type="line"/>
-      <point x="108" y="296" type="line"/>
-    </contour>
-    <contour>
-      <point x="63" y="0" type="line"/>
-      <point x="148" y="0" type="line"/>
-      <point x="148" y="716" type="line"/>
-      <point x="63" y="716" type="line"/>
     </contour>
     <contour>
       <point x="498" y="61" type="curve" smooth="yes"/>
@@ -42,6 +36,12 @@
       <point x="665" y="255" type="curve" smooth="yes"/>
       <point x="665" y="133"/>
       <point x="585" y="61"/>
+    </contour>
+    <contour>
+      <point x="108" y="219" type="line"/>
+      <point x="288" y="219" type="line"/>
+      <point x="288" y="296" type="line"/>
+      <point x="108" y="296" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="706" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="438" y="-393" type="curve" smooth="yes"/>
-      <point x="503" y="-393"/>
-      <point x="553" y="-343"/>
-      <point x="553" y="-276" type="curve" smooth="yes"/>
-      <point x="553" y="-209"/>
-      <point x="503" y="-159"/>
-      <point x="438" y="-159" type="curve" smooth="yes"/>
-      <point x="371" y="-159"/>
-      <point x="321" y="-209"/>
-      <point x="321" y="-276" type="curve" smooth="yes"/>
-      <point x="321" y="-344"/>
-      <point x="371" y="-393"/>
-    </contour>
-    <contour>
-      <point x="433" y="-325" type="curve" smooth="yes"/>
-      <point x="404" y="-325"/>
-      <point x="385" y="-305"/>
-      <point x="385" y="-276" type="curve" smooth="yes"/>
-      <point x="385" y="-247"/>
-      <point x="404" y="-227"/>
-      <point x="433" y="-227" type="curve" smooth="yes"/>
-      <point x="461" y="-227"/>
-      <point x="481" y="-247"/>
-      <point x="481" y="-276" type="curve" smooth="yes"/>
-      <point x="481" y="-305"/>
-      <point x="462" y="-325"/>
-    </contour>
-    <contour>
       <point x="587" y="-385" type="line"/>
       <point x="667" y="-385" type="line"/>
       <point x="667" y="213" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="537" y="-52"/>
       <point x="587" y="-102"/>
       <point x="587" y="-184" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="438" y="-393" type="curve" smooth="yes"/>
+      <point x="503" y="-393"/>
+      <point x="553" y="-343"/>
+      <point x="553" y="-276" type="curve" smooth="yes"/>
+      <point x="553" y="-209"/>
+      <point x="503" y="-159"/>
+      <point x="438" y="-159" type="curve" smooth="yes"/>
+      <point x="371" y="-159"/>
+      <point x="321" y="-209"/>
+      <point x="321" y="-276" type="curve" smooth="yes"/>
+      <point x="321" y="-344"/>
+      <point x="371" y="-393"/>
+    </contour>
+    <contour>
+      <point x="433" y="-325" type="curve" smooth="yes"/>
+      <point x="404" y="-325"/>
+      <point x="385" y="-305"/>
+      <point x="385" y="-276" type="curve" smooth="yes"/>
+      <point x="385" y="-247"/>
+      <point x="404" y="-227"/>
+      <point x="433" y="-227" type="curve" smooth="yes"/>
+      <point x="461" y="-227"/>
+      <point x="481" y="-247"/>
+      <point x="481" y="-276" type="curve" smooth="yes"/>
+      <point x="481" y="-305"/>
+      <point x="462" y="-325"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-7"/>
-    <component base="zeropercent" xOffset="663" yOffset="32"/>
+    <component base="zeropercent" xOffset="663"/>
     <component base="numero-bar" xOffset="-1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/percent.glif
@@ -3,8 +3,14 @@
   <advance width="828"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="30"/>
-    <component base="zeropercent" xOffset="408" yOffset="-374"/>
-    <component base="percentbar" xOffset="-20"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-406"/>
+    <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="828"/>
   <outline>
     <contour>
-      <point x="220" y="-9" type="line"/>
-      <point x="680" y="679" type="line"/>
-      <point x="623" y="719" type="line"/>
-      <point x="162" y="30" type="line"/>
+      <point x="212" y="-3" type="line"/>
+      <point x="673" y="680" type="line"/>
+      <point x="616" y="719" type="line"/>
+      <point x="155" y="36" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1389"/>
+  <advance width="1358"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent" yOffset="34"/>
-    <component base="percentbar" xOffset="-10" yOffset="2"/>
-    <component base="zeropercent" xOffset="408" yOffset="-372"/>
-    <component base="zeropercent" xOffset="676" yOffset="-372"/>
-    <component base="zeropercent" xOffset="946" yOffset="-374"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="673" yOffset="-406"/>
+    <component base="zeropercent" xOffset="938" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1108"/>
+  <advance width="1093"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="zeropercent" xOffset="408" yOffset="-374"/>
-    <component base="percentbar" xOffset="-10"/>
-    <component base="zeropercent" xOffset="688" yOffset="-374"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="673" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="51" y="495" type="line"/>
-      <point x="128" y="495" type="line" name="hr00"/>
+      <point x="128" y="495" type="line"/>
       <point x="128" y="716" type="line"/>
       <point x="51" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="748"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
   <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="533" y="716" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1065"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="850" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="692" y="0" name="caret_2"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="533" y="716" name="top_2"/>
-  <anchor x="888" y="716" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
-  <advance width="745"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="613" y="0" name="bottom_2"/>
+  <advance width="744"/>
   <anchor x="332" y="0" name="caret_1"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="581" y="654" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="502" y="362" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="519" y="-202" type="curve" smooth="yes"/>
-      <point x="586" y="-202"/>
-      <point x="638" y="-151"/>
-      <point x="638" y="-83" type="curve" smooth="yes"/>
-      <point x="638" y="-15"/>
-      <point x="586" y="36"/>
-      <point x="519" y="36" type="curve" smooth="yes"/>
-      <point x="450" y="36"/>
-      <point x="398" y="-15"/>
-      <point x="398" y="-83" type="curve" smooth="yes"/>
-      <point x="398" y="-152"/>
-      <point x="450" y="-202"/>
-    </contour>
-    <contour>
-      <point x="514" y="-134" type="curve" smooth="yes"/>
-      <point x="483" y="-134"/>
-      <point x="462" y="-113"/>
-      <point x="462" y="-83" type="curve" smooth="yes"/>
-      <point x="462" y="-53"/>
-      <point x="483" y="-32"/>
-      <point x="514" y="-32" type="curve" smooth="yes"/>
-      <point x="544" y="-32"/>
-      <point x="566" y="-53"/>
-      <point x="566" y="-83" type="curve" smooth="yes"/>
-      <point x="566" y="-113"/>
-      <point x="545" y="-134"/>
-    </contour>
-    <contour>
       <point x="389" y="58" type="line"/>
       <point x="389" y="138" type="line"/>
       <point x="318" y="170" type="line"/>
@@ -102,6 +74,34 @@
       <point x="340" y="48" type="curve" smooth="yes"/>
       <point x="340" y="-15"/>
       <point x="374" y="-67"/>
+    </contour>
+    <contour>
+      <point x="519" y="-202" type="curve" smooth="yes"/>
+      <point x="586" y="-202"/>
+      <point x="638" y="-151"/>
+      <point x="638" y="-83" type="curve" smooth="yes"/>
+      <point x="638" y="-15"/>
+      <point x="586" y="36"/>
+      <point x="519" y="36" type="curve" smooth="yes"/>
+      <point x="450" y="36"/>
+      <point x="398" y="-15"/>
+      <point x="398" y="-83" type="curve" smooth="yes"/>
+      <point x="398" y="-152"/>
+      <point x="450" y="-202"/>
+    </contour>
+    <contour>
+      <point x="514" y="-134" type="curve" smooth="yes"/>
+      <point x="483" y="-134"/>
+      <point x="462" y="-113"/>
+      <point x="462" y="-83" type="curve" smooth="yes"/>
+      <point x="462" y="-53"/>
+      <point x="483" y="-32"/>
+      <point x="514" y="-32" type="curve" smooth="yes"/>
+      <point x="544" y="-32"/>
+      <point x="566" y="-53"/>
+      <point x="566" y="-83" type="curve" smooth="yes"/>
+      <point x="566" y="-113"/>
+      <point x="545" y="-134"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="691"/>
-  <anchor x="234" y="0" name="bottom_1"/>
-  <anchor x="475" y="0" name="bottom_2"/>
+  <advance width="690"/>
   <anchor x="345" y="0" name="caret_1"/>
-  <anchor x="183" y="255" name="center_1"/>
-  <anchor x="478" y="255" name="center_2"/>
-  <anchor x="202" y="654" name="top_1"/>
-  <anchor x="474" y="716" name="top_2"/>
-  <anchor x="269" y="560" name="topright_1"/>
-  <anchor x="692" y="510" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="311"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="680"/>
-  <anchor x="234" y="0" name="bottom_1"/>
-  <anchor x="549" y="0" name="bottom_2"/>
+  <advance width="679"/>
   <anchor x="324" y="0" name="caret_1"/>
-  <anchor x="170" y="255" name="center_1"/>
-  <anchor x="511" y="255" name="center_2"/>
-  <anchor x="202" y="654" name="top_1"/>
-  <anchor x="516" y="654" name="top_2"/>
-  <anchor x="267" y="530" name="topright_1"/>
-  <anchor x="589" y="530" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="314"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="210" y="358" type="curve" smooth="yes"/>
-      <point x="305" y="358"/>
-      <point x="380" y="437"/>
-      <point x="380" y="529" type="curve" smooth="yes"/>
-      <point x="380" y="621"/>
-      <point x="305" y="700"/>
-      <point x="210" y="700" type="curve" smooth="yes"/>
-      <point x="116" y="700"/>
-      <point x="40" y="621"/>
-      <point x="40" y="529" type="curve" smooth="yes"/>
-      <point x="40" y="437"/>
-      <point x="116" y="358"/>
+      <point x="210" y="390" type="curve" smooth="yes"/>
+      <point x="305" y="390"/>
+      <point x="380" y="469"/>
+      <point x="380" y="561" type="curve" smooth="yes"/>
+      <point x="380" y="653"/>
+      <point x="305" y="732"/>
+      <point x="210" y="732" type="curve" smooth="yes"/>
+      <point x="115" y="732"/>
+      <point x="40" y="653"/>
+      <point x="40" y="561" type="curve" smooth="yes"/>
+      <point x="40" y="469"/>
+      <point x="115" y="390"/>
     </contour>
     <contour>
-      <point x="210" y="428" type="curve" smooth="yes"/>
-      <point x="157" y="428"/>
-      <point x="116" y="471"/>
-      <point x="116" y="529" type="curve" smooth="yes"/>
-      <point x="116" y="587"/>
-      <point x="157" y="630"/>
-      <point x="210" y="630" type="curve" smooth="yes"/>
-      <point x="264" y="630"/>
-      <point x="305" y="587"/>
-      <point x="305" y="529" type="curve" smooth="yes"/>
-      <point x="305" y="471"/>
-      <point x="264" y="428"/>
+      <point x="210" y="460" type="curve" smooth="yes"/>
+      <point x="156" y="460"/>
+      <point x="115" y="503"/>
+      <point x="115" y="561" type="curve" smooth="yes"/>
+      <point x="115" y="619"/>
+      <point x="156" y="662"/>
+      <point x="210" y="662" type="curve" smooth="yes"/>
+      <point x="264" y="662"/>
+      <point x="305" y="619"/>
+      <point x="305" y="561" type="curve" smooth="yes"/>
+      <point x="305" y="503"/>
+      <point x="264" y="460"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -14,8 +14,6 @@
     <string>Google Sans</string>
     <key>guidelines</key>
     <array/>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -62,6 +60,8 @@
       <integer>526</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="775"/>
   <unicode hex="0132"/>
-  <anchor x="665" y="716" name="top.UC_2"/>
   <anchor x="128" y="716" name="top.UC.1"/>
+  <anchor x="665" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="67" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_u-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/I_u-cy.glif
@@ -1,48 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iu-cy" format="2">
-  <advance width="1063"/>
+  <advance width="1060"/>
   <unicode hex="042E"/>
-  <anchor x="523" y="716" name="top"/>
+  <anchor x="520" y="716" name="top"/>
   <outline>
     <contour>
-      <point x="661" y="-16" type="curve" smooth="yes"/>
-      <point x="872" y="-16"/>
-      <point x="1028" y="151"/>
-      <point x="1028" y="358" type="curve" smooth="yes"/>
-      <point x="1028" y="565"/>
-      <point x="862" y="732"/>
-      <point x="661" y="732" type="curve" smooth="yes"/>
-      <point x="460" y="732"/>
-      <point x="294" y="579"/>
-      <point x="294" y="364" type="curve" smooth="yes"/>
-      <point x="294" y="149"/>
-      <point x="450" y="-16"/>
+      <point x="658" y="-16" type="curve" smooth="yes"/>
+      <point x="869" y="-16"/>
+      <point x="1025" y="151"/>
+      <point x="1025" y="358" type="curve" smooth="yes"/>
+      <point x="1025" y="565"/>
+      <point x="859" y="732"/>
+      <point x="658" y="732" type="curve" smooth="yes"/>
+      <point x="457" y="732"/>
+      <point x="291" y="579"/>
+      <point x="291" y="364" type="curve" smooth="yes"/>
+      <point x="291" y="149"/>
+      <point x="447" y="-16"/>
     </contour>
     <contour>
-      <point x="70" y="0" type="line"/>
-      <point x="195" y="0" type="line"/>
-      <point x="195" y="716" type="line"/>
-      <point x="70" y="716" type="line"/>
+      <point x="67" y="0" type="line"/>
+      <point x="192" y="0" type="line"/>
+      <point x="192" y="716" type="line"/>
+      <point x="67" y="716" type="line"/>
     </contour>
     <contour>
-      <point x="125" y="306" type="line"/>
-      <point x="345" y="306" type="line"/>
-      <point x="345" y="421" type="line"/>
-      <point x="125" y="421" type="line"/>
+      <point x="122" y="306" type="line"/>
+      <point x="342" y="306" type="line"/>
+      <point x="342" y="421" type="line"/>
+      <point x="122" y="421" type="line"/>
     </contour>
     <contour>
-      <point x="661" y="100" type="curve" smooth="yes"/>
-      <point x="521" y="100"/>
-      <point x="420" y="193"/>
-      <point x="420" y="358" type="curve" smooth="yes"/>
-      <point x="420" y="523"/>
-      <point x="522" y="616"/>
-      <point x="661" y="616" type="curve" smooth="yes"/>
-      <point x="800" y="616"/>
-      <point x="902" y="525"/>
-      <point x="902" y="358" type="curve" smooth="yes"/>
-      <point x="902" y="191"/>
-      <point x="801" y="100"/>
+      <point x="658" y="100" type="curve" smooth="yes"/>
+      <point x="518" y="100"/>
+      <point x="417" y="193"/>
+      <point x="417" y="358" type="curve" smooth="yes"/>
+      <point x="417" y="523"/>
+      <point x="519" y="616"/>
+      <point x="658" y="616" type="curve" smooth="yes"/>
+      <point x="797" y="616"/>
+      <point x="899" y="525"/>
+      <point x="899" y="358" type="curve" smooth="yes"/>
+      <point x="899" y="191"/>
+      <point x="798" y="100"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="624" y="315" type="line"/>
+      <point x="643" y="315" type="line" smooth="yes"/>
+      <point x="801" y="315"/>
+      <point x="893" y="414"/>
+      <point x="893" y="543" type="curve" smooth="yes"/>
+      <point x="893" y="662"/>
+      <point x="816" y="751"/>
+      <point x="689" y="751" type="curve" smooth="yes"/>
+      <point x="590" y="751"/>
+      <point x="503" y="689"/>
+      <point x="503" y="584" type="curve" smooth="yes"/>
+      <point x="503" y="512"/>
+      <point x="543" y="465"/>
+      <point x="602" y="465" type="curve" smooth="yes"/>
+      <point x="645" y="465"/>
+      <point x="680" y="495"/>
+      <point x="680" y="537" type="curve" smooth="yes"/>
+      <point x="680" y="579"/>
+      <point x="650" y="609"/>
+      <point x="611" y="609" type="curve" smooth="yes"/>
+      <point x="587" y="609"/>
+      <point x="567" y="599"/>
+      <point x="556" y="577" type="curve"/>
+      <point x="571" y="576" type="line"/>
+      <point x="571" y="586" type="line" smooth="yes"/>
+      <point x="571" y="651"/>
+      <point x="629" y="686"/>
+      <point x="688" y="686" type="curve" smooth="yes"/>
+      <point x="772" y="686"/>
+      <point x="820" y="627"/>
+      <point x="820" y="542" type="curve" smooth="yes"/>
+      <point x="820" y="446"/>
+      <point x="751" y="379"/>
+      <point x="643" y="379" type="curve" smooth="yes"/>
+      <point x="624" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="578" y="-250" type="line"/>
       <point x="649" y="-250" type="line"/>
       <point x="649" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="553" y="-12"/>
       <point x="574" y="16" type="curve"/>
       <point x="578" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="506" type="curve" smooth="yes"/>
+      <point x="129" y="506"/>
+      <point x="116" y="521"/>
+      <point x="116" y="537" type="curve" smooth="yes"/>
+      <point x="116" y="553"/>
+      <point x="129" y="569"/>
+      <point x="146" y="569" type="curve" smooth="yes"/>
+      <point x="163" y="569"/>
+      <point x="176" y="554"/>
+      <point x="176" y="537" type="curve" smooth="yes"/>
+      <point x="176" y="521"/>
+      <point x="163" y="506"/>
     </contour>
     <contour>
       <point x="164" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="291" y="379"/>
       <point x="183" y="379" type="curve" smooth="yes"/>
       <point x="164" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="146" y="506" type="curve" smooth="yes"/>
-      <point x="129" y="506"/>
-      <point x="116" y="521"/>
-      <point x="116" y="537" type="curve" smooth="yes"/>
-      <point x="116" y="553"/>
-      <point x="129" y="569"/>
-      <point x="146" y="569" type="curve" smooth="yes"/>
-      <point x="163" y="569"/>
-      <point x="176" y="554"/>
-      <point x="176" y="537" type="curve" smooth="yes"/>
-      <point x="176" y="521"/>
-      <point x="163" y="506"/>
-    </contour>
-    <contour>
-      <point x="624" y="315" type="line"/>
-      <point x="643" y="315" type="line" smooth="yes"/>
-      <point x="801" y="315"/>
-      <point x="893" y="414"/>
-      <point x="893" y="543" type="curve" smooth="yes"/>
-      <point x="893" y="662"/>
-      <point x="816" y="751"/>
-      <point x="689" y="751" type="curve" smooth="yes"/>
-      <point x="590" y="751"/>
-      <point x="503" y="689"/>
-      <point x="503" y="584" type="curve" smooth="yes"/>
-      <point x="503" y="512"/>
-      <point x="543" y="465"/>
-      <point x="602" y="465" type="curve" smooth="yes"/>
-      <point x="645" y="465"/>
-      <point x="680" y="495"/>
-      <point x="680" y="537" type="curve" smooth="yes"/>
-      <point x="680" y="579"/>
-      <point x="650" y="609"/>
-      <point x="611" y="609" type="curve" smooth="yes"/>
-      <point x="587" y="609"/>
-      <point x="567" y="599"/>
-      <point x="556" y="577" type="curve"/>
-      <point x="571" y="576" type="line"/>
-      <point x="571" y="586" type="line" smooth="yes"/>
-      <point x="571" y="651"/>
-      <point x="629" y="686"/>
-      <point x="688" y="686" type="curve" smooth="yes"/>
-      <point x="772" y="686"/>
-      <point x="820" y="627"/>
-      <point x="820" y="542" type="curve" smooth="yes"/>
-      <point x="820" y="446"/>
-      <point x="751" y="379"/>
-      <point x="643" y="379" type="curve" smooth="yes"/>
-      <point x="624" y="379" type="line"/>
     </contour>
     <contour>
       <point x="606" y="506" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="164" y="-250" type="line"/>
-      <point x="183" y="-250" type="line" smooth="yes"/>
-      <point x="341" y="-250"/>
-      <point x="433" y="-151"/>
-      <point x="433" y="-22" type="curve" smooth="yes"/>
-      <point x="433" y="97"/>
-      <point x="356" y="186"/>
-      <point x="229" y="186" type="curve" smooth="yes"/>
-      <point x="130" y="186"/>
-      <point x="43" y="124"/>
-      <point x="43" y="19" type="curve" smooth="yes"/>
-      <point x="43" y="-53"/>
-      <point x="83" y="-100"/>
-      <point x="142" y="-100" type="curve" smooth="yes"/>
-      <point x="185" y="-100"/>
-      <point x="220" y="-70"/>
-      <point x="220" y="-28" type="curve" smooth="yes"/>
-      <point x="220" y="14"/>
-      <point x="190" y="44"/>
-      <point x="151" y="44" type="curve" smooth="yes"/>
-      <point x="127" y="44"/>
-      <point x="107" y="34"/>
-      <point x="96" y="12" type="curve"/>
-      <point x="111" y="11" type="line"/>
-      <point x="111" y="21" type="line" smooth="yes"/>
-      <point x="111" y="86"/>
-      <point x="169" y="121"/>
-      <point x="228" y="121" type="curve" smooth="yes"/>
-      <point x="312" y="121"/>
-      <point x="360" y="62"/>
-      <point x="360" y="-23" type="curve" smooth="yes"/>
-      <point x="360" y="-119"/>
-      <point x="291" y="-186"/>
-      <point x="183" y="-186" type="curve" smooth="yes"/>
-      <point x="164" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="146" y="-59" type="curve" smooth="yes"/>
-      <point x="129" y="-59"/>
-      <point x="116" y="-44"/>
-      <point x="116" y="-28" type="curve" smooth="yes"/>
-      <point x="116" y="-12"/>
-      <point x="129" y="4"/>
-      <point x="146" y="4" type="curve" smooth="yes"/>
-      <point x="163" y="4"/>
-      <point x="176" y="-11"/>
-      <point x="176" y="-28" type="curve" smooth="yes"/>
-      <point x="176" y="-44"/>
-      <point x="163" y="-59"/>
-    </contour>
-    <contour>
       <point x="624" y="-250" type="line"/>
       <point x="643" y="-250" type="line" smooth="yes"/>
       <point x="801" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="751" y="-186"/>
       <point x="643" y="-186" type="curve" smooth="yes"/>
       <point x="624" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="-59" type="curve" smooth="yes"/>
+      <point x="129" y="-59"/>
+      <point x="116" y="-44"/>
+      <point x="116" y="-28" type="curve" smooth="yes"/>
+      <point x="116" y="-12"/>
+      <point x="129" y="4"/>
+      <point x="146" y="4" type="curve" smooth="yes"/>
+      <point x="163" y="4"/>
+      <point x="176" y="-11"/>
+      <point x="176" y="-28" type="curve" smooth="yes"/>
+      <point x="176" y="-44"/>
+      <point x="163" y="-59"/>
+    </contour>
+    <contour>
+      <point x="164" y="-250" type="line"/>
+      <point x="183" y="-250" type="line" smooth="yes"/>
+      <point x="341" y="-250"/>
+      <point x="433" y="-151"/>
+      <point x="433" y="-22" type="curve" smooth="yes"/>
+      <point x="433" y="97"/>
+      <point x="356" y="186"/>
+      <point x="229" y="186" type="curve" smooth="yes"/>
+      <point x="130" y="186"/>
+      <point x="43" y="124"/>
+      <point x="43" y="19" type="curve" smooth="yes"/>
+      <point x="43" y="-53"/>
+      <point x="83" y="-100"/>
+      <point x="142" y="-100" type="curve" smooth="yes"/>
+      <point x="185" y="-100"/>
+      <point x="220" y="-70"/>
+      <point x="220" y="-28" type="curve" smooth="yes"/>
+      <point x="220" y="14"/>
+      <point x="190" y="44"/>
+      <point x="151" y="44" type="curve" smooth="yes"/>
+      <point x="127" y="44"/>
+      <point x="107" y="34"/>
+      <point x="96" y="12" type="curve"/>
+      <point x="111" y="11" type="line"/>
+      <point x="111" y="21" type="line" smooth="yes"/>
+      <point x="111" y="86"/>
+      <point x="169" y="121"/>
+      <point x="228" y="121" type="curve" smooth="yes"/>
+      <point x="312" y="121"/>
+      <point x="360" y="62"/>
+      <point x="360" y="-23" type="curve" smooth="yes"/>
+      <point x="360" y="-119"/>
+      <point x="291" y="-186"/>
+      <point x="183" y="-186" type="curve" smooth="yes"/>
+      <point x="164" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="606" y="-59" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="480"/>
   <unicode hex="025B"/>
-  <anchor x="328" y="0" name="ogonek"/>
   <anchor x="236" y="0" name="bottom"/>
+  <anchor x="328" y="0" name="ogonek"/>
   <anchor x="245" y="510" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="978"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="677" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="677" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="696"/>
   <anchor x="323" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="317"/>
     <component base="flig2"/>
+    <component base="f" xOffset="317"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_b.glif
@@ -1,18 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
-  <advance width="1296"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="994" y="0" name="bottom_3"/>
-  <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="798" y="716" name="top_3"/>
+  <advance width="1295"/>
+  <anchor x="322" y="0" name="caret_1"/>
+  <anchor x="638" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="1"/>
-    <component base="flig1" xOffset="318"/>
-    <component base="b" xOffset="694"/>
+    <component base="flig2"/>
+    <component base="flig1" xOffset="317"/>
+    <component base="b" xOffset="693"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1257"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="976" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="798" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="317"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="910"/>
+  <anchor x="164" y="0" name="bottom_1"/>
+  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="797" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
+  <anchor x="164" y="716" name="top_1"/>
+  <anchor x="481" y="716" name="top_2"/>
+  <anchor x="797" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="i" xOffset="684"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="481" y="716" name="top_2"/>
   <anchor x="797" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="j" xOffset="684"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1198"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="954" y="0" name="bottom_3"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="797" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="317"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="1004"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="871" y="0" name="bottom_3"/>
   <anchor x="324" y="0" name="caret_1"/>
   <anchor x="639" y="0" name="caret_2"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
-  <anchor x="840" y="654" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="317"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="317"/>
     <component base="t" xOffset="638"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="940"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="677" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="677" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_j.glif
@@ -2,7 +2,7 @@
 <glyph name="f_j" format="2">
   <advance width="594"/>
   <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="481" y="-216" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
   <anchor x="164" y="716" name="top_1"/>
   <anchor x="481" y="716" name="top_2"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="881"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="638" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="587"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="481" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="376"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="688"/>
-  <anchor x="164" y="0" name="bottom_1"/>
-  <anchor x="556" y="0" name="bottom_2"/>
+  <advance width="687"/>
   <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="164" y="716" name="top_1"/>
-  <anchor x="524" y="654" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="322"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.glif
@@ -1,48 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="786"/>
+  <advance width="783"/>
   <unicode hex="044E"/>
   <anchor x="393" y="510" name="top"/>
   <outline>
     <contour>
       <point x="498" y="-16" type="curve" smooth="yes"/>
-      <point x="645" y="-16"/>
-      <point x="755" y="99"/>
+      <point x="652" y="-16"/>
+      <point x="754" y="99"/>
       <point x="755" y="255" type="curve" smooth="yes"/>
-      <point x="755" y="411"/>
-      <point x="647" y="526"/>
+      <point x="756" y="411"/>
+      <point x="651" y="526"/>
       <point x="498" y="526" type="curve" smooth="yes"/>
       <point x="345" y="526"/>
-      <point x="231" y="412"/>
-      <point x="231" y="256" type="curve" smooth="yes"/>
-      <point x="231" y="99"/>
-      <point x="343" y="-16"/>
+      <point x="241" y="417"/>
+      <point x="240" y="256" type="curve" smooth="yes"/>
+      <point x="239" y="95"/>
+      <point x="344" y="-16"/>
     </contour>
     <contour>
       <point x="53" y="0" type="line"/>
-      <point x="171" y="0" type="line"/>
-      <point x="171" y="510" type="line"/>
+      <point x="168" y="0" type="line"/>
+      <point x="168" y="510" type="line"/>
       <point x="53" y="510" type="line"/>
     </contour>
     <contour>
-      <point x="108" y="204" type="line"/>
-      <point x="291" y="204" type="line"/>
-      <point x="291" y="311" type="line"/>
-      <point x="108" y="311" type="line"/>
+      <point x="108" y="219" type="line"/>
+      <point x="291" y="219" type="line"/>
+      <point x="291" y="296" type="line"/>
+      <point x="108" y="296" type="line"/>
     </contour>
     <contour>
       <point x="498" y="91" type="curve" smooth="yes"/>
-      <point x="413" y="91"/>
-      <point x="350" y="161"/>
+      <point x="416" y="91"/>
+      <point x="350" y="137"/>
       <point x="350" y="255" type="curve" smooth="yes"/>
-      <point x="350" y="349"/>
-      <point x="413" y="419"/>
+      <point x="350" y="373"/>
+      <point x="415" y="419"/>
       <point x="498" y="419" type="curve" smooth="yes"/>
-      <point x="578" y="419"/>
-      <point x="636" y="349"/>
-      <point x="636" y="255" type="curve" smooth="yes"/>
-      <point x="636" y="161"/>
-      <point x="578" y="91"/>
+      <point x="581" y="419"/>
+      <point x="645" y="372"/>
+      <point x="645" y="255" type="curve" smooth="yes"/>
+      <point x="645" y="138"/>
+      <point x="580" y="91"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -1,47 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.loclBGR" format="2">
-  <advance width="786"/>
+  <advance width="788"/>
   <anchor x="393" y="510" name="top"/>
   <outline>
     <contour>
-      <point x="498" y="-16" type="curve" smooth="yes"/>
-      <point x="645" y="-16"/>
-      <point x="755" y="99"/>
-      <point x="755" y="255" type="curve" smooth="yes"/>
-      <point x="755" y="411"/>
-      <point x="647" y="526"/>
-      <point x="498" y="526" type="curve" smooth="yes"/>
-      <point x="345" y="526"/>
-      <point x="231" y="412"/>
-      <point x="231" y="256" type="curve" smooth="yes"/>
-      <point x="231" y="99"/>
-      <point x="343" y="-16"/>
-    </contour>
-    <contour>
-      <point x="108" y="204" type="line"/>
-      <point x="291" y="204" type="line"/>
-      <point x="291" y="311" type="line"/>
-      <point x="108" y="311" type="line"/>
-    </contour>
-    <contour>
       <point x="53" y="0" type="line"/>
-      <point x="171" y="0" type="line"/>
-      <point x="171" y="716" type="line"/>
+      <point x="168" y="0" type="line"/>
+      <point x="168" y="716" type="line"/>
       <point x="53" y="716" type="line"/>
     </contour>
     <contour>
+      <point x="498" y="-16" type="curve" smooth="yes"/>
+      <point x="653" y="-16"/>
+      <point x="760" y="103"/>
+      <point x="760" y="255" type="curve" smooth="yes"/>
+      <point x="760" y="405"/>
+      <point x="653" y="526"/>
+      <point x="498" y="526" type="curve" smooth="yes"/>
+      <point x="343" y="526"/>
+      <point x="237" y="429"/>
+      <point x="236" y="262" type="curve" smooth="yes"/>
+      <point x="235" y="84"/>
+      <point x="343" y="-16"/>
+    </contour>
+    <contour>
       <point x="498" y="91" type="curve" smooth="yes"/>
-      <point x="413" y="91"/>
-      <point x="350" y="161"/>
+      <point x="410" y="91"/>
+      <point x="350" y="143"/>
       <point x="350" y="255" type="curve" smooth="yes"/>
-      <point x="350" y="349"/>
-      <point x="413" y="419"/>
+      <point x="350" y="367"/>
+      <point x="410" y="419"/>
       <point x="498" y="419" type="curve" smooth="yes"/>
-      <point x="578" y="419"/>
-      <point x="636" y="349"/>
-      <point x="636" y="255" type="curve" smooth="yes"/>
-      <point x="636" y="161"/>
-      <point x="578" y="91"/>
+      <point x="585" y="419"/>
+      <point x="645" y="367"/>
+      <point x="645" y="255" type="curve" smooth="yes"/>
+      <point x="645" y="143"/>
+      <point x="585" y="91"/>
+    </contour>
+    <contour>
+      <point x="108" y="204" type="line"/>
+      <point x="288" y="204" type="line"/>
+      <point x="288" y="311" type="line"/>
+      <point x="108" y="311" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
@@ -24,10 +24,10 @@
       <point x="63" y="580" type="line"/>
     </contour>
     <contour>
-      <point x="120" y="245" type="line"/>
-      <point x="304" y="245" type="line"/>
-      <point x="304" y="353" type="line"/>
-      <point x="120" y="353" type="line"/>
+      <point x="120" y="247" type="line"/>
+      <point x="304" y="247" type="line"/>
+      <point x="304" y="346" type="line"/>
+      <point x="120" y="346" type="line"/>
     </contour>
     <contour>
       <point x="548" y="93" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/khook.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/khook.glif
@@ -40,6 +40,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>k</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>k</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="706" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="438" y="-393" type="curve" smooth="yes"/>
-      <point x="503" y="-393"/>
-      <point x="553" y="-343"/>
-      <point x="553" y="-276" type="curve" smooth="yes"/>
-      <point x="553" y="-209"/>
-      <point x="503" y="-159"/>
-      <point x="438" y="-159" type="curve" smooth="yes"/>
-      <point x="371" y="-159"/>
-      <point x="321" y="-209"/>
-      <point x="321" y="-276" type="curve" smooth="yes"/>
-      <point x="321" y="-344"/>
-      <point x="371" y="-393"/>
-    </contour>
-    <contour>
-      <point x="433" y="-325" type="curve" smooth="yes"/>
-      <point x="404" y="-325"/>
-      <point x="385" y="-305"/>
-      <point x="385" y="-276" type="curve" smooth="yes"/>
-      <point x="385" y="-247"/>
-      <point x="404" y="-227"/>
-      <point x="433" y="-227" type="curve" smooth="yes"/>
-      <point x="461" y="-227"/>
-      <point x="481" y="-247"/>
-      <point x="481" y="-276" type="curve" smooth="yes"/>
-      <point x="481" y="-305"/>
-      <point x="462" y="-325"/>
-    </contour>
-    <contour>
       <point x="587" y="-385" type="line"/>
       <point x="667" y="-385" type="line"/>
       <point x="667" y="213" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="537" y="-52"/>
       <point x="587" y="-102"/>
       <point x="587" y="-184" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="438" y="-393" type="curve" smooth="yes"/>
+      <point x="503" y="-393"/>
+      <point x="553" y="-343"/>
+      <point x="553" y="-276" type="curve" smooth="yes"/>
+      <point x="553" y="-209"/>
+      <point x="503" y="-159"/>
+      <point x="438" y="-159" type="curve" smooth="yes"/>
+      <point x="371" y="-159"/>
+      <point x="321" y="-209"/>
+      <point x="321" y="-276" type="curve" smooth="yes"/>
+      <point x="321" y="-344"/>
+      <point x="371" y="-393"/>
+    </contour>
+    <contour>
+      <point x="433" y="-325" type="curve" smooth="yes"/>
+      <point x="404" y="-325"/>
+      <point x="385" y="-305"/>
+      <point x="385" y="-276" type="curve" smooth="yes"/>
+      <point x="385" y="-247"/>
+      <point x="404" y="-227"/>
+      <point x="433" y="-227" type="curve" smooth="yes"/>
+      <point x="461" y="-227"/>
+      <point x="481" y="-247"/>
+      <point x="481" y="-276" type="curve" smooth="yes"/>
+      <point x="481" y="-305"/>
+      <point x="462" y="-325"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-7"/>
-    <component base="zeropercent" xOffset="663" yOffset="32"/>
+    <component base="zeropercent" xOffset="663"/>
     <component base="numero-bar" xOffset="-1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/percent.glif
@@ -3,8 +3,14 @@
   <advance width="828"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="zeropercent" xOffset="408" yOffset="-357"/>
-    <component base="percentbar" xOffset="-19"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-380"/>
+    <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="828"/>
   <outline>
     <contour>
-      <point x="234" y="-9" type="line"/>
-      <point x="694" y="679" type="line"/>
-      <point x="609" y="719" type="line"/>
-      <point x="148" y="30" type="line"/>
+      <point x="219" y="-16" type="line"/>
+      <point x="684" y="678" type="line"/>
+      <point x="608" y="731" type="line"/>
+      <point x="143" y="37" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1389"/>
+  <advance width="1358"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="percentbar" yOffset="2"/>
-    <component base="zeropercent" xOffset="408" yOffset="-352"/>
-    <component base="zeropercent" xOffset="676" yOffset="-352"/>
-    <component base="zeropercent" xOffset="946" yOffset="-354"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-380"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="672" yOffset="-380"/>
+    <component base="zeropercent" xOffset="938" yOffset="-380"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1108"/>
+  <advance width="1093"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent" yOffset="30"/>
-    <component base="zeropercent" xOffset="408" yOffset="-354"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="408" yOffset="-380"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="688" yOffset="-354"/>
+    <component base="zeropercent" xOffset="673" yOffset="-380"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="33" y="495" type="line"/>
-      <point x="146" y="495" type="line" name="hr00"/>
+      <point x="146" y="495" type="line"/>
       <point x="146" y="716" type="line"/>
       <point x="33" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/r_f.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
-  <advance width="748"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="320" y="0" name="caret_1"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="533" y="716" name="top_2"/>
+  <advance width="747"/>
+  <anchor x="319" y="0" name="caret_1"/>
   <outline>
-    <component base="rlig"/>
-    <component base="f" xOffset="369"/>
+    <component base="rlig" xOffset="-1"/>
+    <component base="f" xOffset="368"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1065"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="533" y="0" name="bottom_2"/>
-  <anchor x="850" y="0" name="bottom_3"/>
   <anchor x="320" y="0" name="caret_1"/>
   <anchor x="692" y="0" name="caret_2"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="533" y="716" name="top_2"/>
-  <anchor x="888" y="716" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
-  <advance width="745"/>
-  <anchor x="105" y="0" name="bottom_1"/>
-  <anchor x="613" y="0" name="bottom_2"/>
+  <advance width="744"/>
   <anchor x="332" y="0" name="caret_1"/>
-  <anchor x="204" y="510" name="top_1"/>
-  <anchor x="581" y="654" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="502" y="362" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="519" y="-202" type="curve" smooth="yes"/>
-      <point x="586" y="-202"/>
-      <point x="638" y="-151"/>
-      <point x="638" y="-83" type="curve" smooth="yes"/>
-      <point x="638" y="-15"/>
-      <point x="586" y="36"/>
-      <point x="519" y="36" type="curve" smooth="yes"/>
-      <point x="450" y="36"/>
-      <point x="398" y="-15"/>
-      <point x="398" y="-83" type="curve" smooth="yes"/>
-      <point x="398" y="-152"/>
-      <point x="450" y="-202"/>
-    </contour>
-    <contour>
-      <point x="514" y="-134" type="curve" smooth="yes"/>
-      <point x="483" y="-134"/>
-      <point x="462" y="-113"/>
-      <point x="462" y="-83" type="curve" smooth="yes"/>
-      <point x="462" y="-53"/>
-      <point x="483" y="-32"/>
-      <point x="514" y="-32" type="curve" smooth="yes"/>
-      <point x="544" y="-32"/>
-      <point x="566" y="-53"/>
-      <point x="566" y="-83" type="curve" smooth="yes"/>
-      <point x="566" y="-113"/>
-      <point x="545" y="-134"/>
-    </contour>
-    <contour>
       <point x="389" y="58" type="line"/>
       <point x="389" y="138" type="line"/>
       <point x="318" y="170" type="line"/>
@@ -102,6 +74,34 @@
       <point x="340" y="48" type="curve" smooth="yes"/>
       <point x="340" y="-15"/>
       <point x="374" y="-67"/>
+    </contour>
+    <contour>
+      <point x="519" y="-202" type="curve" smooth="yes"/>
+      <point x="586" y="-202"/>
+      <point x="638" y="-151"/>
+      <point x="638" y="-83" type="curve" smooth="yes"/>
+      <point x="638" y="-15"/>
+      <point x="586" y="36"/>
+      <point x="519" y="36" type="curve" smooth="yes"/>
+      <point x="450" y="36"/>
+      <point x="398" y="-15"/>
+      <point x="398" y="-83" type="curve" smooth="yes"/>
+      <point x="398" y="-152"/>
+      <point x="450" y="-202"/>
+    </contour>
+    <contour>
+      <point x="514" y="-134" type="curve" smooth="yes"/>
+      <point x="483" y="-134"/>
+      <point x="462" y="-113"/>
+      <point x="462" y="-83" type="curve" smooth="yes"/>
+      <point x="462" y="-53"/>
+      <point x="483" y="-32"/>
+      <point x="514" y="-32" type="curve" smooth="yes"/>
+      <point x="544" y="-32"/>
+      <point x="566" y="-53"/>
+      <point x="566" y="-83" type="curve" smooth="yes"/>
+      <point x="566" y="-113"/>
+      <point x="545" y="-134"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="691"/>
-  <anchor x="234" y="0" name="bottom_1"/>
-  <anchor x="475" y="0" name="bottom_2"/>
+  <advance width="690"/>
   <anchor x="345" y="0" name="caret_1"/>
-  <anchor x="183" y="255" name="center_1"/>
-  <anchor x="478" y="255" name="center_2"/>
-  <anchor x="202" y="654" name="top_1"/>
-  <anchor x="474" y="716" name="top_2"/>
-  <anchor x="269" y="560" name="topright_1"/>
-  <anchor x="692" y="510" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="311"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="680"/>
-  <anchor x="234" y="0" name="bottom_1"/>
-  <anchor x="549" y="0" name="bottom_2"/>
+  <advance width="679"/>
   <anchor x="324" y="0" name="caret_1"/>
-  <anchor x="170" y="255" name="center_1"/>
-  <anchor x="511" y="255" name="center_2"/>
-  <anchor x="202" y="654" name="top_1"/>
-  <anchor x="516" y="654" name="top_2"/>
-  <anchor x="267" y="530" name="topright_1"/>
-  <anchor x="589" y="530" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="314"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/yhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/yhook.glif
@@ -14,7 +14,7 @@
       <point x="-5" y="510" type="line"/>
       <point x="199" y="27" type="line"/>
       <point x="148" y="-75" type="line" smooth="yes"/>
-      <point x="142.596" y="-85.8074"/>
+      <point x="142.596" y="-85.807"/>
       <point x="130" y="-112"/>
       <point x="117" y="-135" type="curve" smooth="yes"/>
       <point x="104" y="-159"/>
@@ -43,6 +43,8 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=whook</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/yhook.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/yhook.sc.glif
@@ -33,4 +33,10 @@
       <point x="326" y="254" type="line"/>
     </contour>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>y.sc</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="210" y="344" type="curve" smooth="yes"/>
-      <point x="315" y="344"/>
-      <point x="396" y="428"/>
-      <point x="396" y="528" type="curve" smooth="yes"/>
-      <point x="396" y="627"/>
-      <point x="315" y="711"/>
-      <point x="210" y="711" type="curve" smooth="yes"/>
-      <point x="106" y="711"/>
-      <point x="24" y="627"/>
-      <point x="24" y="528" type="curve" smooth="yes"/>
-      <point x="24" y="428"/>
-      <point x="106" y="344"/>
+      <point x="210" y="364" type="curve" smooth="yes"/>
+      <point x="314" y="364"/>
+      <point x="394" y="448"/>
+      <point x="394" y="548" type="curve" smooth="yes"/>
+      <point x="394" y="648"/>
+      <point x="314" y="732"/>
+      <point x="210" y="732" type="curve" smooth="yes"/>
+      <point x="107" y="732"/>
+      <point x="26" y="648"/>
+      <point x="26" y="548" type="curve" smooth="yes"/>
+      <point x="26" y="448"/>
+      <point x="107" y="364"/>
     </contour>
     <contour>
-      <point x="210" y="444" type="curve" smooth="yes"/>
-      <point x="166" y="444"/>
-      <point x="129" y="480"/>
-      <point x="129" y="528" type="curve" smooth="yes"/>
-      <point x="129" y="576"/>
-      <point x="166" y="612"/>
-      <point x="210" y="612" type="curve" smooth="yes"/>
-      <point x="255" y="612"/>
-      <point x="292" y="576"/>
-      <point x="292" y="528" type="curve" smooth="yes"/>
-      <point x="292" y="480"/>
-      <point x="255" y="444"/>
+      <point x="210" y="464" type="curve" smooth="yes"/>
+      <point x="167" y="464"/>
+      <point x="131" y="500"/>
+      <point x="131" y="548" type="curve" smooth="yes"/>
+      <point x="131" y="596"/>
+      <point x="167" y="632"/>
+      <point x="210" y="632" type="curve" smooth="yes"/>
+      <point x="254" y="632"/>
+      <point x="290" y="596"/>
+      <point x="290" y="548" type="curve" smooth="yes"/>
+      <point x="290" y="500"/>
+      <point x="254" y="464"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -65,8 +65,6 @@
         <integer>413</integer>
       </dict>
     </array>
-    <key>italicAngle</key>
-    <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
@@ -113,6 +111,8 @@
       <integer>526</integer>
       <integer>580</integer>
       <integer>596</integer>
+      <integer>716</integer>
+      <integer>732</integer>
       <integer>716</integer>
       <integer>732</integer>
     </array>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/I_J_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/I_J_.glif
@@ -2,8 +2,8 @@
 <glyph name="IJ" format="2">
   <advance width="867"/>
   <unicode hex="0132"/>
-  <anchor x="730" y="716" name="top.UC_2"/>
   <anchor x="150" y="716" name="top.UC.1"/>
+  <anchor x="730" y="716" name="top.UC_2"/>
   <outline>
     <contour>
       <point x="82" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/I_u-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/I_u-cy.glif
@@ -26,8 +26,8 @@
     </contour>
     <contour>
       <point x="149" y="302" type="line"/>
-      <point x="379" y="302" type="line"/>
-      <point x="379" y="430" type="line"/>
+      <point x="378" y="302" type="line"/>
+      <point x="380" y="430" type="line"/>
       <point x="149" y="430" type="line"/>
     </contour>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="693" y="330" type="line"/>
+      <point x="703" y="330" type="line" smooth="yes"/>
+      <point x="874" y="330"/>
+      <point x="971" y="431"/>
+      <point x="971" y="560" type="curve" smooth="yes"/>
+      <point x="971" y="681"/>
+      <point x="886" y="781"/>
+      <point x="755" y="781" type="curve" smooth="yes"/>
+      <point x="627" y="781"/>
+      <point x="539" y="698"/>
+      <point x="539" y="594" type="curve" smooth="yes"/>
+      <point x="539" y="514"/>
+      <point x="587" y="463"/>
+      <point x="654" y="463" type="curve" smooth="yes"/>
+      <point x="704" y="463"/>
+      <point x="745" y="501"/>
+      <point x="745" y="549" type="curve" smooth="yes"/>
+      <point x="745" y="592"/>
+      <point x="711" y="627"/>
+      <point x="665" y="627" type="curve" smooth="yes"/>
+      <point x="644" y="627"/>
+      <point x="628" y="620"/>
+      <point x="617" y="615" type="curve"/>
+      <point x="639" y="594" type="line"/>
+      <point x="639" y="603" type="line" smooth="yes"/>
+      <point x="639" y="631"/>
+      <point x="676" y="682"/>
+      <point x="749" y="682" type="curve" smooth="yes"/>
+      <point x="814" y="682"/>
+      <point x="858" y="627"/>
+      <point x="858" y="563" type="curve" smooth="yes"/>
+      <point x="858" y="483"/>
+      <point x="794" y="428"/>
+      <point x="703" y="428" type="curve" smooth="yes"/>
+      <point x="693" y="428" type="line"/>
+    </contour>
+    <contour>
       <point x="578" y="-250" type="line"/>
       <point x="689" y="-250" type="line"/>
       <point x="689" y="197" type="line"/>
@@ -29,6 +66,20 @@
       <point x="548" y="-31"/>
       <point x="573" y="-4" type="curve"/>
       <point x="578" y="-4" type="line"/>
+    </contour>
+    <contour>
+      <point x="164" y="518" type="curve" smooth="yes"/>
+      <point x="147" y="518"/>
+      <point x="134" y="532"/>
+      <point x="134" y="549" type="curve" smooth="yes"/>
+      <point x="134" y="564"/>
+      <point x="147" y="579"/>
+      <point x="164" y="579" type="curve" smooth="yes"/>
+      <point x="181" y="579"/>
+      <point x="195" y="565"/>
+      <point x="195" y="549" type="curve" smooth="yes"/>
+      <point x="195" y="532"/>
+      <point x="181" y="518"/>
     </contour>
     <contour>
       <point x="199" y="330" type="line"/>
@@ -66,57 +117,6 @@
       <point x="300" y="428"/>
       <point x="209" y="428" type="curve" smooth="yes"/>
       <point x="199" y="428" type="line"/>
-    </contour>
-    <contour>
-      <point x="164" y="518" type="curve" smooth="yes"/>
-      <point x="147" y="518"/>
-      <point x="134" y="532"/>
-      <point x="134" y="549" type="curve" smooth="yes"/>
-      <point x="134" y="564"/>
-      <point x="147" y="579"/>
-      <point x="164" y="579" type="curve" smooth="yes"/>
-      <point x="181" y="579"/>
-      <point x="195" y="565"/>
-      <point x="195" y="549" type="curve" smooth="yes"/>
-      <point x="195" y="532"/>
-      <point x="181" y="518"/>
-    </contour>
-    <contour>
-      <point x="693" y="330" type="line"/>
-      <point x="703" y="330" type="line" smooth="yes"/>
-      <point x="874" y="330"/>
-      <point x="971" y="431"/>
-      <point x="971" y="560" type="curve" smooth="yes"/>
-      <point x="971" y="681"/>
-      <point x="886" y="781"/>
-      <point x="755" y="781" type="curve" smooth="yes"/>
-      <point x="627" y="781"/>
-      <point x="539" y="698"/>
-      <point x="539" y="594" type="curve" smooth="yes"/>
-      <point x="539" y="514"/>
-      <point x="587" y="463"/>
-      <point x="654" y="463" type="curve" smooth="yes"/>
-      <point x="704" y="463"/>
-      <point x="745" y="501"/>
-      <point x="745" y="549" type="curve" smooth="yes"/>
-      <point x="745" y="592"/>
-      <point x="711" y="627"/>
-      <point x="665" y="627" type="curve" smooth="yes"/>
-      <point x="644" y="627"/>
-      <point x="628" y="620"/>
-      <point x="617" y="615" type="curve"/>
-      <point x="639" y="594" type="line"/>
-      <point x="639" y="603" type="line" smooth="yes"/>
-      <point x="639" y="631"/>
-      <point x="676" y="682"/>
-      <point x="749" y="682" type="curve" smooth="yes"/>
-      <point x="814" y="682"/>
-      <point x="858" y="627"/>
-      <point x="858" y="563" type="curve" smooth="yes"/>
-      <point x="858" y="483"/>
-      <point x="794" y="428"/>
-      <point x="703" y="428" type="curve" smooth="yes"/>
-      <point x="693" y="428" type="line"/>
     </contour>
     <contour>
       <point x="654" y="518" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="199" y="-250" type="line"/>
-      <point x="209" y="-250" type="line" smooth="yes"/>
-      <point x="380" y="-250"/>
-      <point x="477" y="-149"/>
-      <point x="477" y="-20" type="curve" smooth="yes"/>
-      <point x="477" y="101"/>
-      <point x="392" y="201"/>
-      <point x="261" y="201" type="curve" smooth="yes"/>
-      <point x="133" y="201"/>
-      <point x="45" y="118"/>
-      <point x="45" y="14" type="curve" smooth="yes"/>
-      <point x="45" y="-66"/>
-      <point x="93" y="-117"/>
-      <point x="160" y="-117" type="curve" smooth="yes"/>
-      <point x="210" y="-117"/>
-      <point x="251" y="-79"/>
-      <point x="251" y="-31" type="curve" smooth="yes"/>
-      <point x="251" y="12"/>
-      <point x="217" y="47"/>
-      <point x="171" y="47" type="curve" smooth="yes"/>
-      <point x="150" y="47"/>
-      <point x="134" y="40"/>
-      <point x="123" y="35" type="curve"/>
-      <point x="145" y="14" type="line"/>
-      <point x="145" y="23" type="line" smooth="yes"/>
-      <point x="145" y="51"/>
-      <point x="182" y="102"/>
-      <point x="255" y="102" type="curve" smooth="yes"/>
-      <point x="320" y="102"/>
-      <point x="364" y="47"/>
-      <point x="364" y="-17" type="curve" smooth="yes"/>
-      <point x="364" y="-97"/>
-      <point x="300" y="-152"/>
-      <point x="209" y="-152" type="curve" smooth="yes"/>
-      <point x="199" y="-152" type="line"/>
-    </contour>
-    <contour>
-      <point x="164" y="-62" type="curve" smooth="yes"/>
-      <point x="147" y="-62"/>
-      <point x="134" y="-48"/>
-      <point x="134" y="-31" type="curve" smooth="yes"/>
-      <point x="134" y="-16"/>
-      <point x="147" y="-1"/>
-      <point x="164" y="-1" type="curve" smooth="yes"/>
-      <point x="181" y="-1"/>
-      <point x="195" y="-15"/>
-      <point x="195" y="-31" type="curve" smooth="yes"/>
-      <point x="195" y="-48"/>
-      <point x="181" y="-62"/>
-    </contour>
-    <contour>
       <point x="693" y="-250" type="line"/>
       <point x="703" y="-250" type="line" smooth="yes"/>
       <point x="874" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="794" y="-152"/>
       <point x="703" y="-152" type="curve" smooth="yes"/>
       <point x="693" y="-152" type="line"/>
+    </contour>
+    <contour>
+      <point x="164" y="-62" type="curve" smooth="yes"/>
+      <point x="147" y="-62"/>
+      <point x="134" y="-48"/>
+      <point x="134" y="-31" type="curve" smooth="yes"/>
+      <point x="134" y="-16"/>
+      <point x="147" y="-1"/>
+      <point x="164" y="-1" type="curve" smooth="yes"/>
+      <point x="181" y="-1"/>
+      <point x="195" y="-15"/>
+      <point x="195" y="-31" type="curve" smooth="yes"/>
+      <point x="195" y="-48"/>
+      <point x="181" y="-62"/>
+    </contour>
+    <contour>
+      <point x="199" y="-250" type="line"/>
+      <point x="209" y="-250" type="line" smooth="yes"/>
+      <point x="380" y="-250"/>
+      <point x="477" y="-149"/>
+      <point x="477" y="-20" type="curve" smooth="yes"/>
+      <point x="477" y="101"/>
+      <point x="392" y="201"/>
+      <point x="261" y="201" type="curve" smooth="yes"/>
+      <point x="133" y="201"/>
+      <point x="45" y="118"/>
+      <point x="45" y="14" type="curve" smooth="yes"/>
+      <point x="45" y="-66"/>
+      <point x="93" y="-117"/>
+      <point x="160" y="-117" type="curve" smooth="yes"/>
+      <point x="210" y="-117"/>
+      <point x="251" y="-79"/>
+      <point x="251" y="-31" type="curve" smooth="yes"/>
+      <point x="251" y="12"/>
+      <point x="217" y="47"/>
+      <point x="171" y="47" type="curve" smooth="yes"/>
+      <point x="150" y="47"/>
+      <point x="134" y="40"/>
+      <point x="123" y="35" type="curve"/>
+      <point x="145" y="14" type="line"/>
+      <point x="145" y="23" type="line" smooth="yes"/>
+      <point x="145" y="51"/>
+      <point x="182" y="102"/>
+      <point x="255" y="102" type="curve" smooth="yes"/>
+      <point x="320" y="102"/>
+      <point x="364" y="47"/>
+      <point x="364" y="-17" type="curve" smooth="yes"/>
+      <point x="364" y="-97"/>
+      <point x="300" y="-152"/>
+      <point x="209" y="-152" type="curve" smooth="yes"/>
+      <point x="199" y="-152" type="line"/>
     </contour>
     <contour>
       <point x="654" y="-62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dhook.glif
@@ -56,8 +56,6 @@
     <dict>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>=d</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>=|j</string>
     </dict>
   </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dhook.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/dhook.sc.glif
@@ -40,8 +40,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>bhook.sc</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>d.sc</string>
     </dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/eopen.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/eopen.glif
@@ -2,8 +2,8 @@
 <glyph name="eopen" format="2">
   <advance width="521"/>
   <unicode hex="025B"/>
-  <anchor x="359" y="0" name="ogonek"/>
   <anchor x="269" y="0" name="bottom"/>
+  <anchor x="359" y="0" name="ogonek"/>
   <anchor x="276" y="510" name="top"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="1018"/>
-  <anchor x="185" y="0" name="bottom_1"/>
-  <anchor x="704" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="185" y="716" name="top_1"/>
-  <anchor x="704" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="388"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="746"/>
   <anchor x="351" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="333"/>
     <component base="flig2"/>
+    <component base="f" xOffset="333"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,18 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
-  <advance width="1352"/>
-  <anchor x="184" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
-  <anchor x="1037" y="0" name="bottom_3"/>
-  <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="684" y="0" name="caret_2"/>
-  <anchor x="184" y="716" name="top_1"/>
-  <anchor x="517" y="716" name="top_2"/>
-  <anchor x="850" y="716" name="top_3"/>
+  <advance width="1351"/>
+  <anchor x="350" y="0" name="caret_1"/>
+  <anchor x="683" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="1"/>
-    <component base="flig1" xOffset="333"/>
-    <component base="b" xOffset="721"/>
+    <component base="flig2"/>
+    <component base="flig1" xOffset="332"/>
+    <component base="b" xOffset="720"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
-  <advance width="1322"/>
-  <anchor x="184" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
-  <anchor x="1023" y="0" name="bottom_3"/>
+  <advance width="1323"/>
   <anchor x="351" y="0" name="caret_1"/>
   <anchor x="684" y="0" name="caret_2"/>
-  <anchor x="184" y="716" name="top_1"/>
-  <anchor x="518" y="716" name="top_2"/>
-  <anchor x="850" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="333"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
   <advance width="987"/>
+  <anchor x="184" y="0" name="bottom_1"/>
+  <anchor x="517" y="0" name="bottom_2"/>
+  <anchor x="850" y="0" name="bottom_3"/>
   <anchor x="329.333" y="0" name="caret_1"/>
   <anchor x="658.667" y="0" name="caret_2"/>
+  <anchor x="184" y="716" name="top_1"/>
+  <anchor x="517" y="716" name="top_2"/>
+  <anchor x="850" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="333"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="333"/>
     <component base="i" xOffset="712"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="517" y="716" name="top_2"/>
   <anchor x="850" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="333"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="333"/>
     <component base="j" xOffset="712"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1279"/>
-  <anchor x="184" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
-  <anchor x="1008" y="0" name="bottom_3"/>
   <anchor x="343" y="0" name="caret_1"/>
   <anchor x="684" y="0" name="caret_2"/>
-  <anchor x="184" y="716" name="top_1"/>
-  <anchor x="517" y="716" name="top_2"/>
-  <anchor x="850" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="333"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
-  <advance width="1085"/>
-  <anchor x="184" y="0" name="bottom_1"/>
-  <anchor x="518" y="0" name="bottom_2"/>
-  <anchor x="929" y="0" name="bottom_3"/>
+  <advance width="1086"/>
   <anchor x="351" y="0" name="caret_1"/>
   <anchor x="723.333" y="0" name="caret_2"/>
-  <anchor x="184" y="716" name="top_1"/>
-  <anchor x="518" y="716" name="top_2"/>
-  <anchor x="915" y="654" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="333"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="333"/>
     <component base="t" xOffset="668"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="989"/>
-  <anchor x="185" y="0" name="bottom_1"/>
-  <anchor x="704" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="185" y="716" name="top_1"/>
-  <anchor x="704" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="387"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_j.glif
@@ -2,7 +2,7 @@
 <glyph name="f_j" format="2">
   <advance width="655"/>
   <anchor x="185" y="0" name="bottom_1"/>
-  <anchor x="518" y="0" name="bottom_2"/>
+  <anchor x="518" y="-216" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
   <anchor x="185" y="716" name="top_1"/>
   <anchor x="518" y="735" name="top_2"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="946"/>
-  <anchor x="185" y="0" name="bottom_1"/>
-  <anchor x="676" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="185" y="716" name="top_1"/>
-  <anchor x="518" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="388"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="648"/>
-  <anchor x="184" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="184" y="716" name="top_1"/>
-  <anchor x="517" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="387"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="753"/>
-  <anchor x="185" y="0" name="bottom_1"/>
-  <anchor x="596" y="0" name="bottom_2"/>
   <anchor x="351" y="0" name="caret_1"/>
-  <anchor x="185" y="716" name="top_1"/>
-  <anchor x="583" y="654" name="top_2"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="335"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.glif
@@ -13,9 +13,9 @@
       <point x="687" y="526"/>
       <point x="534" y="526" type="curve" smooth="yes"/>
       <point x="381" y="526"/>
-      <point x="272" y="409"/>
+      <point x="274" y="409"/>
       <point x="272" y="254" type="curve" smooth="yes"/>
-      <point x="272" y="99"/>
+      <point x="270" y="99"/>
       <point x="381" y="-16"/>
     </contour>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="421" y="510" name="top"/>
   <outline>
     <contour>
+      <point x="64" y="0" type="line"/>
+      <point x="195" y="0" type="line"/>
+      <point x="195" y="716" type="line"/>
+      <point x="64" y="716" type="line"/>
+    </contour>
+    <contour>
       <point x="534" y="-16" type="curve" smooth="yes"/>
       <point x="687" y="-16"/>
       <point x="795" y="100"/>
@@ -12,22 +18,10 @@
       <point x="687" y="526"/>
       <point x="534" y="526" type="curve" smooth="yes"/>
       <point x="381" y="526"/>
-      <point x="272" y="412"/>
+      <point x="274" y="412"/>
       <point x="272" y="256" type="curve" smooth="yes"/>
-      <point x="272" y="100"/>
+      <point x="270" y="100"/>
       <point x="381" y="-16"/>
-    </contour>
-    <contour>
-      <point x="64" y="0" type="line"/>
-      <point x="195" y="0" type="line"/>
-      <point x="195" y="716" type="line"/>
-      <point x="64" y="716" type="line"/>
-    </contour>
-    <contour>
-      <point x="135" y="202" type="line"/>
-      <point x="338" y="202" type="line"/>
-      <point x="338" y="314" type="line"/>
-      <point x="135" y="314" type="line"/>
     </contour>
     <contour>
       <point x="534" y="105" type="curve" smooth="yes"/>
@@ -42,6 +36,12 @@
       <point x="664" y="255" type="curve" smooth="yes"/>
       <point x="664" y="161"/>
       <point x="604" y="105"/>
+    </contour>
+    <contour>
+      <point x="135" y="202" type="line"/>
+      <point x="338" y="202" type="line"/>
+      <point x="338" y="314" type="line"/>
+      <point x="135" y="314" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,34 +39,6 @@
       <point x="719" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="435" y="-409" type="curve" smooth="yes"/>
-      <point x="504" y="-409"/>
-      <point x="556" y="-356"/>
-      <point x="556" y="-286" type="curve" smooth="yes"/>
-      <point x="556" y="-215"/>
-      <point x="504" y="-163"/>
-      <point x="435" y="-163" type="curve" smooth="yes"/>
-      <point x="363" y="-163"/>
-      <point x="311" y="-215"/>
-      <point x="311" y="-286" type="curve" smooth="yes"/>
-      <point x="311" y="-357"/>
-      <point x="363" y="-409"/>
-    </contour>
-    <contour>
-      <point x="431" y="-328" type="curve" smooth="yes"/>
-      <point x="406" y="-328"/>
-      <point x="389" y="-310"/>
-      <point x="389" y="-286" type="curve" smooth="yes"/>
-      <point x="389" y="-261"/>
-      <point x="406" y="-244"/>
-      <point x="431" y="-244" type="curve" smooth="yes"/>
-      <point x="455" y="-244"/>
-      <point x="472" y="-261"/>
-      <point x="472" y="-286" type="curve" smooth="yes"/>
-      <point x="472" y="-310"/>
-      <point x="456" y="-328"/>
-    </contour>
-    <contour>
       <point x="592" y="-400" type="line"/>
       <point x="691" y="-400" type="line"/>
       <point x="691" y="219" type="line" smooth="yes"/>
@@ -125,6 +97,34 @@
       <point x="547" y="-65"/>
       <point x="592" y="-113"/>
       <point x="592" y="-195" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="435" y="-409" type="curve" smooth="yes"/>
+      <point x="504" y="-409"/>
+      <point x="556" y="-356"/>
+      <point x="556" y="-286" type="curve" smooth="yes"/>
+      <point x="556" y="-215"/>
+      <point x="504" y="-163"/>
+      <point x="435" y="-163" type="curve" smooth="yes"/>
+      <point x="363" y="-163"/>
+      <point x="311" y="-215"/>
+      <point x="311" y="-286" type="curve" smooth="yes"/>
+      <point x="311" y="-357"/>
+      <point x="363" y="-409"/>
+    </contour>
+    <contour>
+      <point x="431" y="-328" type="curve" smooth="yes"/>
+      <point x="406" y="-328"/>
+      <point x="389" y="-310"/>
+      <point x="389" y="-286" type="curve" smooth="yes"/>
+      <point x="389" y="-261"/>
+      <point x="406" y="-244"/>
+      <point x="431" y="-244" type="curve" smooth="yes"/>
+      <point x="455" y="-244"/>
+      <point x="472" y="-261"/>
+      <point x="472" y="-286" type="curve" smooth="yes"/>
+      <point x="472" y="-310"/>
+      <point x="456" y="-328"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-7"/>
-    <component base="zeropercent" xOffset="673" yOffset="32"/>
+    <component base="zeropercent" xOffset="673"/>
     <component base="numero-bar" xOffset="-1"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/percent.glif
@@ -1,10 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="857"/>
+  <advance width="844"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="zeropercent" xOffset="424" yOffset="-374"/>
-    <component base="percentbar" xOffset="26"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="424" yOffset="-406"/>
+    <component base="percentbar"/>
   </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
+    </dict>
+  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="844"/>
   <outline>
     <contour>
-      <point x="220" y="-16" type="line"/>
-      <point x="685" y="678" type="line"/>
-      <point x="606" y="731" type="line"/>
-      <point x="141" y="37" type="line"/>
+      <point x="229" y="-16" type="line"/>
+      <point x="694" y="679" type="line"/>
+      <point x="615" y="732" type="line"/>
+      <point x="150" y="37" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1362"/>
+  <advance width="1336"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent" yOffset="34"/>
-    <component base="percentbar" xOffset="27" yOffset="2"/>
-    <component base="zeropercent" xOffset="424" yOffset="-372"/>
-    <component base="zeropercent" xOffset="676" yOffset="-372"/>
-    <component base="zeropercent" xOffset="929" yOffset="-374"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="424" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="670" yOffset="-406"/>
+    <component base="zeropercent" xOffset="916" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1110"/>
+  <advance width="1100"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent" yOffset="32"/>
-    <component base="zeropercent" xOffset="424" yOffset="-374"/>
-    <component base="percentbar" xOffset="15" yOffset="-14"/>
-    <component base="zeropercent" xOffset="677" yOffset="-374"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="424" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="680" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="52" y="490" type="line"/>
-      <point x="171" y="490" type="line" name="hr00"/>
+      <point x="171" y="490" type="line"/>
       <point x="171" y="716" type="line"/>
       <point x="52" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="835"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="606" y="0" name="bottom_2"/>
   <anchor x="368" y="0" name="caret_1"/>
-  <anchor x="232" y="510" name="top_1"/>
-  <anchor x="606" y="716" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="422"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1168"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="606" y="0" name="bottom_2"/>
-  <anchor x="940" y="0" name="bottom_3"/>
   <anchor x="368" y="0" name="caret_1"/>
   <anchor x="773" y="0" name="caret_2"/>
-  <anchor x="232" y="510" name="top_1"/>
-  <anchor x="606" y="716" name="top_2"/>
-  <anchor x="940" y="716" name="top_3"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="422"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="850"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="693" y="0" name="bottom_2"/>
   <anchor x="372" y="0" name="caret_1"/>
-  <anchor x="213" y="510" name="top_1"/>
-  <anchor x="680" y="654" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="432"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -37,34 +37,6 @@
       <point x="503" y="358" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="531" y="-215" type="curve" smooth="yes"/>
-      <point x="603" y="-215"/>
-      <point x="658" y="-161"/>
-      <point x="658" y="-89" type="curve" smooth="yes"/>
-      <point x="658" y="-17"/>
-      <point x="603" y="37"/>
-      <point x="531" y="37" type="curve" smooth="yes"/>
-      <point x="457" y="37"/>
-      <point x="403" y="-17"/>
-      <point x="403" y="-89" type="curve" smooth="yes"/>
-      <point x="403" y="-162"/>
-      <point x="457" y="-215"/>
-    </contour>
-    <contour>
-      <point x="525" y="-134" type="curve" smooth="yes"/>
-      <point x="498" y="-134"/>
-      <point x="480" y="-115"/>
-      <point x="480" y="-89" type="curve" smooth="yes"/>
-      <point x="480" y="-63"/>
-      <point x="498" y="-45"/>
-      <point x="525" y="-45" type="curve" smooth="yes"/>
-      <point x="552" y="-45"/>
-      <point x="571" y="-63"/>
-      <point x="571" y="-89" type="curve" smooth="yes"/>
-      <point x="571" y="-115"/>
-      <point x="553" y="-134"/>
-    </contour>
-    <contour>
       <point x="407" y="52" type="line"/>
       <point x="407" y="157" type="line"/>
       <point x="332" y="190" type="line"/>
@@ -102,6 +74,34 @@
       <point x="339" y="49" type="curve" smooth="yes"/>
       <point x="339" y="-21"/>
       <point x="380" y="-75"/>
+    </contour>
+    <contour>
+      <point x="531" y="-215" type="curve" smooth="yes"/>
+      <point x="603" y="-215"/>
+      <point x="658" y="-161"/>
+      <point x="658" y="-89" type="curve" smooth="yes"/>
+      <point x="658" y="-17"/>
+      <point x="603" y="37"/>
+      <point x="531" y="37" type="curve" smooth="yes"/>
+      <point x="457" y="37"/>
+      <point x="403" y="-17"/>
+      <point x="403" y="-89" type="curve" smooth="yes"/>
+      <point x="403" y="-162"/>
+      <point x="457" y="-215"/>
+    </contour>
+    <contour>
+      <point x="525" y="-134" type="curve" smooth="yes"/>
+      <point x="498" y="-134"/>
+      <point x="480" y="-115"/>
+      <point x="480" y="-89" type="curve" smooth="yes"/>
+      <point x="480" y="-63"/>
+      <point x="498" y="-45"/>
+      <point x="525" y="-45" type="curve" smooth="yes"/>
+      <point x="552" y="-45"/>
+      <point x="571" y="-63"/>
+      <point x="571" y="-89" type="curve" smooth="yes"/>
+      <point x="571" y="-115"/>
+      <point x="553" y="-134"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/schwa.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/schwa.sc.glif
@@ -4,12 +4,4 @@
   <outline>
     <component base="schwa-cy.sc"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>schwa-cy.sc</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>schwa-cy.sc</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="744"/>
-  <anchor x="261" y="0" name="bottom_1"/>
-  <anchor x="513" y="0" name="bottom_2"/>
   <anchor x="378.5" y="0" name="caret_1"/>
-  <anchor x="210" y="255" name="center_1"/>
-  <anchor x="568" y="255" name="center_2"/>
-  <anchor x="248" y="654" name="top_1"/>
-  <anchor x="511" y="716" name="top_2"/>
-  <anchor x="342" y="560" name="topright_1"/>
-  <anchor x="737" y="510" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="331"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="742"/>
-  <anchor x="261" y="0" name="bottom_1"/>
-  <anchor x="585" y="0" name="bottom_2"/>
   <anchor x="371" y="0" name="caret_1"/>
-  <anchor x="186" y="255" name="center_1"/>
-  <anchor x="557" y="255" name="center_2"/>
-  <anchor x="248" y="654" name="top_1"/>
-  <anchor x="572" y="654" name="top_2"/>
-  <anchor x="339" y="550" name="topright_1"/>
-  <anchor x="664" y="550" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="324"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/yhook.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/yhook.glif
@@ -14,7 +14,7 @@
       <point x="8" y="510" type="line"/>
       <point x="224" y="24" type="line"/>
       <point x="195" y="-41" type="line" smooth="yes"/>
-      <point x="185.523" y="-62.2412"/>
+      <point x="185.523" y="-62.241"/>
       <point x="162" y="-115"/>
       <point x="151" y="-139" type="curve" smooth="yes"/>
       <point x="140" y="-163"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="430"/>
+  <advance width="420"/>
   <outline>
     <contour>
-      <point x="217" y="358" type="curve" smooth="yes"/>
-      <point x="318" y="358"/>
-      <point x="393" y="435"/>
-      <point x="393" y="529" type="curve" smooth="yes"/>
-      <point x="393" y="623"/>
-      <point x="318" y="700"/>
-      <point x="217" y="700" type="curve" smooth="yes"/>
-      <point x="115" y="700"/>
-      <point x="40" y="623"/>
-      <point x="40" y="529" type="curve" smooth="yes"/>
-      <point x="40" y="435"/>
-      <point x="115" y="358"/>
+      <point x="210" y="390" type="curve" smooth="yes"/>
+      <point x="312" y="390"/>
+      <point x="387" y="467"/>
+      <point x="387" y="561" type="curve" smooth="yes"/>
+      <point x="387" y="655"/>
+      <point x="312" y="732"/>
+      <point x="210" y="732" type="curve" smooth="yes"/>
+      <point x="109" y="732"/>
+      <point x="34" y="655"/>
+      <point x="33" y="561" type="curve" smooth="yes"/>
+      <point x="34" y="467"/>
+      <point x="109" y="390"/>
     </contour>
     <contour>
-      <point x="217" y="456" type="curve" smooth="yes"/>
-      <point x="179" y="456"/>
-      <point x="148" y="485"/>
-      <point x="148" y="529" type="curve" smooth="yes"/>
-      <point x="148" y="573"/>
-      <point x="179" y="602"/>
-      <point x="217" y="602" type="curve" smooth="yes"/>
-      <point x="256" y="602"/>
-      <point x="285" y="573"/>
-      <point x="285" y="529" type="curve" smooth="yes"/>
-      <point x="285" y="485"/>
-      <point x="256" y="456"/>
+      <point x="210" y="488" type="curve" smooth="yes"/>
+      <point x="172" y="488"/>
+      <point x="142" y="517"/>
+      <point x="142" y="561" type="curve" smooth="yes"/>
+      <point x="142" y="605"/>
+      <point x="172" y="634"/>
+      <point x="210" y="634" type="curve" smooth="yes"/>
+      <point x="249" y="634"/>
+      <point x="279" y="605"/>
+      <point x="279" y="561" type="curve" smooth="yes"/>
+      <point x="279" y="517"/>
+      <point x="249" y="488"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_aiMatra-beng.init.short2_L</key>
     <array>
@@ -83,9 +83,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -95,21 +95,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -175,10 +175,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -266,6 +266,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -284,19 +285,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -314,30 +314,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -350,58 +350,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -409,39 +409,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -463,16 +463,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -481,115 +481,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -610,152 +610,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -768,95 +768,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -865,145 +865,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1027,8 +1027,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1044,69 +1044,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1122,9 +1122,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1184,21 +1184,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1232,30 +1232,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1270,7 +1271,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1285,16 +1285,16 @@
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1322,8 +1322,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1341,20 +1341,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1364,14 +1364,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1398,8 +1398,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1444,50 +1444,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1500,83 +1500,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1584,9 +1584,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1652,12 +1652,12 @@
     </array>
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
-      <string>nge-kannada</string>
-      <string>nyi-kannada</string>
-      <string>nye-kannada</string>
-      <string>nni-kannada</string>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>nge-kannada</string>
+      <string>nni-kannada</string>
+      <string>nye-kannada</string>
+      <string>nyi-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1696,10 +1696,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1708,14 +1708,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1733,81 +1733,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1815,13 +1815,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1859,29 +1859,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1890,8 +1890,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1899,70 +1899,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -1994,8 +1994,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2013,8 +2013,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2048,8 +2048,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2063,12 +2063,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2118,8 +2118,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2139,15 +2139,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2160,9 +2160,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2170,8 +2170,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2184,22 +2184,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2224,30 +2224,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2259,8 +2259,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2316,31 +2316,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2361,12 +2361,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2382,21 +2382,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2460,8 +2460,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2485,13 +2485,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2503,26 +2503,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2566,8 +2566,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2600,8 +2600,19 @@
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2610,32 +2621,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2646,48 +2646,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_aaMatra-oriya_L</key>
     <array>
@@ -2703,9 +2703,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2730,21 +2730,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2765,66 +2765,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2845,16 +2845,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2876,8 +2876,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2907,10 +2907,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2938,13 +2938,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2952,8 +2952,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -2982,9 +2982,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -2995,13 +2995,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3012,17 +3012,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3037,26 +3037,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3076,9 +3076,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3107,11 +3107,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3125,18 +3125,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3154,11 +3154,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3167,55 +3167,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3224,21 +3224,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3247,42 +3247,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3311,23 +3311,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3341,115 +3341,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3457,30 +3457,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3502,24 +3502,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3579,9 +3579,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3595,10 +3595,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3606,12 +3606,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3620,53 +3620,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3679,38 +3679,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3763,62 +3763,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3826,18 +3826,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3845,12 +3845,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3881,9 +3881,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3926,9 +3926,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3981,68 +3981,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4051,18 +4051,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_rVocalicMatra-telugu_L</key>
     <array>
@@ -4074,141 +4074,141 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>lluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>lluu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
       <string>shuu-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4220,21 +4220,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_uu-telugu_L</key>
     <array>
@@ -4251,27 +4251,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4300,23 +4300,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4332,8 +4332,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4365,27 +4365,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4398,8 +4398,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4412,20 +4412,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4441,19 +4441,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4461,9 +4461,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4480,16 +4480,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4497,11 +4497,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4537,11 +4537,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4549,19 +4549,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4570,8 +4572,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
     </array>
     <key>public.kern1.Yhook</key>
     <array>
@@ -4587,8 +4587,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4601,6 +4603,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4609,14 +4612,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4630,6 +4632,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4639,9 +4642,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4657,16 +4657,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4684,15 +4684,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4701,10 +4701,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4730,14 +4730,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4751,14 +4751,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4766,8 +4766,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4815,13 +4815,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4841,14 +4841,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4861,13 +4861,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4921,19 +4921,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4983,8 +4983,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5020,13 +5020,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5059,27 +5059,27 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
       <string>b.sc</string>
-      <string>ve-cy.sc</string>
       <string>bhook.sc</string>
+      <string>ve-cy.sc</string>
     </array>
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5090,9 +5090,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5100,11 +5100,11 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5115,13 +5115,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5131,70 +5131,70 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5212,25 +5212,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5240,27 +5240,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5269,18 +5269,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5292,9 +5292,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5302,24 +5302,24 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5335,34 +5335,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5371,24 +5371,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5397,40 +5397,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5442,12 +5442,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5470,18 +5470,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5490,7 +5490,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5509,21 +5514,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5542,26 +5543,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5602,70 +5602,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5684,21 +5684,21 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>do-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5806,13 +5806,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5889,14 +5889,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5952,12 +5952,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -5983,8 +5983,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6013,18 +6013,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6033,48 +6052,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6087,36 +6087,36 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
+      <string>chin-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
-      <string>chin-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6126,11 +6126,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6146,38 +6146,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6195,6 +6195,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6203,16 +6208,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6220,8 +6220,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6230,40 +6242,38 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6271,32 +6281,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6309,33 +6309,33 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
-      <string>thorn.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
+      <string>thorn.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6344,34 +6344,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6382,10 +6382,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6396,64 +6396,64 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6467,10 +6467,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6480,6 +6480,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6493,15 +6494,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6523,9 +6523,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6537,8 +6537,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6546,27 +6546,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6575,14 +6580,11 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6591,8 +6593,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6604,9 +6604,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6629,19 +6629,21 @@
     </array>
     <key>public.kern1.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6655,6 +6657,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6663,9 +6666,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6739,14 +6739,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,16 +6758,16 @@
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6775,8 +6775,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6797,8 +6797,8 @@
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6824,17 +6824,17 @@
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
       <string>kha-deva</string>
+      <string>khha-deva</string>
       <string>ra-deva</string>
       <string>rra-deva</string>
       <string>sa-deva</string>
-      <string>khha-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6865,9 +6865,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6887,13 +6887,13 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6903,50 +6903,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6955,40 +6955,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7005,15 +7005,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7022,10 +7022,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7038,153 +7038,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7194,57 +7194,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7252,156 +7252,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7417,8 +7417,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7434,69 +7434,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7518,27 +7518,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7546,8 +7546,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7559,9 +7559,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7570,30 +7570,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7605,17 +7605,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7623,10 +7623,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7643,9 +7643,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7653,8 +7653,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7667,15 +7667,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7691,9 +7691,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7701,13 +7701,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7723,9 +7723,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_ra-gujarati_L</key>
     <array>
@@ -7747,14 +7747,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7762,9 +7762,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7775,55 +7775,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7831,9 +7831,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7846,8 +7846,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7882,9 +7882,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7932,9 +7932,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7942,15 +7942,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_colon.loclKNDA_R</key>
     <array>
@@ -7962,59 +7962,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8027,15 +8027,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8044,58 +8044,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8103,14 +8103,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8121,15 +8121,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8141,43 +8141,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8189,14 +8189,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8204,15 +8204,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8224,15 +8224,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8244,15 +8244,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8264,27 +8264,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8303,11 +8303,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8315,54 +8315,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8375,13 +8375,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8401,9 +8401,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8411,29 +8411,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8449,14 +8449,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8472,15 +8472,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8488,15 +8488,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8521,72 +8521,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8615,11 +8615,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8627,13 +8627,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8642,58 +8642,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8710,22 +8710,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8741,10 +8741,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8753,33 +8753,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8791,9 +8791,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8819,11 +8819,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8836,10 +8836,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8872,8 +8872,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8896,8 +8896,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8922,8 +8922,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -8964,10 +8964,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -8981,13 +8981,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -8996,6 +9011,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9010,25 +9026,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9084,13 +9084,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9102,81 +9102,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9184,18 +9184,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9206,37 +9206,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9246,14 +9246,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9261,8 +9261,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9275,9 +9275,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9289,17 +9289,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9320,15 +9320,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9344,13 +9344,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9376,15 +9376,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9392,18 +9392,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9425,82 +9425,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9518,8 +9518,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9531,9 +9531,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9563,15 +9563,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9643,18 +9643,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9663,44 +9663,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9717,154 +9717,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9873,19 +9873,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9909,8 +9909,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9940,31 +9940,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -9983,12 +9983,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -9996,19 +9996,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10047,18 +10047,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10071,22 +10071,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10108,8 +10108,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10122,32 +10122,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10166,8 +10166,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10216,15 +10216,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10246,18 +10246,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10310,8 +10310,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10360,9 +10360,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10376,8 +10376,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10401,56 +10401,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10460,10 +10460,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10471,12 +10471,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10485,8 +10485,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10545,9 +10545,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10588,30 +10588,30 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10623,8 +10623,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10637,25 +10639,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10669,31 +10671,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10735,13 +10735,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10765,22 +10765,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10789,8 +10789,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10798,19 +10798,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -10977,13 +10977,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -10997,19 +10997,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11031,35 +11031,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11074,94 +11074,94 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>colon.ss03</string>
-      <string>questiongreek</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11170,8 +11170,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11188,32 +11188,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11225,17 +11225,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11272,18 +11272,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11291,36 +11291,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11335,50 +11335,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11388,11 +11388,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11402,51 +11402,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11466,36 +11466,36 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>do-ethiopic</string>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>do-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11505,25 +11505,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11533,65 +11533,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11601,20 +11601,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11626,20 +11626,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11658,24 +11658,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11690,9 +11690,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11704,39 +11704,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11750,22 +11750,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11776,11 +11776,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11790,11 +11790,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11803,46 +11803,46 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -11851,45 +11851,45 @@
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -11899,10 +11899,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -11934,12 +11934,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -11953,14 +11953,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -11990,8 +11990,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12007,26 +12009,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12037,80 +12075,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12119,11 +12119,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12146,8 +12146,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12162,14 +12162,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12191,107 +12191,107 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12303,28 +12303,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12334,59 +12334,6 @@
     </array>
     <key>public.kern2.o</key>
     <array>
-      <string>c</string>
-      <string>cacute</string>
-      <string>ccaron</string>
-      <string>ccedilla</string>
-      <string>ccircumflex</string>
-      <string>cdotaccent</string>
-      <string>d</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>e</string>
-      <string>eacute</string>
-      <string>ebreve</string>
-      <string>ecaron</string>
-      <string>ecircumflex</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edieresis</string>
-      <string>edotaccent</string>
-      <string>edotbelow</string>
-      <string>egrave</string>
-      <string>ehookabove</string>
-      <string>emacron</string>
-      <string>eogonek</string>
-      <string>etilde</string>
-      <string>o</string>
-      <string>oacute</string>
-      <string>obreve</string>
-      <string>ocircumflex</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odieresis</string>
-      <string>odotbelow</string>
-      <string>ograve</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>ohungarumlaut</string>
-      <string>omacron</string>
-      <string>oslash</string>
-      <string>oslashacute</string>
-      <string>otilde</string>
-      <string>oe</string>
-      <string>q</string>
       <string>a.alt</string>
       <string>aacute.alt</string>
       <string>abreve.alt</string>
@@ -12403,6 +12350,8 @@
       <string>acircumflextilde.alt</string>
       <string>adieresis.alt</string>
       <string>adotbelow.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
       <string>agrave.alt</string>
       <string>ahookabove.alt</string>
       <string>amacron.alt</string>
@@ -12410,35 +12359,86 @@
       <string>aring.alt</string>
       <string>aringacute.alt</string>
       <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>cdotaccent</string>
       <string>cheabkhasian-cy</string>
       <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
-      <string>schwa-cy</string>
-      <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>e</string>
+      <string>e-cy</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
+      <string>edieresis</string>
       <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>ef-cy</string>
       <string>ef-cy.loclBGR</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
+      <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
+      <string>o</string>
+      <string>o-cy</string>
+      <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
+      <string>odieresis</string>
+      <string>odieresis-cy</string>
+      <string>odotbelow</string>
+      <string>oe</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>q</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
       <string>schwa</string>
+      <string>schwa-cy</string>
+      <string>schwadieresis-cy</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12448,13 +12448,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12462,8 +12478,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12477,30 +12495,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12522,10 +12522,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12535,51 +12535,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12590,9 +12590,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12600,84 +12600,84 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
     <array>
-      <string>seven.ss03</string>
       <string>seven</string>
+      <string>seven.ss03</string>
     </array>
     <key>public.kern2.shin-hb</key>
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12696,6 +12696,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12715,22 +12722,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12756,15 +12756,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12772,8 +12772,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12781,62 +12781,62 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraight-cy.sc</string>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraight-cy.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>
@@ -12860,8 +12860,8 @@
     </array>
     <key>public.kern2.zero</key>
     <array>
-      <string>zero.ss03</string>
       <string>zero</string>
+      <string>zero.ss03</string>
     </array>
   </dict>
 </plist>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -64,6 +64,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="644" y="315" type="line"/>
+      <point x="661" y="315" type="line" smooth="yes"/>
+      <point x="822" y="315"/>
+      <point x="947" y="434"/>
+      <point x="947" y="589" type="curve" smooth="yes"/>
+      <point x="947" y="684"/>
+      <point x="888" y="751"/>
+      <point x="783" y="751" type="curve" smooth="yes"/>
+      <point x="667" y="751"/>
+      <point x="571" y="662"/>
+      <point x="571" y="553" type="curve" smooth="yes"/>
+      <point x="571" y="499"/>
+      <point x="601" y="465"/>
+      <point x="649" y="465" type="curve" smooth="yes"/>
+      <point x="697" y="465"/>
+      <point x="738" y="505"/>
+      <point x="738" y="552" type="curve" smooth="yes"/>
+      <point x="738" y="586"/>
+      <point x="715" y="609"/>
+      <point x="682" y="609" type="curve" smooth="yes"/>
+      <point x="661" y="609"/>
+      <point x="640" y="600"/>
+      <point x="625" y="577" type="curve"/>
+      <point x="639" y="576" type="line"/>
+      <point x="641" y="586" type="line" smooth="yes"/>
+      <point x="654" y="651"/>
+      <point x="715" y="686"/>
+      <point x="771" y="686" type="curve" smooth="yes"/>
+      <point x="838" y="686"/>
+      <point x="874" y="643"/>
+      <point x="874" y="578" type="curve" smooth="yes"/>
+      <point x="874" y="465"/>
+      <point x="787" y="379"/>
+      <point x="673" y="379" type="curve" smooth="yes"/>
+      <point x="656" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="488" y="-250" type="line"/>
       <point x="558" y="-250" type="line"/>
       <point x="634" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="506" y="-12"/>
       <point x="532" y="16" type="curve"/>
       <point x="535" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="200" y="505" type="curve" smooth="yes"/>
+      <point x="184" y="505"/>
+      <point x="174" y="516"/>
+      <point x="174" y="531" type="curve" smooth="yes"/>
+      <point x="174" y="551"/>
+      <point x="191" y="569"/>
+      <point x="211" y="569" type="curve" smooth="yes"/>
+      <point x="226" y="569"/>
+      <point x="235" y="558"/>
+      <point x="235" y="544" type="curve" smooth="yes"/>
+      <point x="235" y="523"/>
+      <point x="218" y="505"/>
     </contour>
     <contour>
       <point x="184" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="327" y="379"/>
       <point x="213" y="379" type="curve" smooth="yes"/>
       <point x="196" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="200" y="505" type="curve" smooth="yes"/>
-      <point x="184" y="505"/>
-      <point x="174" y="516"/>
-      <point x="174" y="531" type="curve" smooth="yes"/>
-      <point x="174" y="551"/>
-      <point x="191" y="569"/>
-      <point x="211" y="569" type="curve" smooth="yes"/>
-      <point x="226" y="569"/>
-      <point x="235" y="558"/>
-      <point x="235" y="544" type="curve" smooth="yes"/>
-      <point x="235" y="523"/>
-      <point x="218" y="505"/>
-    </contour>
-    <contour>
-      <point x="644" y="315" type="line"/>
-      <point x="661" y="315" type="line" smooth="yes"/>
-      <point x="822" y="315"/>
-      <point x="947" y="434"/>
-      <point x="947" y="589" type="curve" smooth="yes"/>
-      <point x="947" y="684"/>
-      <point x="888" y="751"/>
-      <point x="783" y="751" type="curve" smooth="yes"/>
-      <point x="667" y="751"/>
-      <point x="571" y="662"/>
-      <point x="571" y="553" type="curve" smooth="yes"/>
-      <point x="571" y="499"/>
-      <point x="601" y="465"/>
-      <point x="649" y="465" type="curve" smooth="yes"/>
-      <point x="697" y="465"/>
-      <point x="738" y="505"/>
-      <point x="738" y="552" type="curve" smooth="yes"/>
-      <point x="738" y="586"/>
-      <point x="715" y="609"/>
-      <point x="682" y="609" type="curve" smooth="yes"/>
-      <point x="661" y="609"/>
-      <point x="640" y="600"/>
-      <point x="625" y="577" type="curve"/>
-      <point x="639" y="576" type="line"/>
-      <point x="641" y="586" type="line" smooth="yes"/>
-      <point x="654" y="651"/>
-      <point x="715" y="686"/>
-      <point x="771" y="686" type="curve" smooth="yes"/>
-      <point x="838" y="686"/>
-      <point x="874" y="643"/>
-      <point x="874" y="578" type="curve" smooth="yes"/>
-      <point x="874" y="465"/>
-      <point x="787" y="379"/>
-      <point x="673" y="379" type="curve" smooth="yes"/>
-      <point x="656" y="379" type="line"/>
     </contour>
     <contour>
       <point x="660" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="85" y="-250" type="line"/>
-      <point x="102" y="-250" type="line" smooth="yes"/>
-      <point x="263" y="-250"/>
-      <point x="388" y="-131"/>
-      <point x="388" y="24" type="curve" smooth="yes"/>
-      <point x="388" y="119"/>
-      <point x="329" y="186"/>
-      <point x="224" y="186" type="curve" smooth="yes"/>
-      <point x="108" y="186"/>
-      <point x="12" y="97"/>
-      <point x="12" y="-12" type="curve" smooth="yes"/>
-      <point x="12" y="-66"/>
-      <point x="42" y="-100"/>
-      <point x="90" y="-100" type="curve" smooth="yes"/>
-      <point x="138" y="-100"/>
-      <point x="179" y="-60"/>
-      <point x="179" y="-13" type="curve" smooth="yes"/>
-      <point x="179" y="21"/>
-      <point x="156" y="44"/>
-      <point x="123" y="44" type="curve" smooth="yes"/>
-      <point x="102" y="44"/>
-      <point x="81" y="35"/>
-      <point x="66" y="12" type="curve"/>
-      <point x="80" y="11" type="line"/>
-      <point x="82" y="21" type="line" smooth="yes"/>
-      <point x="95" y="86"/>
-      <point x="156" y="121"/>
-      <point x="212" y="121" type="curve" smooth="yes"/>
-      <point x="279" y="121"/>
-      <point x="315" y="78"/>
-      <point x="315" y="13" type="curve" smooth="yes"/>
-      <point x="315" y="-100"/>
-      <point x="228" y="-186"/>
-      <point x="114" y="-186" type="curve" smooth="yes"/>
-      <point x="97" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="101" y="-60" type="curve" smooth="yes"/>
-      <point x="85" y="-60"/>
-      <point x="75" y="-49"/>
-      <point x="75" y="-34" type="curve" smooth="yes"/>
-      <point x="75" y="-14"/>
-      <point x="92" y="4"/>
-      <point x="112" y="4" type="curve" smooth="yes"/>
-      <point x="127" y="4"/>
-      <point x="136" y="-7"/>
-      <point x="136" y="-21" type="curve" smooth="yes"/>
-      <point x="136" y="-42"/>
-      <point x="119" y="-60"/>
-    </contour>
-    <contour>
       <point x="545" y="-250" type="line"/>
       <point x="562" y="-250" type="line" smooth="yes"/>
       <point x="723" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="688" y="-186"/>
       <point x="574" y="-186" type="curve" smooth="yes"/>
       <point x="557" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="101" y="-60" type="curve" smooth="yes"/>
+      <point x="85" y="-60"/>
+      <point x="75" y="-49"/>
+      <point x="75" y="-34" type="curve" smooth="yes"/>
+      <point x="75" y="-14"/>
+      <point x="92" y="4"/>
+      <point x="112" y="4" type="curve" smooth="yes"/>
+      <point x="127" y="4"/>
+      <point x="136" y="-7"/>
+      <point x="136" y="-21" type="curve" smooth="yes"/>
+      <point x="136" y="-42"/>
+      <point x="119" y="-60"/>
+    </contour>
+    <contour>
+      <point x="85" y="-250" type="line"/>
+      <point x="102" y="-250" type="line" smooth="yes"/>
+      <point x="263" y="-250"/>
+      <point x="388" y="-131"/>
+      <point x="388" y="24" type="curve" smooth="yes"/>
+      <point x="388" y="119"/>
+      <point x="329" y="186"/>
+      <point x="224" y="186" type="curve" smooth="yes"/>
+      <point x="108" y="186"/>
+      <point x="12" y="97"/>
+      <point x="12" y="-12" type="curve" smooth="yes"/>
+      <point x="12" y="-66"/>
+      <point x="42" y="-100"/>
+      <point x="90" y="-100" type="curve" smooth="yes"/>
+      <point x="138" y="-100"/>
+      <point x="179" y="-60"/>
+      <point x="179" y="-13" type="curve" smooth="yes"/>
+      <point x="179" y="21"/>
+      <point x="156" y="44"/>
+      <point x="123" y="44" type="curve" smooth="yes"/>
+      <point x="102" y="44"/>
+      <point x="81" y="35"/>
+      <point x="66" y="12" type="curve"/>
+      <point x="80" y="11" type="line"/>
+      <point x="82" y="21" type="line" smooth="yes"/>
+      <point x="95" y="86"/>
+      <point x="156" y="121"/>
+      <point x="212" y="121" type="curve" smooth="yes"/>
+      <point x="279" y="121"/>
+      <point x="315" y="78"/>
+      <point x="315" y="13" type="curve" smooth="yes"/>
+      <point x="315" y="-100"/>
+      <point x="228" y="-186"/>
+      <point x="114" y="-186" type="curve" smooth="yes"/>
+      <point x="97" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="561" y="-60" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="960"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="626" y="0" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="b" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="689"/>
   <anchor x="270" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="316"/>
     <component base="flig2"/>
+    <component base="f" xOffset="316"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1276"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="946" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="614" y="734" name="top_2"/>
-  <anchor x="873" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1252"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="920" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="299" y="734" name="top_1"/>
-  <anchor x="615" y="734" name="top_2"/>
-  <anchor x="874" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="904"/>
+  <advance width="905"/>
+  <anchor x="112" y="0" name="bottom_1"/>
+  <anchor x="428" y="0" name="bottom_2"/>
+  <anchor x="744" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
+  <anchor x="299" y="734" name="top_1"/>
+  <anchor x="615" y="734" name="top_2"/>
+  <anchor x="874" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="i" xOffset="677"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="615" y="734" name="top_2"/>
   <anchor x="874" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="j" xOffset="677"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1174"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="896" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="299" y="734" name="top_1"/>
-  <anchor x="615" y="734" name="top_2"/>
-  <anchor x="874" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
-  <advance width="993"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="810" y="0" name="bottom_3"/>
+  <advance width="994"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="614" y="734" name="top_2"/>
-  <anchor x="904" y="670" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="t" xOffset="634"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="936"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
   <anchor x="273" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="h" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_j.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_j" format="2">
-  <advance width="588"/>
+  <advance width="589"/>
   <anchor x="114" y="0" name="bottom_1"/>
   <anchor x="390" y="-216" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="858"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="580" y="0" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-8"/>
     <component base="k" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
-  <advance width="589"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
+  <advance width="590"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="l" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="677"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="494" y="0" name="bottom_2"/>
-  <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="588" y="670" name="top_2"/>
+  <advance width="678"/>
+  <anchor x="280" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="318"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="314" y="366"/>
       <point x="342" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="307" yOffset="-111"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="307" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="314" y="366"/>
       <point x="342" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="307" yOffset="-111"/>
+    <component base="geez-part-4" xOffset="307" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
@@ -5,18 +5,18 @@
   <anchor x="455" y="526" name="top"/>
   <outline>
     <contour>
-      <point x="460" y="-16" type="curve" smooth="yes"/>
-      <point x="641" y="-16"/>
-      <point x="742" y="132"/>
-      <point x="742" y="311" type="curve" smooth="yes"/>
-      <point x="742" y="451"/>
-      <point x="670" y="542"/>
-      <point x="542" y="542" type="curve" smooth="yes"/>
-      <point x="363" y="542"/>
-      <point x="258" y="394"/>
-      <point x="258" y="216" type="curve" smooth="yes"/>
-      <point x="258" y="76"/>
-      <point x="337" y="-16"/>
+      <point x="473" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="743" y="132"/>
+      <point x="743" y="311" type="curve" smooth="yes"/>
+      <point x="743" y="451"/>
+      <point x="668" y="542"/>
+      <point x="531" y="542" type="curve" smooth="yes"/>
+      <point x="381" y="542"/>
+      <point x="259" y="408"/>
+      <point x="259" y="227" type="curve" smooth="yes"/>
+      <point x="259" y="75"/>
+      <point x="332" y="-16"/>
     </contour>
     <contour>
       <point x="37" y="0" type="line"/>
@@ -31,18 +31,18 @@
       <point x="124" y="294" type="line"/>
     </contour>
     <contour>
-      <point x="471" y="41" type="curve" smooth="yes"/>
-      <point x="386" y="41"/>
-      <point x="325" y="101"/>
-      <point x="325" y="227" type="curve" smooth="yes"/>
-      <point x="325" y="368"/>
-      <point x="399" y="485"/>
-      <point x="531" y="485" type="curve" smooth="yes"/>
-      <point x="624" y="485"/>
-      <point x="677" y="417"/>
-      <point x="677" y="300" type="curve" smooth="yes"/>
-      <point x="677" y="164"/>
-      <point x="600" y="41"/>
+      <point x="481" y="41" type="curve" smooth="yes"/>
+      <point x="376" y="41"/>
+      <point x="324" y="101"/>
+      <point x="324" y="227" type="curve" smooth="yes"/>
+      <point x="324" y="367"/>
+      <point x="395" y="485"/>
+      <point x="522" y="485" type="curve" smooth="yes"/>
+      <point x="625" y="485"/>
+      <point x="678" y="418"/>
+      <point x="678" y="300" type="curve" smooth="yes"/>
+      <point x="678" y="149"/>
+      <point x="609" y="41"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -1,28 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.loclBGR" format="2">
-  <advance width="789"/>
+  <advance width="790"/>
   <anchor x="441.374" y="526" name="top"/>
   <outline>
-    <contour>
-      <point x="460" y="-16" type="curve" smooth="yes"/>
-      <point x="641" y="-16"/>
-      <point x="742" y="132"/>
-      <point x="742" y="311" type="curve" smooth="yes"/>
-      <point x="742" y="451"/>
-      <point x="670" y="542"/>
-      <point x="542" y="542" type="curve" smooth="yes"/>
-      <point x="363" y="542"/>
-      <point x="258" y="394"/>
-      <point x="258" y="216" type="curve" smooth="yes"/>
-      <point x="258" y="76"/>
-      <point x="337" y="-16"/>
-    </contour>
-    <contour>
-      <point x="115" y="237" type="line"/>
-      <point x="291" y="237" type="line"/>
-      <point x="297" y="294" type="line"/>
-      <point x="124" y="294" type="line"/>
-    </contour>
     <contour>
       <point x="37" y="0" type="line"/>
       <point x="101" y="0" type="line"/>
@@ -30,18 +10,38 @@
       <point x="173" y="776" type="line"/>
     </contour>
     <contour>
-      <point x="471" y="41" type="curve" smooth="yes"/>
-      <point x="386" y="41"/>
-      <point x="325" y="101"/>
-      <point x="325" y="227" type="curve" smooth="yes"/>
-      <point x="325" y="368"/>
-      <point x="399" y="485"/>
-      <point x="531" y="485" type="curve" smooth="yes"/>
-      <point x="624" y="485"/>
-      <point x="677" y="417"/>
-      <point x="677" y="300" type="curve" smooth="yes"/>
-      <point x="677" y="164"/>
-      <point x="600" y="41"/>
+      <point x="461" y="-16" type="curve" smooth="yes"/>
+      <point x="643" y="-16"/>
+      <point x="743" y="132"/>
+      <point x="743" y="311" type="curve" smooth="yes"/>
+      <point x="743" y="451"/>
+      <point x="668" y="542"/>
+      <point x="543" y="542" type="curve" smooth="yes"/>
+      <point x="387" y="542"/>
+      <point x="259" y="414"/>
+      <point x="259" y="227" type="curve" smooth="yes"/>
+      <point x="259" y="75"/>
+      <point x="332" y="-16"/>
+    </contour>
+    <contour>
+      <point x="478" y="41" type="curve" smooth="yes"/>
+      <point x="382" y="41"/>
+      <point x="324" y="101"/>
+      <point x="324" y="227" type="curve" smooth="yes"/>
+      <point x="324" y="367"/>
+      <point x="395" y="485"/>
+      <point x="527" y="485" type="curve" smooth="yes"/>
+      <point x="622" y="485"/>
+      <point x="678" y="425"/>
+      <point x="678" y="300" type="curve" smooth="yes"/>
+      <point x="678" y="159"/>
+      <point x="609" y="41"/>
+    </contour>
+    <contour>
+      <point x="115" y="237" type="line"/>
+      <point x="293" y="237" type="line"/>
+      <point x="299" y="294" type="line"/>
+      <point x="124" y="294" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
@@ -26,8 +26,8 @@
     <contour>
       <point x="127" y="268" type="line"/>
       <point x="312" y="268" type="line"/>
-      <point x="321" y="330" type="line"/>
-      <point x="141" y="330" type="line"/>
+      <point x="321" y="328" type="line"/>
+      <point x="141" y="328" type="line"/>
     </contour>
     <contour>
       <point x="515" y="43" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="722" y="226" type="curve"/>
     </contour>
     <contour>
-      <point x="347" y="-434" type="curve" smooth="yes"/>
-      <point x="432" y="-434"/>
-      <point x="476" y="-359"/>
-      <point x="476" y="-273" type="curve" smooth="yes"/>
-      <point x="476" y="-206"/>
-      <point x="440" y="-165"/>
-      <point x="375" y="-165" type="curve" smooth="yes"/>
-      <point x="295" y="-165"/>
-      <point x="232" y="-250"/>
-      <point x="232" y="-335" type="curve" smooth="yes"/>
-      <point x="232" y="-397"/>
-      <point x="274" y="-434"/>
-    </contour>
-    <contour>
       <point x="495" y="-421" type="line"/>
       <point x="575" y="-421" type="line"/>
       <point x="690" y="236" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="531" y="-205"/>
       <point x="530" y="-217"/>
       <point x="528" y="-230" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="347" y="-434" type="curve" smooth="yes"/>
+      <point x="432" y="-434"/>
+      <point x="476" y="-359"/>
+      <point x="476" y="-273" type="curve" smooth="yes"/>
+      <point x="476" y="-206"/>
+      <point x="440" y="-165"/>
+      <point x="375" y="-165" type="curve" smooth="yes"/>
+      <point x="295" y="-165"/>
+      <point x="232" y="-250"/>
+      <point x="232" y="-335" type="curve" smooth="yes"/>
+      <point x="232" y="-397"/>
+      <point x="274" y="-434"/>
     </contour>
     <contour>
       <point x="347" y="-365" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ngo-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ngo-khmer.glif
@@ -38,7 +38,7 @@
       <point x="276" y="366" type="curve" smooth="yes"/>
       <point x="319" y="366"/>
       <point x="353" y="378"/>
-      <point x="410" y="407" type="curve" name="7.9 ⛔️"/>
+      <point x="410" y="407" type="curve"/>
       <point x="459" y="429"/>
       <point x="516" y="456"/>
       <point x="516" y="517" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-6"/>
-    <component base="zeropercent" xOffset="653" yOffset="1"/>
+    <component base="zeropercent" xOffset="652"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="864"/>
+  <advance width="866"/>
   <unicode hex="0025"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="357" yOffset="-393"/>
-    <component base="percentbar" xOffset="5" yOffset="1"/>
+    <component base="zeropercent" xOffset="358" yOffset="-393"/>
+    <component base="percentbar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/percentbar.glif
@@ -3,10 +3,10 @@
   <advance width="826"/>
   <outline>
     <contour>
-      <point x="180" y="4" type="line"/>
-      <point x="784" y="720" type="line"/>
-      <point x="718" y="710" type="line"/>
-      <point x="114" y="-6" type="line"/>
+      <point x="176" y="0" type="line"/>
+      <point x="780" y="716" type="line"/>
+      <point x="722" y="716" type="line"/>
+      <point x="118" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1430"/>
+  <advance width="1432"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="357" yOffset="-393"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="358" yOffset="-394"/>
-    <component base="zeropercent" xOffset="642" yOffset="-394"/>
-    <component base="zeropercent" xOffset="926" yOffset="-393"/>
+    <component base="zeropercent" xOffset="640" yOffset="-393"/>
+    <component base="zeropercent" xOffset="924" yOffset="-393"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1147"/>
+  <advance width="1149"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="357" yOffset="-394"/>
+    <component base="zeropercent" xOffset="357" yOffset="-393"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="642" yOffset="-394"/>
+    <component base="zeropercent" xOffset="641" yOffset="-393"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="756"/>
-  <anchor x="69" y="0" name="bottom_1"/>
-  <anchor x="495" y="0" name="bottom_2"/>
   <anchor x="282" y="0" name="caret_1"/>
-  <anchor x="257" y="526" name="top_1"/>
-  <anchor x="684" y="748" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="383"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1068"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="857" y="0" name="bottom_3"/>
-  <anchor x="328" y="0" name="caret_1"/>
-  <anchor x="699" y="0" name="caret_2"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="734" name="top_2"/>
-  <anchor x="914" y="734" name="top_3"/>
+  <anchor x="318" y="0" name="caret_1"/>
+  <anchor x="646" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="749"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="516" y="0" name="bottom_2"/>
   <anchor x="374.5" y="0" name="caret_1"/>
-  <anchor x="233" y="526" name="top_1"/>
-  <anchor x="608" y="526" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="390"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="552" y="363" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="489" y="-237" type="curve" smooth="yes"/>
-      <point x="578" y="-237"/>
-      <point x="626" y="-161"/>
-      <point x="626" y="-71" type="curve" smooth="yes"/>
-      <point x="626" y="-1"/>
-      <point x="586" y="42"/>
-      <point x="517" y="42" type="curve" smooth="yes"/>
-      <point x="433" y="42"/>
-      <point x="369" y="-53"/>
-      <point x="369" y="-139" type="curve" smooth="yes"/>
-      <point x="369" y="-198"/>
-      <point x="412" y="-237"/>
-    </contour>
-    <contour>
       <point x="383" y="69" type="line"/>
       <point x="396" y="140" type="line"/>
       <point x="318" y="189" type="line"/>
@@ -94,6 +80,20 @@
       <point x="340" y="22" type="curve" smooth="yes"/>
       <point x="340" y="-33"/>
       <point x="369" y="-76"/>
+    </contour>
+    <contour>
+      <point x="489" y="-237" type="curve" smooth="yes"/>
+      <point x="578" y="-237"/>
+      <point x="626" y="-161"/>
+      <point x="626" y="-71" type="curve" smooth="yes"/>
+      <point x="626" y="-1"/>
+      <point x="586" y="42"/>
+      <point x="517" y="42" type="curve" smooth="yes"/>
+      <point x="433" y="42"/>
+      <point x="369" y="-53"/>
+      <point x="369" y="-139" type="curve" smooth="yes"/>
+      <point x="369" y="-198"/>
+      <point x="412" y="-237"/>
     </contour>
     <contour>
       <point x="490" y="-168" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="688"/>
-  <anchor x="125" y="0" name="bottom_1"/>
-  <anchor x="427" y="0" name="bottom_2"/>
-  <anchor x="274" y="0" name="caret_1"/>
-  <anchor x="179" y="255" name="center_1"/>
-  <anchor x="492" y="255" name="center_2"/>
-  <anchor x="271" y="670" name="top_1"/>
-  <anchor x="613" y="734" name="top_2"/>
-  <anchor x="312" y="526" name="topright_1"/>
-  <anchor x="628" y="526" name="topright_2"/>
+  <anchor x="320" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="315"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="677"/>
-  <anchor x="177" y="0" name="bottom_1"/>
-  <anchor x="493" y="0" name="bottom_2"/>
-  <anchor x="274" y="0" name="caret_1"/>
-  <anchor x="169" y="263" name="center_1"/>
-  <anchor x="507" y="263" name="center_2"/>
-  <anchor x="271" y="670" name="top_1"/>
-  <anchor x="588" y="669" name="top_2"/>
-  <anchor x="312" y="526" name="topright_1"/>
-  <anchor x="628" y="526" name="topright_2"/>
+  <advance width="679"/>
+  <anchor x="334" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="319"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
@@ -18,6 +18,8 @@
   </outline>
   <lib>
     <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
       <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/yhook.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/yhook.sc.glif
@@ -33,10 +33,4 @@
       <point x="295" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>y.sc</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
       <point x="247" y="378" type="curve" smooth="yes"/>
-      <point x="363" y="378"/>
-      <point x="443" y="467"/>
-      <point x="443" y="585" type="curve" smooth="yes"/>
-      <point x="443" y="674"/>
-      <point x="387" y="732"/>
-      <point x="294" y="732" type="curve" smooth="yes"/>
+      <point x="364" y="378"/>
+      <point x="444" y="464"/>
+      <point x="444" y="582" type="curve" smooth="yes"/>
+      <point x="444" y="673"/>
+      <point x="386" y="732"/>
+      <point x="295" y="732" type="curve" smooth="yes"/>
       <point x="178" y="732"/>
-      <point x="97" y="649"/>
-      <point x="97" y="532" type="curve" smooth="yes"/>
-      <point x="97" y="438"/>
-      <point x="157" y="378"/>
+      <point x="98" y="646"/>
+      <point x="98" y="528" type="curve" smooth="yes"/>
+      <point x="98" y="437"/>
+      <point x="156" y="378"/>
     </contour>
     <contour>
-      <point x="251" y="431" type="curve" smooth="yes"/>
+      <point x="253" y="431" type="curve" smooth="yes"/>
       <point x="196" y="431"/>
-      <point x="157" y="469"/>
-      <point x="157" y="538" type="curve" smooth="yes"/>
-      <point x="157" y="617"/>
-      <point x="211" y="679"/>
-      <point x="287" y="679" type="curve" smooth="yes"/>
-      <point x="345" y="679"/>
-      <point x="383" y="643"/>
-      <point x="383" y="577" type="curve" smooth="yes"/>
-      <point x="383" y="497"/>
-      <point x="329" y="431"/>
+      <point x="158" y="468"/>
+      <point x="158" y="535" type="curve" smooth="yes"/>
+      <point x="158" y="615"/>
+      <point x="212" y="679"/>
+      <point x="289" y="679" type="curve" smooth="yes"/>
+      <point x="346" y="679"/>
+      <point x="384" y="642"/>
+      <point x="384" y="575" type="curve" smooth="yes"/>
+      <point x="384" y="495"/>
+      <point x="330" y="431"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -99,6 +99,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/baht.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/baht.glif
@@ -7,16 +7,16 @@
       <point x="38" y="0" type="line"/>
       <point x="330" y="0" type="line" smooth="yes"/>
       <point x="493" y="0"/>
-      <point x="585" y="95.00000000000003"/>
+      <point x="585" y="95"/>
       <point x="585" y="228" type="curve" smooth="yes"/>
       <point x="585" y="302"/>
       <point x="543" y="352"/>
       <point x="495" y="375" type="curve"/>
       <point x="495" y="379" type="line"/>
       <point x="567" y="405"/>
-      <point x="619" y="468.99999999999994"/>
+      <point x="619" y="468"/>
       <point x="619" y="554" type="curve" smooth="yes"/>
-      <point x="619" y="657.0000000000001"/>
+      <point x="619" y="657"/>
       <point x="543" y="716"/>
       <point x="442" y="716" type="curve" smooth="yes"/>
       <point x="164" y="716" type="line"/>
@@ -37,7 +37,7 @@
       <point x="534" y="604"/>
       <point x="534" y="539" type="curve" smooth="yes"/>
       <point x="534" y="463"/>
-      <point x="481.99999999999994" y="417"/>
+      <point x="481" y="417"/>
       <point x="389" y="417" type="curve" smooth="yes"/>
       <point x="156" y="417" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="644" y="315" type="line"/>
+      <point x="661" y="315" type="line" smooth="yes"/>
+      <point x="822" y="315"/>
+      <point x="947" y="434"/>
+      <point x="947" y="589" type="curve" smooth="yes"/>
+      <point x="947" y="684"/>
+      <point x="888" y="751"/>
+      <point x="783" y="751" type="curve" smooth="yes"/>
+      <point x="667" y="751"/>
+      <point x="571" y="662"/>
+      <point x="571" y="553" type="curve" smooth="yes"/>
+      <point x="571" y="499"/>
+      <point x="601" y="465"/>
+      <point x="649" y="465" type="curve" smooth="yes"/>
+      <point x="697" y="465"/>
+      <point x="738" y="505"/>
+      <point x="738" y="552" type="curve" smooth="yes"/>
+      <point x="738" y="586"/>
+      <point x="715" y="609"/>
+      <point x="682" y="609" type="curve" smooth="yes"/>
+      <point x="661" y="609"/>
+      <point x="640" y="600"/>
+      <point x="625" y="577" type="curve"/>
+      <point x="639" y="576" type="line"/>
+      <point x="641" y="586" type="line" smooth="yes"/>
+      <point x="654" y="651"/>
+      <point x="715" y="686"/>
+      <point x="771" y="686" type="curve" smooth="yes"/>
+      <point x="838" y="686"/>
+      <point x="874" y="643"/>
+      <point x="874" y="578" type="curve" smooth="yes"/>
+      <point x="874" y="465"/>
+      <point x="787" y="379"/>
+      <point x="673" y="379" type="curve" smooth="yes"/>
+      <point x="656" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="488" y="-250" type="line"/>
       <point x="558" y="-250" type="line"/>
       <point x="634" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="506" y="-12"/>
       <point x="532" y="16" type="curve"/>
       <point x="535" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="200" y="505" type="curve" smooth="yes"/>
+      <point x="184" y="505"/>
+      <point x="174" y="516"/>
+      <point x="174" y="531" type="curve" smooth="yes"/>
+      <point x="174" y="551"/>
+      <point x="191" y="569"/>
+      <point x="211" y="569" type="curve" smooth="yes"/>
+      <point x="226" y="569"/>
+      <point x="235" y="558"/>
+      <point x="235" y="544" type="curve" smooth="yes"/>
+      <point x="235" y="523"/>
+      <point x="218" y="505"/>
     </contour>
     <contour>
       <point x="184" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="327" y="379"/>
       <point x="213" y="379" type="curve" smooth="yes"/>
       <point x="196" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="200" y="505" type="curve" smooth="yes"/>
-      <point x="184" y="505"/>
-      <point x="174" y="516"/>
-      <point x="174" y="531" type="curve" smooth="yes"/>
-      <point x="174" y="551"/>
-      <point x="191" y="569"/>
-      <point x="211" y="569" type="curve" smooth="yes"/>
-      <point x="226" y="569"/>
-      <point x="235" y="558"/>
-      <point x="235" y="544" type="curve" smooth="yes"/>
-      <point x="235" y="523"/>
-      <point x="218" y="505"/>
-    </contour>
-    <contour>
-      <point x="644" y="315" type="line"/>
-      <point x="661" y="315" type="line" smooth="yes"/>
-      <point x="822" y="315"/>
-      <point x="947" y="434"/>
-      <point x="947" y="589" type="curve" smooth="yes"/>
-      <point x="947" y="684"/>
-      <point x="888" y="751"/>
-      <point x="783" y="751" type="curve" smooth="yes"/>
-      <point x="667" y="751"/>
-      <point x="571" y="662"/>
-      <point x="571" y="553" type="curve" smooth="yes"/>
-      <point x="571" y="499"/>
-      <point x="601" y="465"/>
-      <point x="649" y="465" type="curve" smooth="yes"/>
-      <point x="697" y="465"/>
-      <point x="738" y="505"/>
-      <point x="738" y="552" type="curve" smooth="yes"/>
-      <point x="738" y="586"/>
-      <point x="715" y="609"/>
-      <point x="682" y="609" type="curve" smooth="yes"/>
-      <point x="661" y="609"/>
-      <point x="640" y="600"/>
-      <point x="625" y="577" type="curve"/>
-      <point x="639" y="576" type="line"/>
-      <point x="641" y="586" type="line" smooth="yes"/>
-      <point x="654" y="651"/>
-      <point x="715" y="686"/>
-      <point x="771" y="686" type="curve" smooth="yes"/>
-      <point x="838" y="686"/>
-      <point x="874" y="643"/>
-      <point x="874" y="578" type="curve" smooth="yes"/>
-      <point x="874" y="465"/>
-      <point x="787" y="379"/>
-      <point x="673" y="379" type="curve" smooth="yes"/>
-      <point x="656" y="379" type="line"/>
     </contour>
     <contour>
       <point x="660" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="85" y="-250" type="line"/>
-      <point x="102" y="-250" type="line" smooth="yes"/>
-      <point x="263" y="-250"/>
-      <point x="388" y="-131"/>
-      <point x="388" y="24" type="curve" smooth="yes"/>
-      <point x="388" y="119"/>
-      <point x="329" y="186"/>
-      <point x="224" y="186" type="curve" smooth="yes"/>
-      <point x="108" y="186"/>
-      <point x="12" y="97"/>
-      <point x="12" y="-12" type="curve" smooth="yes"/>
-      <point x="12" y="-66"/>
-      <point x="42" y="-100"/>
-      <point x="90" y="-100" type="curve" smooth="yes"/>
-      <point x="138" y="-100"/>
-      <point x="179" y="-60"/>
-      <point x="179" y="-13" type="curve" smooth="yes"/>
-      <point x="179" y="21"/>
-      <point x="156" y="44"/>
-      <point x="123" y="44" type="curve" smooth="yes"/>
-      <point x="102" y="44"/>
-      <point x="81" y="35"/>
-      <point x="66" y="12" type="curve"/>
-      <point x="80" y="11" type="line"/>
-      <point x="82" y="21" type="line" smooth="yes"/>
-      <point x="95" y="86"/>
-      <point x="156" y="121"/>
-      <point x="212" y="121" type="curve" smooth="yes"/>
-      <point x="279" y="121"/>
-      <point x="315" y="78"/>
-      <point x="315" y="13" type="curve" smooth="yes"/>
-      <point x="315" y="-100"/>
-      <point x="228" y="-186"/>
-      <point x="114" y="-186" type="curve" smooth="yes"/>
-      <point x="97" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="101" y="-60" type="curve" smooth="yes"/>
-      <point x="85" y="-60"/>
-      <point x="75" y="-49"/>
-      <point x="75" y="-34" type="curve" smooth="yes"/>
-      <point x="75" y="-14"/>
-      <point x="92" y="4"/>
-      <point x="112" y="4" type="curve" smooth="yes"/>
-      <point x="127" y="4"/>
-      <point x="136" y="-7"/>
-      <point x="136" y="-21" type="curve" smooth="yes"/>
-      <point x="136" y="-42"/>
-      <point x="119" y="-60"/>
-    </contour>
-    <contour>
       <point x="545" y="-250" type="line"/>
       <point x="562" y="-250" type="line" smooth="yes"/>
       <point x="723" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="688" y="-186"/>
       <point x="574" y="-186" type="curve" smooth="yes"/>
       <point x="557" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="101" y="-60" type="curve" smooth="yes"/>
+      <point x="85" y="-60"/>
+      <point x="75" y="-49"/>
+      <point x="75" y="-34" type="curve" smooth="yes"/>
+      <point x="75" y="-14"/>
+      <point x="92" y="4"/>
+      <point x="112" y="4" type="curve" smooth="yes"/>
+      <point x="127" y="4"/>
+      <point x="136" y="-7"/>
+      <point x="136" y="-21" type="curve" smooth="yes"/>
+      <point x="136" y="-42"/>
+      <point x="119" y="-60"/>
+    </contour>
+    <contour>
+      <point x="85" y="-250" type="line"/>
+      <point x="102" y="-250" type="line" smooth="yes"/>
+      <point x="263" y="-250"/>
+      <point x="388" y="-131"/>
+      <point x="388" y="24" type="curve" smooth="yes"/>
+      <point x="388" y="119"/>
+      <point x="329" y="186"/>
+      <point x="224" y="186" type="curve" smooth="yes"/>
+      <point x="108" y="186"/>
+      <point x="12" y="97"/>
+      <point x="12" y="-12" type="curve" smooth="yes"/>
+      <point x="12" y="-66"/>
+      <point x="42" y="-100"/>
+      <point x="90" y="-100" type="curve" smooth="yes"/>
+      <point x="138" y="-100"/>
+      <point x="179" y="-60"/>
+      <point x="179" y="-13" type="curve" smooth="yes"/>
+      <point x="179" y="21"/>
+      <point x="156" y="44"/>
+      <point x="123" y="44" type="curve" smooth="yes"/>
+      <point x="102" y="44"/>
+      <point x="81" y="35"/>
+      <point x="66" y="12" type="curve"/>
+      <point x="80" y="11" type="line"/>
+      <point x="82" y="21" type="line" smooth="yes"/>
+      <point x="95" y="86"/>
+      <point x="156" y="121"/>
+      <point x="212" y="121" type="curve" smooth="yes"/>
+      <point x="279" y="121"/>
+      <point x="315" y="78"/>
+      <point x="315" y="13" type="curve" smooth="yes"/>
+      <point x="315" y="-100"/>
+      <point x="228" y="-186"/>
+      <point x="114" y="-186" type="curve" smooth="yes"/>
+      <point x="97" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="561" y="-60" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="960"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="626" y="0" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="b" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="689"/>
   <anchor x="270" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="316"/>
     <component base="flig2"/>
+    <component base="f" xOffset="316"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1276"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="946" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="614" y="734" name="top_2"/>
-  <anchor x="873" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1252"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="920" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="299" y="734" name="top_1"/>
-  <anchor x="615" y="734" name="top_2"/>
-  <anchor x="874" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="904"/>
+  <advance width="905"/>
+  <anchor x="112" y="0" name="bottom_1"/>
+  <anchor x="428" y="0" name="bottom_2"/>
+  <anchor x="744" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
+  <anchor x="299" y="734" name="top_1"/>
+  <anchor x="615" y="734" name="top_2"/>
+  <anchor x="870" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="i" xOffset="677"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="615" y="734" name="top_2"/>
   <anchor x="874" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="j" xOffset="677"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1174"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="896" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="299" y="734" name="top_1"/>
-  <anchor x="615" y="734" name="top_2"/>
-  <anchor x="874" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
-  <advance width="993"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="810" y="0" name="bottom_3"/>
+  <advance width="994"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="614" y="734" name="top_2"/>
-  <anchor x="904" y="670" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="t" xOffset="634"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="936"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
   <anchor x="273" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="h" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_j.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_j" format="2">
-  <advance width="588"/>
+  <advance width="589"/>
   <anchor x="114" y="0" name="bottom_1"/>
   <anchor x="390" y="-216" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="858"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="580" y="0" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-8"/>
     <component base="k" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
-  <advance width="589"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
+  <advance width="590"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="l" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="677"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="494" y="0" name="bottom_2"/>
-  <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="588" y="670" name="top_2"/>
+  <advance width="678"/>
+  <anchor x="280" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="318"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="314" y="366"/>
       <point x="342" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="307" yOffset="-111"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="307" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="314" y="366"/>
       <point x="342" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="307" yOffset="-111"/>
+    <component base="geez-part-4" xOffset="307" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="441.374" y="526" name="top"/>
   <outline>
     <contour>
+      <point x="27" y="0" type="line"/>
+      <point x="111" y="0" type="line"/>
+      <point x="247" y="776" type="line"/>
+      <point x="163" y="776" type="line"/>
+    </contour>
+    <contour>
       <point x="461" y="-16" type="curve" smooth="yes"/>
       <point x="643" y="-16"/>
       <point x="753" y="132"/>
@@ -18,18 +24,6 @@
       <point x="332" y="-16"/>
     </contour>
     <contour>
-      <point x="111" y="227" type="line"/>
-      <point x="289" y="227" type="line"/>
-      <point x="299" y="304" type="line"/>
-      <point x="124" y="304" type="line"/>
-    </contour>
-    <contour>
-      <point x="27" y="0" type="line"/>
-      <point x="111" y="0" type="line"/>
-      <point x="247" y="776" type="line"/>
-      <point x="163" y="776" type="line"/>
-    </contour>
-    <contour>
       <point x="472" y="61" type="curve" smooth="yes"/>
       <point x="392" y="61"/>
       <point x="334" y="121"/>
@@ -42,6 +36,12 @@
       <point x="668" y="300" type="curve" smooth="yes"/>
       <point x="668" y="179"/>
       <point x="599" y="61"/>
+    </contour>
+    <contour>
+      <point x="111" y="227" type="line"/>
+      <point x="289" y="227" type="line"/>
+      <point x="299" y="304" type="line"/>
+      <point x="124" y="304" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="722" y="226" type="curve"/>
     </contour>
     <contour>
-      <point x="347" y="-434" type="curve" smooth="yes"/>
-      <point x="432" y="-434"/>
-      <point x="476" y="-359"/>
-      <point x="476" y="-273" type="curve" smooth="yes"/>
-      <point x="476" y="-206"/>
-      <point x="440" y="-165"/>
-      <point x="375" y="-165" type="curve" smooth="yes"/>
-      <point x="295" y="-165"/>
-      <point x="232" y="-250"/>
-      <point x="232" y="-335" type="curve" smooth="yes"/>
-      <point x="232" y="-397"/>
-      <point x="274" y="-434"/>
-    </contour>
-    <contour>
       <point x="495" y="-421" type="line"/>
       <point x="575" y="-421" type="line"/>
       <point x="690" y="236" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="531" y="-205"/>
       <point x="530" y="-217"/>
       <point x="528" y="-230" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="347" y="-434" type="curve" smooth="yes"/>
+      <point x="432" y="-434"/>
+      <point x="476" y="-359"/>
+      <point x="476" y="-273" type="curve" smooth="yes"/>
+      <point x="476" y="-206"/>
+      <point x="440" y="-165"/>
+      <point x="375" y="-165" type="curve" smooth="yes"/>
+      <point x="295" y="-165"/>
+      <point x="232" y="-250"/>
+      <point x="232" y="-335" type="curve" smooth="yes"/>
+      <point x="232" y="-397"/>
+      <point x="274" y="-434"/>
     </contour>
     <contour>
       <point x="347" y="-365" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ngo-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ngo-khmer.glif
@@ -38,7 +38,7 @@
       <point x="276" y="366" type="curve" smooth="yes"/>
       <point x="319" y="366"/>
       <point x="353" y="378"/>
-      <point x="410" y="407" type="curve" name="7.9 ⛔️"/>
+      <point x="410" y="407" type="curve"/>
       <point x="459" y="429"/>
       <point x="516" y="456"/>
       <point x="516" y="517" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-6"/>
-    <component base="zeropercent" xOffset="653" yOffset="1"/>
+    <component base="zeropercent" xOffset="653"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/percent.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="864"/>
+  <advance width="866"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="-1"/>
+    <component base="zeropercent"/>
     <component base="zeropercent" xOffset="357" yOffset="-394"/>
     <component base="percentbar"/>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="866"/>
   <outline>
     <contour>
-      <point x="188" y="0" type="line"/>
-      <point x="792" y="716" type="line"/>
-      <point x="710" y="716" type="line"/>
-      <point x="106" y="0" type="line"/>
+      <point x="189" y="0" type="line"/>
+      <point x="793" y="716" type="line"/>
+      <point x="711" y="716" type="line"/>
+      <point x="107" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1430"/>
+  <advance width="1432"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="357" yOffset="-394"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="358" yOffset="-394"/>
-    <component base="zeropercent" xOffset="642" yOffset="-394"/>
-    <component base="zeropercent" xOffset="926" yOffset="-393"/>
+    <component base="zeropercent" xOffset="640" yOffset="-394"/>
+    <component base="zeropercent" xOffset="923" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1147"/>
+  <advance width="1149"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>
     <component base="zeropercent" xOffset="357" yOffset="-394"/>
     <component base="percentbar"/>
-    <component base="zeropercent" xOffset="642" yOffset="-394"/>
+    <component base="zeropercent" xOffset="640" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="121" y="495" type="line"/>
-      <point x="198" y="495" type="line" name="hr00"/>
+      <point x="198" y="495" type="line"/>
       <point x="236" y="716" type="line"/>
       <point x="159" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="756"/>
-  <anchor x="69" y="0" name="bottom_1"/>
-  <anchor x="495" y="0" name="bottom_2"/>
   <anchor x="282" y="0" name="caret_1"/>
-  <anchor x="257" y="526" name="top_1"/>
-  <anchor x="684" y="748" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="383"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1068"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="857" y="0" name="bottom_3"/>
   <anchor x="328" y="0" name="caret_1"/>
-  <anchor x="699" y="0" name="caret_2"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="734" name="top_2"/>
-  <anchor x="914" y="734" name="top_3"/>
+  <anchor x="639" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="749"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="516" y="0" name="bottom_2"/>
   <anchor x="374.5" y="0" name="caret_1"/>
-  <anchor x="233" y="526" name="top_1"/>
-  <anchor x="608" y="526" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="390"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="552" y="363" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="489" y="-237" type="curve" smooth="yes"/>
-      <point x="578" y="-237"/>
-      <point x="626" y="-161"/>
-      <point x="626" y="-71" type="curve" smooth="yes"/>
-      <point x="626" y="-1"/>
-      <point x="586" y="42"/>
-      <point x="517" y="42" type="curve" smooth="yes"/>
-      <point x="433" y="42"/>
-      <point x="369" y="-53"/>
-      <point x="369" y="-139" type="curve" smooth="yes"/>
-      <point x="369" y="-198"/>
-      <point x="412" y="-237"/>
-    </contour>
-    <contour>
       <point x="383" y="69" type="line"/>
       <point x="396" y="140" type="line"/>
       <point x="318" y="189" type="line"/>
@@ -94,6 +80,20 @@
       <point x="340" y="22" type="curve" smooth="yes"/>
       <point x="340" y="-33"/>
       <point x="369" y="-76"/>
+    </contour>
+    <contour>
+      <point x="489" y="-237" type="curve" smooth="yes"/>
+      <point x="578" y="-237"/>
+      <point x="626" y="-161"/>
+      <point x="626" y="-71" type="curve" smooth="yes"/>
+      <point x="626" y="-1"/>
+      <point x="586" y="42"/>
+      <point x="517" y="42" type="curve" smooth="yes"/>
+      <point x="433" y="42"/>
+      <point x="369" y="-53"/>
+      <point x="369" y="-139" type="curve" smooth="yes"/>
+      <point x="369" y="-198"/>
+      <point x="412" y="-237"/>
     </contour>
     <contour>
       <point x="490" y="-168" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/sdotbelow.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/sdotbelow.sc.glif
@@ -7,8 +7,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>s.sc</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>s.sc</string>
     </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/t_f.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="688"/>
-  <anchor x="125" y="0" name="bottom_1"/>
-  <anchor x="427" y="0" name="bottom_2"/>
-  <anchor x="274" y="0" name="caret_1"/>
-  <anchor x="179" y="255" name="center_1"/>
-  <anchor x="492" y="255" name="center_2"/>
-  <anchor x="271" y="670" name="top_1"/>
-  <anchor x="613" y="734" name="top_2"/>
-  <anchor x="312" y="526" name="topright_1"/>
-  <anchor x="628" y="526" name="topright_2"/>
+  <advance width="687"/>
+  <anchor x="319" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="f" xOffset="315"/>
+    <component base="tlig" xOffset="-1"/>
+    <component base="f" xOffset="314"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/t_t.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="677"/>
-  <anchor x="177" y="0" name="bottom_1"/>
-  <anchor x="493" y="0" name="bottom_2"/>
-  <anchor x="274" y="0" name="caret_1"/>
-  <anchor x="169" y="263" name="center_1"/>
-  <anchor x="507" y="263" name="center_2"/>
-  <anchor x="271" y="670" name="top_1"/>
-  <anchor x="588" y="669" name="top_2"/>
-  <anchor x="312" y="526" name="topright_1"/>
-  <anchor x="628" y="526" name="topright_2"/>
+  <advance width="678"/>
+  <anchor x="333" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="t" xOffset="319"/>
+    <component base="tlig" xOffset="-1"/>
+    <component base="t" xOffset="318"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
       <point x="247" y="378" type="curve" smooth="yes"/>
-      <point x="363" y="378"/>
-      <point x="447" y="467"/>
-      <point x="447" y="585" type="curve" smooth="yes"/>
-      <point x="447" y="674"/>
-      <point x="387" y="732"/>
-      <point x="294" y="732" type="curve" smooth="yes"/>
+      <point x="364" y="378"/>
+      <point x="448" y="464"/>
+      <point x="448" y="582" type="curve" smooth="yes"/>
+      <point x="448" y="673"/>
+      <point x="386" y="732"/>
+      <point x="295" y="732" type="curve" smooth="yes"/>
       <point x="178" y="732"/>
-      <point x="93" y="649"/>
-      <point x="93" y="532" type="curve" smooth="yes"/>
-      <point x="93" y="438"/>
-      <point x="157" y="378"/>
+      <point x="94" y="646"/>
+      <point x="94" y="528" type="curve" smooth="yes"/>
+      <point x="94" y="437"/>
+      <point x="156" y="378"/>
     </contour>
     <contour>
-      <point x="252" y="440" type="curve" smooth="yes"/>
+      <point x="254" y="440" type="curve" smooth="yes"/>
       <point x="201" y="440"/>
-      <point x="161" y="475"/>
-      <point x="161" y="539" type="curve" smooth="yes"/>
-      <point x="161" y="612"/>
-      <point x="215" y="670"/>
-      <point x="286" y="670" type="curve" smooth="yes"/>
-      <point x="340" y="670"/>
-      <point x="379" y="637"/>
-      <point x="379" y="576" type="curve" smooth="yes"/>
-      <point x="379" y="502"/>
-      <point x="325" y="440"/>
+      <point x="162" y="474"/>
+      <point x="162" y="536" type="curve" smooth="yes"/>
+      <point x="162" y="610"/>
+      <point x="216" y="670"/>
+      <point x="288" y="670" type="curve" smooth="yes"/>
+      <point x="341" y="670"/>
+      <point x="380" y="636"/>
+      <point x="380" y="574" type="curve" smooth="yes"/>
+      <point x="380" y="500"/>
+      <point x="326" y="440"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -64,6 +64,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/F_ivethousand-roman.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/F_ivethousand-roman.glif
@@ -30,24 +30,24 @@
       <point x="240" y="111" type="line"/>
     </contour>
     <contour>
-      <point x="192" y="182" type="line"/>
-      <point x="322" y="182" type="line" smooth="yes"/>
-      <point x="442" y="182"/>
-      <point x="546" y="266"/>
-      <point x="546" y="376" type="curve" smooth="yes"/>
-      <point x="546" y="462"/>
-      <point x="465" y="539"/>
-      <point x="373" y="539" type="curve" smooth="yes"/>
-      <point x="259" y="539" type="line"/>
-      <point x="238" y="437" type="line"/>
-      <point x="351" y="437" type="line" smooth="yes"/>
-      <point x="398" y="437"/>
-      <point x="430" y="425"/>
-      <point x="430" y="370" type="curve" smooth="yes"/>
-      <point x="430" y="306"/>
-      <point x="403" y="279"/>
-      <point x="339" y="279" type="curve" smooth="yes"/>
-      <point x="213" y="279" type="line"/>
+      <point x="192" y="180" type="line"/>
+      <point x="322" y="180" type="line" smooth="yes"/>
+      <point x="442" y="180"/>
+      <point x="546" y="264"/>
+      <point x="546" y="374" type="curve" smooth="yes"/>
+      <point x="546" y="460"/>
+      <point x="465" y="537"/>
+      <point x="373" y="537" type="curve" smooth="yes"/>
+      <point x="259" y="537" type="line"/>
+      <point x="238" y="435" type="line"/>
+      <point x="351" y="435" type="line" smooth="yes"/>
+      <point x="398" y="435"/>
+      <point x="430" y="423"/>
+      <point x="430" y="368" type="curve" smooth="yes"/>
+      <point x="430" y="304"/>
+      <point x="403" y="277"/>
+      <point x="339" y="277" type="curve" smooth="yes"/>
+      <point x="213" y="277" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/K_hook.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/K_hook.glif
@@ -42,10 +42,4 @@
       <point x="149" y="335" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>K</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="644" y="315" type="line"/>
+      <point x="661" y="315" type="line" smooth="yes"/>
+      <point x="822" y="315"/>
+      <point x="947" y="434"/>
+      <point x="947" y="589" type="curve" smooth="yes"/>
+      <point x="947" y="684"/>
+      <point x="888" y="751"/>
+      <point x="783" y="751" type="curve" smooth="yes"/>
+      <point x="667" y="751"/>
+      <point x="571" y="662"/>
+      <point x="571" y="553" type="curve" smooth="yes"/>
+      <point x="571" y="499"/>
+      <point x="601" y="465"/>
+      <point x="649" y="465" type="curve" smooth="yes"/>
+      <point x="697" y="465"/>
+      <point x="738" y="505"/>
+      <point x="738" y="552" type="curve" smooth="yes"/>
+      <point x="738" y="586"/>
+      <point x="715" y="609"/>
+      <point x="682" y="609" type="curve" smooth="yes"/>
+      <point x="661" y="609"/>
+      <point x="640" y="600"/>
+      <point x="625" y="577" type="curve"/>
+      <point x="639" y="576" type="line"/>
+      <point x="641" y="586" type="line" smooth="yes"/>
+      <point x="654" y="651"/>
+      <point x="715" y="686"/>
+      <point x="771" y="686" type="curve" smooth="yes"/>
+      <point x="838" y="686"/>
+      <point x="874" y="643"/>
+      <point x="874" y="578" type="curve" smooth="yes"/>
+      <point x="874" y="465"/>
+      <point x="787" y="379"/>
+      <point x="673" y="379" type="curve" smooth="yes"/>
+      <point x="656" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="488" y="-250" type="line"/>
       <point x="558" y="-250" type="line"/>
       <point x="634" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="506" y="-12"/>
       <point x="532" y="16" type="curve"/>
       <point x="535" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="200" y="505" type="curve" smooth="yes"/>
+      <point x="184" y="505"/>
+      <point x="174" y="516"/>
+      <point x="174" y="531" type="curve" smooth="yes"/>
+      <point x="174" y="551"/>
+      <point x="191" y="569"/>
+      <point x="211" y="569" type="curve" smooth="yes"/>
+      <point x="226" y="569"/>
+      <point x="235" y="558"/>
+      <point x="235" y="544" type="curve" smooth="yes"/>
+      <point x="235" y="523"/>
+      <point x="218" y="505"/>
     </contour>
     <contour>
       <point x="184" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="327" y="379"/>
       <point x="213" y="379" type="curve" smooth="yes"/>
       <point x="196" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="200" y="505" type="curve" smooth="yes"/>
-      <point x="184" y="505"/>
-      <point x="174" y="516"/>
-      <point x="174" y="531" type="curve" smooth="yes"/>
-      <point x="174" y="551"/>
-      <point x="191" y="569"/>
-      <point x="211" y="569" type="curve" smooth="yes"/>
-      <point x="226" y="569"/>
-      <point x="235" y="558"/>
-      <point x="235" y="544" type="curve" smooth="yes"/>
-      <point x="235" y="523"/>
-      <point x="218" y="505"/>
-    </contour>
-    <contour>
-      <point x="644" y="315" type="line"/>
-      <point x="661" y="315" type="line" smooth="yes"/>
-      <point x="822" y="315"/>
-      <point x="947" y="434"/>
-      <point x="947" y="589" type="curve" smooth="yes"/>
-      <point x="947" y="684"/>
-      <point x="888" y="751"/>
-      <point x="783" y="751" type="curve" smooth="yes"/>
-      <point x="667" y="751"/>
-      <point x="571" y="662"/>
-      <point x="571" y="553" type="curve" smooth="yes"/>
-      <point x="571" y="499"/>
-      <point x="601" y="465"/>
-      <point x="649" y="465" type="curve" smooth="yes"/>
-      <point x="697" y="465"/>
-      <point x="738" y="505"/>
-      <point x="738" y="552" type="curve" smooth="yes"/>
-      <point x="738" y="586"/>
-      <point x="715" y="609"/>
-      <point x="682" y="609" type="curve" smooth="yes"/>
-      <point x="661" y="609"/>
-      <point x="640" y="600"/>
-      <point x="625" y="577" type="curve"/>
-      <point x="639" y="576" type="line"/>
-      <point x="641" y="586" type="line" smooth="yes"/>
-      <point x="654" y="651"/>
-      <point x="715" y="686"/>
-      <point x="771" y="686" type="curve" smooth="yes"/>
-      <point x="838" y="686"/>
-      <point x="874" y="643"/>
-      <point x="874" y="578" type="curve" smooth="yes"/>
-      <point x="874" y="465"/>
-      <point x="787" y="379"/>
-      <point x="673" y="379" type="curve" smooth="yes"/>
-      <point x="656" y="379" type="line"/>
     </contour>
     <contour>
       <point x="660" y="505" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="85" y="-250" type="line"/>
-      <point x="102" y="-250" type="line" smooth="yes"/>
-      <point x="263" y="-250"/>
-      <point x="388" y="-131"/>
-      <point x="388" y="24" type="curve" smooth="yes"/>
-      <point x="388" y="119"/>
-      <point x="329" y="186"/>
-      <point x="224" y="186" type="curve" smooth="yes"/>
-      <point x="108" y="186"/>
-      <point x="12" y="97"/>
-      <point x="12" y="-12" type="curve" smooth="yes"/>
-      <point x="12" y="-66"/>
-      <point x="42" y="-100"/>
-      <point x="90" y="-100" type="curve" smooth="yes"/>
-      <point x="138" y="-100"/>
-      <point x="179" y="-60"/>
-      <point x="179" y="-13" type="curve" smooth="yes"/>
-      <point x="179" y="21"/>
-      <point x="156" y="44"/>
-      <point x="123" y="44" type="curve" smooth="yes"/>
-      <point x="102" y="44"/>
-      <point x="81" y="35"/>
-      <point x="66" y="12" type="curve"/>
-      <point x="80" y="11" type="line"/>
-      <point x="82" y="21" type="line" smooth="yes"/>
-      <point x="95" y="86"/>
-      <point x="156" y="121"/>
-      <point x="212" y="121" type="curve" smooth="yes"/>
-      <point x="279" y="121"/>
-      <point x="315" y="78"/>
-      <point x="315" y="13" type="curve" smooth="yes"/>
-      <point x="315" y="-100"/>
-      <point x="228" y="-186"/>
-      <point x="114" y="-186" type="curve" smooth="yes"/>
-      <point x="97" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="101" y="-60" type="curve" smooth="yes"/>
-      <point x="85" y="-60"/>
-      <point x="75" y="-49"/>
-      <point x="75" y="-34" type="curve" smooth="yes"/>
-      <point x="75" y="-14"/>
-      <point x="92" y="4"/>
-      <point x="112" y="4" type="curve" smooth="yes"/>
-      <point x="127" y="4"/>
-      <point x="136" y="-7"/>
-      <point x="136" y="-21" type="curve" smooth="yes"/>
-      <point x="136" y="-42"/>
-      <point x="119" y="-60"/>
-    </contour>
-    <contour>
       <point x="545" y="-250" type="line"/>
       <point x="562" y="-250" type="line" smooth="yes"/>
       <point x="723" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="688" y="-186"/>
       <point x="574" y="-186" type="curve" smooth="yes"/>
       <point x="557" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="101" y="-60" type="curve" smooth="yes"/>
+      <point x="85" y="-60"/>
+      <point x="75" y="-49"/>
+      <point x="75" y="-34" type="curve" smooth="yes"/>
+      <point x="75" y="-14"/>
+      <point x="92" y="4"/>
+      <point x="112" y="4" type="curve" smooth="yes"/>
+      <point x="127" y="4"/>
+      <point x="136" y="-7"/>
+      <point x="136" y="-21" type="curve" smooth="yes"/>
+      <point x="136" y="-42"/>
+      <point x="119" y="-60"/>
+    </contour>
+    <contour>
+      <point x="85" y="-250" type="line"/>
+      <point x="102" y="-250" type="line" smooth="yes"/>
+      <point x="263" y="-250"/>
+      <point x="388" y="-131"/>
+      <point x="388" y="24" type="curve" smooth="yes"/>
+      <point x="388" y="119"/>
+      <point x="329" y="186"/>
+      <point x="224" y="186" type="curve" smooth="yes"/>
+      <point x="108" y="186"/>
+      <point x="12" y="97"/>
+      <point x="12" y="-12" type="curve" smooth="yes"/>
+      <point x="12" y="-66"/>
+      <point x="42" y="-100"/>
+      <point x="90" y="-100" type="curve" smooth="yes"/>
+      <point x="138" y="-100"/>
+      <point x="179" y="-60"/>
+      <point x="179" y="-13" type="curve" smooth="yes"/>
+      <point x="179" y="21"/>
+      <point x="156" y="44"/>
+      <point x="123" y="44" type="curve" smooth="yes"/>
+      <point x="102" y="44"/>
+      <point x="81" y="35"/>
+      <point x="66" y="12" type="curve"/>
+      <point x="80" y="11" type="line"/>
+      <point x="82" y="21" type="line" smooth="yes"/>
+      <point x="95" y="86"/>
+      <point x="156" y="121"/>
+      <point x="212" y="121" type="curve" smooth="yes"/>
+      <point x="279" y="121"/>
+      <point x="315" y="78"/>
+      <point x="315" y="13" type="curve" smooth="yes"/>
+      <point x="315" y="-100"/>
+      <point x="228" y="-186"/>
+      <point x="114" y="-186" type="curve" smooth="yes"/>
+      <point x="97" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="561" y="-60" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="960"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="626" y="0" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-9"/>
     <component base="b" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="689"/>
   <anchor x="270" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="316"/>
     <component base="flig2"/>
+    <component base="f" xOffset="316"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1276"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="946" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="614" y="734" name="top_2"/>
-  <anchor x="873" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1252"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="920" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="299" y="734" name="top_1"/>
-  <anchor x="615" y="734" name="top_2"/>
-  <anchor x="874" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="904"/>
+  <advance width="905"/>
+  <anchor x="112" y="0" name="bottom_1"/>
+  <anchor x="428" y="0" name="bottom_2"/>
+  <anchor x="741" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
+  <anchor x="299" y="734" name="top_1"/>
+  <anchor x="615" y="734" name="top_2"/>
+  <anchor x="874" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="i" xOffset="677"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="615" y="734" name="top_2"/>
   <anchor x="874" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="j" xOffset="677"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1174"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="896" y="0" name="bottom_3"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="299" y="734" name="top_1"/>
-  <anchor x="615" y="734" name="top_2"/>
-  <anchor x="874" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
-  <advance width="993"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="810" y="0" name="bottom_3"/>
+  <advance width="994"/>
   <anchor x="270" y="0" name="caret_1"/>
   <anchor x="586" y="0" name="caret_2"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="614" y="734" name="top_2"/>
-  <anchor x="904" y="670" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="316"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="316"/>
     <component base="t" xOffset="634"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_h.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
-  <advance width="936"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
-  <anchor x="273" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
+  <advance width="935"/>
+  <anchor x="272" y="0" name="caret_1"/>
   <outline>
-    <component base="flig1" xOffset="-9"/>
-    <component base="h" xOffset="359"/>
+    <component base="flig1" xOffset="-10"/>
+    <component base="h" xOffset="358"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_j.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_j" format="2">
-  <advance width="588"/>
+  <advance width="589"/>
   <anchor x="114" y="0" name="bottom_1"/>
   <anchor x="390" y="-216" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="858"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="580" y="0" name="bottom_2"/>
   <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
   <outline>
     <component base="flig1" xOffset="-8"/>
     <component base="k" xOffset="359"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_l.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
-  <advance width="589"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="428" y="0" name="bottom_2"/>
-  <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="557" y="734" name="top_2"/>
+  <advance width="588"/>
+  <anchor x="269" y="0" name="caret_1"/>
   <outline>
-    <component base="flig1" xOffset="-9"/>
-    <component base="l" xOffset="359"/>
+    <component base="flig1" xOffset="-10"/>
+    <component base="l" xOffset="358"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="677"/>
-  <anchor x="112" y="0" name="bottom_1"/>
-  <anchor x="494" y="0" name="bottom_2"/>
-  <anchor x="270" y="0" name="caret_1"/>
-  <anchor x="298" y="734" name="top_1"/>
-  <anchor x="588" y="670" name="top_2"/>
+  <advance width="678"/>
+  <anchor x="280" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="318"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="314" y="366"/>
       <point x="342" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="307" yOffset="-111"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="307" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="314" y="366"/>
       <point x="342" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="307" yOffset="-111"/>
+    <component base="geez-part-4" xOffset="307" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.glif
@@ -5,18 +5,18 @@
   <anchor x="455" y="526" name="top"/>
   <outline>
     <contour>
-      <point x="469" y="-16" type="curve" smooth="yes"/>
+      <point x="461" y="-16" type="curve" smooth="yes"/>
       <point x="643" y="-16"/>
       <point x="763" y="132"/>
       <point x="763" y="311" type="curve" smooth="yes"/>
       <point x="763" y="451"/>
-      <point x="679" y="542"/>
-      <point x="533" y="542" type="curve" smooth="yes"/>
-      <point x="360" y="542"/>
-      <point x="239" y="394"/>
-      <point x="239" y="216" type="curve" smooth="yes"/>
-      <point x="239" y="76"/>
-      <point x="323" y="-16"/>
+      <point x="688" y="542"/>
+      <point x="543" y="542" type="curve" smooth="yes"/>
+      <point x="371" y="542"/>
+      <point x="239" y="408"/>
+      <point x="239" y="227" type="curve" smooth="yes"/>
+      <point x="239" y="75"/>
+      <point x="312" y="-16"/>
     </contour>
     <contour>
       <point x="17" y="0" type="line"/>
@@ -25,24 +25,24 @@
       <point x="109" y="526" type="line"/>
     </contour>
     <contour>
-      <point x="111" y="215" type="line"/>
-      <point x="288" y="215" type="line"/>
-      <point x="303" y="320" type="line"/>
-      <point x="130" y="320" type="line"/>
+      <point x="113" y="227" type="line"/>
+      <point x="289" y="227" type="line"/>
+      <point x="299" y="304" type="line"/>
+      <point x="126" y="304" type="line"/>
     </contour>
     <contour>
-      <point x="472" y="81" type="curve" smooth="yes"/>
-      <point x="392" y="81"/>
-      <point x="354" y="141"/>
+      <point x="472" y="91" type="curve" smooth="yes"/>
+      <point x="396" y="91"/>
+      <point x="354" y="121"/>
       <point x="354" y="227" type="curve" smooth="yes"/>
-      <point x="354" y="337"/>
-      <point x="406" y="435"/>
+      <point x="354" y="347"/>
+      <point x="415" y="435"/>
       <point x="532" y="435" type="curve" smooth="yes"/>
-      <point x="612" y="435"/>
-      <point x="648" y="395"/>
+      <point x="605" y="435"/>
+      <point x="648" y="408"/>
       <point x="648" y="300" type="curve" smooth="yes"/>
-      <point x="648" y="199"/>
-      <point x="598" y="81"/>
+      <point x="648" y="179"/>
+      <point x="589" y="91"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -1,47 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.loclBGR" format="2">
-  <advance width="789"/>
-  <anchor x="441.374" y="526" name="top"/>
+  <advance width="785"/>
+  <anchor x="436" y="526" name="top"/>
   <outline>
     <contour>
-      <point x="469" y="-16" type="curve" smooth="yes"/>
-      <point x="643" y="-16"/>
-      <point x="763" y="132"/>
-      <point x="763" y="311" type="curve" smooth="yes"/>
-      <point x="763" y="451"/>
-      <point x="679" y="542"/>
-      <point x="533" y="542" type="curve" smooth="yes"/>
-      <point x="360" y="542"/>
-      <point x="239" y="394"/>
-      <point x="239" y="216" type="curve" smooth="yes"/>
-      <point x="239" y="76"/>
-      <point x="323" y="-16"/>
+      <point x="12" y="0" type="line"/>
+      <point x="126" y="0" type="line"/>
+      <point x="262" y="776" type="line"/>
+      <point x="148" y="776" type="line"/>
     </contour>
     <contour>
-      <point x="111" y="215" type="line"/>
-      <point x="288" y="215" type="line"/>
-      <point x="303" y="320" type="line"/>
-      <point x="130" y="320" type="line"/>
+      <point x="456" y="-16" type="curve" smooth="yes"/>
+      <point x="638" y="-16"/>
+      <point x="758" y="132"/>
+      <point x="758" y="311" type="curve" smooth="yes"/>
+      <point x="758" y="451"/>
+      <point x="673" y="542"/>
+      <point x="538" y="542" type="curve" smooth="yes"/>
+      <point x="382" y="542"/>
+      <point x="234" y="414"/>
+      <point x="234" y="227" type="curve" smooth="yes"/>
+      <point x="234" y="75"/>
+      <point x="317" y="-16"/>
     </contour>
     <contour>
-      <point x="17" y="0" type="line"/>
-      <point x="131" y="0" type="line"/>
-      <point x="267" y="776" type="line"/>
-      <point x="153" y="776" type="line"/>
+      <point x="467" y="83" type="curve" smooth="yes"/>
+      <point x="387" y="83"/>
+      <point x="349" y="134"/>
+      <point x="349" y="227" type="curve" smooth="yes"/>
+      <point x="349" y="333"/>
+      <point x="400" y="439"/>
+      <point x="527" y="439" type="curve" smooth="yes"/>
+      <point x="607" y="439"/>
+      <point x="643" y="388"/>
+      <point x="643" y="295" type="curve" smooth="yes"/>
+      <point x="643" y="189"/>
+      <point x="594" y="83"/>
     </contour>
     <contour>
-      <point x="472" y="81" type="curve" smooth="yes"/>
-      <point x="392" y="81"/>
-      <point x="354" y="141"/>
-      <point x="354" y="227" type="curve" smooth="yes"/>
-      <point x="354" y="337"/>
-      <point x="406" y="435"/>
-      <point x="532" y="435" type="curve" smooth="yes"/>
-      <point x="612" y="435"/>
-      <point x="648" y="395"/>
-      <point x="648" y="300" type="curve" smooth="yes"/>
-      <point x="648" y="199"/>
-      <point x="598" y="81"/>
+      <point x="106" y="215" type="line"/>
+      <point x="284" y="215" type="line"/>
+      <point x="294" y="322" type="line"/>
+      <point x="119" y="322" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
@@ -5,17 +5,17 @@
   <outline>
     <contour>
       <point x="505" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
+      <point x="694" y="-16"/>
       <point x="814" y="146"/>
       <point x="814" y="335" type="curve" smooth="yes"/>
-      <point x="814" y="497"/>
-      <point x="721" y="596"/>
+      <point x="814" y="487"/>
+      <point x="726" y="596"/>
       <point x="577" y="596" type="curve" smooth="yes"/>
-      <point x="386" y="596"/>
-      <point x="267" y="435"/>
-      <point x="267" y="246" type="curve" smooth="yes"/>
-      <point x="267" y="75"/>
-      <point x="373" y="-16"/>
+      <point x="412" y="596"/>
+      <point x="267" y="460"/>
+      <point x="267" y="258" type="curve" smooth="yes"/>
+      <point x="267" y="89"/>
+      <point x="365" y="-16"/>
     </contour>
     <contour>
       <point x="17" y="0" type="line"/>
@@ -26,22 +26,22 @@
     <contour>
       <point x="125" y="248" type="line"/>
       <point x="310" y="248" type="line"/>
-      <point x="323" y="346" type="line"/>
-      <point x="143" y="346" type="line"/>
+      <point x="323" y="348" type="line"/>
+      <point x="143" y="348" type="line"/>
     </contour>
     <contour>
       <point x="515" y="83" type="curve" smooth="yes"/>
-      <point x="421" y="83"/>
+      <point x="425" y="83"/>
       <point x="372" y="144"/>
       <point x="372" y="252" type="curve" smooth="yes"/>
       <point x="372" y="382"/>
-      <point x="443" y="497"/>
+      <point x="438" y="497"/>
       <point x="567" y="497" type="curve" smooth="yes"/>
-      <point x="661" y="497"/>
-      <point x="710" y="432"/>
+      <point x="647" y="497"/>
+      <point x="710" y="435"/>
       <point x="710" y="328" type="curve" smooth="yes"/>
       <point x="710" y="191"/>
-      <point x="639" y="83"/>
+      <point x="634" y="83"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="722" y="226" type="curve"/>
     </contour>
     <contour>
-      <point x="347" y="-434" type="curve" smooth="yes"/>
-      <point x="432" y="-434"/>
-      <point x="476" y="-359"/>
-      <point x="476" y="-273" type="curve" smooth="yes"/>
-      <point x="476" y="-206"/>
-      <point x="440" y="-165"/>
-      <point x="375" y="-165" type="curve" smooth="yes"/>
-      <point x="295" y="-165"/>
-      <point x="232" y="-250"/>
-      <point x="232" y="-335" type="curve" smooth="yes"/>
-      <point x="232" y="-397"/>
-      <point x="274" y="-434"/>
-    </contour>
-    <contour>
       <point x="495" y="-421" type="line"/>
       <point x="575" y="-421" type="line"/>
       <point x="690" y="236" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="531" y="-205"/>
       <point x="530" y="-217"/>
       <point x="528" y="-230" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="347" y="-434" type="curve" smooth="yes"/>
+      <point x="432" y="-434"/>
+      <point x="476" y="-359"/>
+      <point x="476" y="-273" type="curve" smooth="yes"/>
+      <point x="476" y="-206"/>
+      <point x="440" y="-165"/>
+      <point x="375" y="-165" type="curve" smooth="yes"/>
+      <point x="295" y="-165"/>
+      <point x="232" y="-250"/>
+      <point x="232" y="-335" type="curve" smooth="yes"/>
+      <point x="232" y="-397"/>
+      <point x="274" y="-434"/>
     </contour>
     <contour>
       <point x="347" y="-365" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ngo-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ngo-khmer.glif
@@ -38,7 +38,7 @@
       <point x="276" y="366" type="curve" smooth="yes"/>
       <point x="319" y="366"/>
       <point x="353" y="378"/>
-      <point x="410" y="407" type="curve" name="7.9 ⛔️"/>
+      <point x="410" y="407" type="curve"/>
       <point x="459" y="429"/>
       <point x="516" y="456"/>
       <point x="516" y="517" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-6"/>
-    <component base="zeropercent" xOffset="653" yOffset="1"/>
+    <component base="zeropercent" xOffset="652"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="864"/>
+  <advance width="866"/>
   <unicode hex="0025"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="362" yOffset="-393"/>
-    <component base="percentbar" xOffset="5" yOffset="1"/>
+    <component base="zeropercent" xOffset="356" yOffset="-393"/>
+    <component base="percentbar" xOffset="3"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/percentbar.glif
@@ -3,10 +3,10 @@
   <advance width="826"/>
   <outline>
     <contour>
-      <point x="194" y="-7" type="line"/>
-      <point x="798" y="709" type="line"/>
-      <point x="701" y="724" type="line"/>
-      <point x="97" y="8" type="line"/>
+      <point x="200" y="0" type="line"/>
+      <point x="804" y="716" type="line"/>
+      <point x="694" y="716" type="line"/>
+      <point x="90" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1430"/>
+  <advance width="1432"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="percentbar"/>
-    <component base="zeropercent" xOffset="358" yOffset="-394"/>
-    <component base="zeropercent" xOffset="642" yOffset="-394"/>
-    <component base="zeropercent" xOffset="926" yOffset="-393"/>
+    <component base="zeropercent" xOffset="362" yOffset="-393"/>
+    <component base="percentbar" xOffset="6"/>
+    <component base="zeropercent" xOffset="642" yOffset="-393"/>
+    <component base="zeropercent" xOffset="922" yOffset="-393"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1147"/>
+  <advance width="1149"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="357" yOffset="-394"/>
-    <component base="percentbar"/>
-    <component base="zeropercent" xOffset="642" yOffset="-394"/>
+    <component base="zeropercent" xOffset="362" yOffset="-393"/>
+    <component base="percentbar" xOffset="6"/>
+    <component base="zeropercent" xOffset="639" yOffset="-393"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="756"/>
-  <anchor x="69" y="0" name="bottom_1"/>
-  <anchor x="495" y="0" name="bottom_2"/>
-  <anchor x="282" y="0" name="caret_1"/>
-  <anchor x="257" y="526" name="top_1"/>
-  <anchor x="684" y="748" name="top_2"/>
+  <anchor x="292" y="0" name="caret_1"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="383"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
   <advance width="1068"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="541" y="0" name="bottom_2"/>
-  <anchor x="857" y="0" name="bottom_3"/>
   <anchor x="328" y="0" name="caret_1"/>
-  <anchor x="699" y="0" name="caret_2"/>
-  <anchor x="210" y="526" name="top_1"/>
-  <anchor x="598" y="734" name="top_2"/>
-  <anchor x="914" y="734" name="top_3"/>
+  <anchor x="647" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="749"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="516" y="0" name="bottom_2"/>
   <anchor x="374.5" y="0" name="caret_1"/>
-  <anchor x="233" y="526" name="top_1"/>
-  <anchor x="608" y="526" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="390"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="552" y="363" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="489" y="-237" type="curve" smooth="yes"/>
-      <point x="578" y="-237"/>
-      <point x="626" y="-161"/>
-      <point x="626" y="-71" type="curve" smooth="yes"/>
-      <point x="626" y="-1"/>
-      <point x="586" y="42"/>
-      <point x="517" y="42" type="curve" smooth="yes"/>
-      <point x="433" y="42"/>
-      <point x="369" y="-53"/>
-      <point x="369" y="-139" type="curve" smooth="yes"/>
-      <point x="369" y="-198"/>
-      <point x="412" y="-237"/>
-    </contour>
-    <contour>
       <point x="383" y="69" type="line"/>
       <point x="396" y="140" type="line"/>
       <point x="318" y="189" type="line"/>
@@ -94,6 +80,20 @@
       <point x="340" y="22" type="curve" smooth="yes"/>
       <point x="340" y="-33"/>
       <point x="369" y="-76"/>
+    </contour>
+    <contour>
+      <point x="489" y="-237" type="curve" smooth="yes"/>
+      <point x="578" y="-237"/>
+      <point x="626" y="-161"/>
+      <point x="626" y="-71" type="curve" smooth="yes"/>
+      <point x="626" y="-1"/>
+      <point x="586" y="42"/>
+      <point x="517" y="42" type="curve" smooth="yes"/>
+      <point x="433" y="42"/>
+      <point x="369" y="-53"/>
+      <point x="369" y="-139" type="curve" smooth="yes"/>
+      <point x="369" y="-198"/>
+      <point x="412" y="-237"/>
     </contour>
     <contour>
       <point x="490" y="-168" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/t_f.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="688"/>
-  <anchor x="125" y="0" name="bottom_1"/>
-  <anchor x="427" y="0" name="bottom_2"/>
-  <anchor x="274" y="0" name="caret_1"/>
-  <anchor x="179" y="255" name="center_1"/>
-  <anchor x="492" y="255" name="center_2"/>
-  <anchor x="271" y="670" name="top_1"/>
-  <anchor x="613" y="734" name="top_2"/>
-  <anchor x="312" y="526" name="topright_1"/>
-  <anchor x="628" y="526" name="topright_2"/>
+  <advance width="686"/>
+  <anchor x="318" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="f" xOffset="315"/>
+    <component base="tlig" xOffset="-2"/>
+    <component base="f" xOffset="313"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/t_t.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="677"/>
-  <anchor x="177" y="0" name="bottom_1"/>
-  <anchor x="493" y="0" name="bottom_2"/>
-  <anchor x="274" y="0" name="caret_1"/>
-  <anchor x="169" y="263" name="center_1"/>
-  <anchor x="507" y="263" name="center_2"/>
-  <anchor x="271" y="670" name="top_1"/>
-  <anchor x="588" y="669" name="top_2"/>
-  <anchor x="312" y="526" name="topright_1"/>
-  <anchor x="628" y="526" name="topright_2"/>
+  <anchor x="322" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="t" xOffset="319"/>
+    <component base="tlig" xOffset="-2"/>
+    <component base="t" xOffset="317"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
@@ -18,6 +18,8 @@
   </outline>
   <lib>
     <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
       <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
-      <point x="246" y="378" type="curve" smooth="yes"/>
-      <point x="372" y="378"/>
-      <point x="451" y="467"/>
-      <point x="451" y="585" type="curve" smooth="yes"/>
-      <point x="451" y="674"/>
-      <point x="386" y="732"/>
-      <point x="293" y="732" type="curve" smooth="yes"/>
-      <point x="167" y="732"/>
-      <point x="87" y="649"/>
-      <point x="87" y="532" type="curve" smooth="yes"/>
-      <point x="87" y="438"/>
-      <point x="156" y="378"/>
+      <point x="248" y="378" type="curve" smooth="yes"/>
+      <point x="375" y="378"/>
+      <point x="454" y="464"/>
+      <point x="454" y="582" type="curve" smooth="yes"/>
+      <point x="454" y="673"/>
+      <point x="387" y="732"/>
+      <point x="296" y="732" type="curve" smooth="yes"/>
+      <point x="169" y="732"/>
+      <point x="90" y="646"/>
+      <point x="90" y="528" type="curve" smooth="yes"/>
+      <point x="90" y="437"/>
+      <point x="157" y="378"/>
     </contour>
     <contour>
-      <point x="256" y="468" type="curve" smooth="yes"/>
-      <point x="215" y="468"/>
-      <point x="189" y="493"/>
-      <point x="189" y="543" type="curve" smooth="yes"/>
-      <point x="189" y="599"/>
-      <point x="229" y="642"/>
-      <point x="280" y="642" type="curve" smooth="yes"/>
-      <point x="325" y="642"/>
-      <point x="349" y="619"/>
-      <point x="349" y="572" type="curve" smooth="yes"/>
-      <point x="349" y="515"/>
-      <point x="309" y="468"/>
+      <point x="260" y="468" type="curve" smooth="yes"/>
+      <point x="217" y="468"/>
+      <point x="192" y="492"/>
+      <point x="192" y="540" type="curve" smooth="yes"/>
+      <point x="192" y="597"/>
+      <point x="232" y="642"/>
+      <point x="284" y="642" type="curve" smooth="yes"/>
+      <point x="327" y="642"/>
+      <point x="352" y="618"/>
+      <point x="352" y="570" type="curve" smooth="yes"/>
+      <point x="352" y="513"/>
+      <point x="312" y="468"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -105,6 +105,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,33 +4,6 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
-      <point x="483" y="-250" type="line"/>
-      <point x="593" y="-250" type="line"/>
-      <point x="672" y="197" type="line"/>
-      <point x="564" y="197" type="line"/>
-      <point x="558" y="165" type="line" smooth="yes"/>
-      <point x="545" y="94"/>
-      <point x="488" y="34"/>
-      <point x="430" y="34" type="curve" smooth="yes"/>
-      <point x="403" y="34"/>
-      <point x="387" y="47"/>
-      <point x="387" y="66" type="curve" smooth="yes"/>
-      <point x="387" y="92"/>
-      <point x="409" y="108"/>
-      <point x="440" y="108" type="curve"/>
-      <point x="456" y="197" type="line"/>
-      <point x="346" y="197"/>
-      <point x="276" y="141"/>
-      <point x="276" y="49" type="curve" smooth="yes"/>
-      <point x="276" y="-14"/>
-      <point x="321" y="-56"/>
-      <point x="393" y="-56" type="curve" smooth="yes"/>
-      <point x="451" y="-56"/>
-      <point x="493" y="-31"/>
-      <point x="521" y="-4" type="curve"/>
-      <point x="526" y="-4" type="line"/>
-    </contour>
-    <contour>
       <point x="706" y="330" type="line"/>
       <point x="716" y="330" type="line" smooth="yes"/>
       <point x="890" y="330"/>
@@ -66,6 +39,33 @@
       <point x="831" y="428"/>
       <point x="734" y="428" type="curve" smooth="yes"/>
       <point x="724" y="428" type="line"/>
+    </contour>
+    <contour>
+      <point x="483" y="-250" type="line"/>
+      <point x="593" y="-250" type="line"/>
+      <point x="672" y="197" type="line"/>
+      <point x="564" y="197" type="line"/>
+      <point x="558" y="165" type="line" smooth="yes"/>
+      <point x="545" y="94"/>
+      <point x="488" y="34"/>
+      <point x="430" y="34" type="curve" smooth="yes"/>
+      <point x="403" y="34"/>
+      <point x="387" y="47"/>
+      <point x="387" y="66" type="curve" smooth="yes"/>
+      <point x="387" y="92"/>
+      <point x="409" y="108"/>
+      <point x="440" y="108" type="curve"/>
+      <point x="456" y="197" type="line"/>
+      <point x="346" y="197"/>
+      <point x="276" y="141"/>
+      <point x="276" y="49" type="curve" smooth="yes"/>
+      <point x="276" y="-14"/>
+      <point x="321" y="-56"/>
+      <point x="393" y="-56" type="curve" smooth="yes"/>
+      <point x="451" y="-56"/>
+      <point x="493" y="-31"/>
+      <point x="521" y="-4" type="curve"/>
+      <point x="526" y="-4" type="line"/>
     </contour>
     <contour>
       <point x="210" y="518" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="1026"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="722" y="0" name="bottom_2"/>
-  <anchor x="464" y="0" name="caret_1"/>
-  <anchor x="317" y="734" name="top_1"/>
-  <anchor x="634" y="734" name="top_2"/>
+  <anchor x="302" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="389"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="755"/>
   <anchor x="306" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="351"/>
     <component base="flig2"/>
+    <component base="f" xOffset="351"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1377"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="1019" y="0" name="bottom_3"/>
   <anchor x="306" y="0" name="caret_1"/>
   <anchor x="657" y="0" name="caret_2"/>
-  <anchor x="317" y="734" name="top_1"/>
-  <anchor x="668" y="734" name="top_2"/>
-  <anchor x="961" y="734" name="top_3"/>
   <outline>
     <component base="flig2" xOffset="1"/>
     <component base="flig1" xOffset="351"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1363"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="482" y="0" name="bottom_2"/>
-  <anchor x="1008" y="0" name="bottom_3"/>
   <anchor x="306" y="0" name="caret_1"/>
   <anchor x="657" y="0" name="caret_2"/>
-  <anchor x="318" y="734" name="top_1"/>
-  <anchor x="669" y="734" name="top_2"/>
-  <anchor x="962" y="734" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="351"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="1019"/>
+  <advance width="1018"/>
+  <anchor x="130" y="0" name="bottom_1"/>
+  <anchor x="481" y="0" name="bottom_2"/>
+  <anchor x="829" y="0" name="bottom_3"/>
   <anchor x="306" y="0" name="caret_1"/>
   <anchor x="657" y="0" name="caret_2"/>
+  <anchor x="318" y="734" name="top_1"/>
+  <anchor x="669" y="734" name="top_2"/>
+  <anchor x="963" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="351"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="351"/>
     <component base="i" xOffset="740"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_j.glif
@@ -10,8 +10,8 @@
   <anchor x="669" y="734" name="top_2"/>
   <anchor x="963" y="734" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="351"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="351"/>
     <component base="j" xOffset="747"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1311"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="987" y="0" name="bottom_3"/>
   <anchor x="306" y="0" name="caret_1"/>
   <anchor x="657" y="0" name="caret_2"/>
-  <anchor x="314" y="716" name="top_1"/>
-  <anchor x="665" y="716" name="top_2"/>
-  <anchor x="959" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="351"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="1113"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
-  <anchor x="903" y="0" name="bottom_3"/>
   <anchor x="306" y="0" name="caret_1"/>
   <anchor x="657" y="0" name="caret_2"/>
-  <anchor x="317" y="734" name="top_1"/>
-  <anchor x="668" y="734" name="top_2"/>
-  <anchor x="1016" y="670" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="351"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="351"/>
     <component base="t" xOffset="698"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="1012"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="657" y="0" name="bottom_2"/>
   <anchor x="299" y="0" name="caret_1"/>
-  <anchor x="317" y="734" name="top_1"/>
-  <anchor x="610" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="389"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_j.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_j" format="2">
-  <advance width="670"/>
+  <advance width="671"/>
   <anchor x="132" y="0" name="bottom_1"/>
   <anchor x="444" y="-216" name="bottom_2"/>
   <anchor x="306" y="0" name="caret_1"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="960"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="636" y="0" name="bottom_2"/>
   <anchor x="299" y="0" name="caret_1"/>
-  <anchor x="317" y="734" name="top_1"/>
-  <anchor x="610" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="389"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="667"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="481" y="0" name="bottom_2"/>
   <anchor x="311" y="0" name="caret_1"/>
-  <anchor x="317" y="734" name="top_1"/>
-  <anchor x="610" y="734" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="388"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="762"/>
-  <anchor x="130" y="0" name="bottom_1"/>
-  <anchor x="557" y="0" name="bottom_2"/>
-  <anchor x="306" y="0" name="caret_1"/>
-  <anchor x="314" y="716" name="top_1"/>
-  <anchor x="665" y="670" name="top_2"/>
+  <anchor x="326" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="347"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="282" y="355"/>
       <point x="304" y="366" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="292" yOffset="-117"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="292" yOffset="-117"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="282" y="355"/>
       <point x="304" y="366" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="292" yOffset="-117"/>
+    <component base="geez-part-4" xOffset="292" yOffset="-117"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="459" y="526" name="top"/>
   <outline>
     <contour>
+      <point x="28" y="0" type="line"/>
+      <point x="159" y="0" type="line"/>
+      <point x="295" y="776" type="line"/>
+      <point x="164" y="776" type="line"/>
+    </contour>
+    <contour>
       <point x="505" y="-16" type="curve" smooth="yes"/>
       <point x="672" y="-16"/>
       <point x="788" y="123"/>
@@ -18,18 +24,6 @@
       <point x="365" y="-16"/>
     </contour>
     <contour>
-      <point x="138" y="212" type="line"/>
-      <point x="328" y="212" type="line"/>
-      <point x="341" y="324" type="line"/>
-      <point x="158" y="324" type="line"/>
-    </contour>
-    <contour>
-      <point x="28" y="0" type="line"/>
-      <point x="159" y="0" type="line"/>
-      <point x="295" y="776" type="line"/>
-      <point x="164" y="776" type="line"/>
-    </contour>
-    <contour>
       <point x="510" y="106" type="curve" smooth="yes"/>
       <point x="446" y="106"/>
       <point x="400" y="155"/>
@@ -42,6 +36,12 @@
       <point x="656" y="289" type="curve" smooth="yes"/>
       <point x="656" y="188"/>
       <point x="594" y="106"/>
+    </contour>
+    <contour>
+      <point x="138" y="212" type="line"/>
+      <point x="328" y="212" type="line"/>
+      <point x="341" y="324" type="line"/>
+      <point x="158" y="324" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="757" y="216" type="curve"/>
     </contour>
     <contour>
-      <point x="346" y="-448" type="curve" smooth="yes"/>
-      <point x="434" y="-448"/>
-      <point x="482" y="-375"/>
-      <point x="482" y="-287" type="curve" smooth="yes"/>
-      <point x="482" y="-219"/>
-      <point x="443" y="-177"/>
-      <point x="373" y="-177" type="curve" smooth="yes"/>
-      <point x="291" y="-177"/>
-      <point x="222" y="-256"/>
-      <point x="222" y="-344" type="curve" smooth="yes"/>
-      <point x="222" y="-408"/>
-      <point x="267" y="-448"/>
-    </contour>
-    <contour>
       <point x="498" y="-431" type="line"/>
       <point x="597" y="-431" type="line"/>
       <point x="712" y="230" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="536" y="-209"/>
       <point x="534" y="-221"/>
       <point x="532" y="-235" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="346" y="-448" type="curve" smooth="yes"/>
+      <point x="434" y="-448"/>
+      <point x="482" y="-375"/>
+      <point x="482" y="-287" type="curve" smooth="yes"/>
+      <point x="482" y="-219"/>
+      <point x="443" y="-177"/>
+      <point x="373" y="-177" type="curve" smooth="yes"/>
+      <point x="291" y="-177"/>
+      <point x="222" y="-256"/>
+      <point x="222" y="-344" type="curve" smooth="yes"/>
+      <point x="222" y="-408"/>
+      <point x="267" y="-448"/>
     </contour>
     <contour>
       <point x="342" y="-368" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-16"/>
-    <component base="zeropercent" xOffset="664" yOffset="1"/>
+    <component base="zeropercent" xOffset="664"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/oopen.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/oopen.glif
@@ -2,7 +2,7 @@
 <glyph name="oopen" format="2">
   <advance width="580"/>
   <unicode hex="0254"/>
-  <guideline x="47" y="363" angle="346.8367675103005"/>
+  <guideline x="47" y="363" angle="346.8367675103"/>
   <anchor x="232" y="0" name="bottom"/>
   <anchor x="332" y="0" name="ogonek"/>
   <anchor x="335" y="526" name="top"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="922"/>
+  <advance width="914"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="-1"/>
+    <component base="zeropercent"/>
     <component base="zeropercent" xOffset="404" yOffset="-394"/>
-    <component base="percentbar" xOffset="-13" yOffset="-14"/>
+    <component base="percentbar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="914"/>
   <outline>
     <contour>
-      <point x="236" y="0" type="line"/>
-      <point x="838" y="716" type="line"/>
-      <point x="719" y="716" type="line"/>
-      <point x="117" y="0" type="line"/>
+      <point x="233" y="0" type="line"/>
+      <point x="834" y="716" type="line"/>
+      <point x="715" y="716" type="line"/>
+      <point x="114" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1434"/>
+  <advance width="1432"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="percentbar"/>
     <component base="zeropercent" xOffset="404" yOffset="-394"/>
-    <component base="zeropercent" xOffset="661" yOffset="-394"/>
-    <component base="zeropercent" xOffset="916" yOffset="-393"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="664" yOffset="-394"/>
+    <component base="zeropercent" xOffset="922" yOffset="-394"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1178"/>
+  <advance width="1171"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/pha-khmer.below.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/pha-khmer.below.glif
@@ -10,7 +10,7 @@
       <point x="-386" y="-214" type="line"/>
       <point x="-311" y="-281" type="line"/>
       <point x="-191" y="-281" type="line"/>
-      <point x="-150.24099999999999" y="-50" type="line"/>
+      <point x="-150.241" y="-50" type="line"/>
       <point x="-307" y="-50" type="line"/>
       <point x="-319" y="-118" type="line"/>
       <point x="-282" y="-118" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/quotesingle.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/quotesingle.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="92" y="490" type="line"/>
-      <point x="211" y="490" type="line" name="hr00"/>
+      <point x="211" y="490" type="line"/>
       <point x="251" y="716" type="line"/>
       <point x="132" y="716" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="832"/>
-  <anchor x="92" y="0" name="bottom_1"/>
-  <anchor x="558" y="0" name="bottom_2"/>
   <anchor x="325" y="0" name="caret_1"/>
-  <anchor x="286" y="526" name="top_1"/>
-  <anchor x="746" y="734" name="top_2"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="428"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
-  <advance width="1177"/>
-  <anchor x="138" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
-  <anchor x="955" y="0" name="bottom_3"/>
+  <advance width="1166"/>
   <anchor x="371" y="0" name="caret_1"/>
-  <anchor x="780" y="0" name="caret_2"/>
-  <anchor x="239" y="526" name="top_1"/>
-  <anchor x="662" y="734" name="top_2"/>
-  <anchor x="1013" y="734" name="top_3"/>
+  <anchor x="710" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="411"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="847"/>
-  <anchor x="166" y="0" name="bottom_1"/>
-  <anchor x="589" y="0" name="bottom_2"/>
   <anchor x="423.5" y="0" name="caret_1"/>
-  <anchor x="258" y="526" name="top_1"/>
-  <anchor x="681" y="526" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="432"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="550" y="360" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="500" y="-250" type="curve" smooth="yes"/>
-      <point x="591" y="-250"/>
-      <point x="642" y="-175"/>
-      <point x="642" y="-83" type="curve" smooth="yes"/>
-      <point x="642" y="-12"/>
-      <point x="601" y="32"/>
-      <point x="531" y="32" type="curve" smooth="yes"/>
-      <point x="444" y="32"/>
-      <point x="372" y="-60"/>
-      <point x="372" y="-147" type="curve" smooth="yes"/>
-      <point x="372" y="-209"/>
-      <point x="418" y="-250"/>
-    </contour>
-    <contour>
       <point x="391" y="63" type="line"/>
       <point x="407" y="151" type="line"/>
       <point x="320" y="205" type="line"/>
@@ -94,6 +80,20 @@
       <point x="339" y="27" type="curve" smooth="yes"/>
       <point x="339" y="-29"/>
       <point x="368" y="-70"/>
+    </contour>
+    <contour>
+      <point x="500" y="-250" type="curve" smooth="yes"/>
+      <point x="591" y="-250"/>
+      <point x="642" y="-175"/>
+      <point x="642" y="-83" type="curve" smooth="yes"/>
+      <point x="642" y="-12"/>
+      <point x="601" y="32"/>
+      <point x="531" y="32" type="curve" smooth="yes"/>
+      <point x="444" y="32"/>
+      <point x="372" y="-60"/>
+      <point x="372" y="-147" type="curve" smooth="yes"/>
+      <point x="372" y="-209"/>
+      <point x="418" y="-250"/>
     </contour>
     <contour>
       <point x="498" y="-170" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/schwa.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/schwa.glif
@@ -39,12 +39,4 @@
       <point x="553" y="128"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
-      <string>=|e</string>
-      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
-      <string>=|e</string>
-    </dict>
-  </lib>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="759"/>
-  <anchor x="210" y="0" name="bottom_1"/>
-  <anchor x="485" y="0" name="bottom_2"/>
-  <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="206" y="255" name="center_1"/>
-  <anchor x="557" y="255" name="center_2"/>
-  <anchor x="318" y="670" name="top_1"/>
-  <anchor x="672" y="734" name="top_2"/>
-  <anchor x="395" y="526" name="topright_1"/>
-  <anchor x="764" y="526" name="topright_2"/>
+  <anchor x="373" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="355"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="766"/>
-  <anchor x="209" y="0" name="bottom_1"/>
-  <anchor x="561" y="0" name="bottom_2"/>
-  <anchor x="323" y="0" name="caret_1"/>
-  <anchor x="206" y="255" name="center_1"/>
-  <anchor x="557" y="255" name="center_2"/>
-  <anchor x="318" y="670" name="top_1"/>
-  <anchor x="669" y="670" name="top_2"/>
-  <anchor x="394" y="526" name="topright_1"/>
-  <anchor x="745" y="526" name="topright_2"/>
+  <anchor x="393" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="351"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/zeropercent.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zeropercent" format="2">
-  <advance width="420"/>
+  <advance width="440"/>
   <outline>
     <contour>
-      <point x="254" y="378" type="curve" smooth="yes"/>
-      <point x="376" y="378"/>
-      <point x="459" y="463"/>
-      <point x="459" y="579" type="curve" smooth="yes"/>
-      <point x="459" y="667"/>
-      <point x="397" y="732"/>
-      <point x="300" y="732" type="curve" smooth="yes"/>
+      <point x="248" y="378" type="curve" smooth="yes"/>
+      <point x="377" y="378"/>
+      <point x="455" y="464"/>
+      <point x="455" y="577" type="curve" smooth="yes"/>
+      <point x="455" y="665"/>
+      <point x="390" y="732"/>
+      <point x="295" y="732" type="curve" smooth="yes"/>
       <point x="166" y="732"/>
-      <point x="92" y="645"/>
-      <point x="92" y="535" type="curve" smooth="yes"/>
-      <point x="92" y="447"/>
-      <point x="160" y="378"/>
+      <point x="88" y="646"/>
+      <point x="88" y="533" type="curve" smooth="yes"/>
+      <point x="88" y="445"/>
+      <point x="153" y="378"/>
     </contour>
     <contour>
-      <point x="265" y="476" type="curve" smooth="yes"/>
-      <point x="228" y="476"/>
-      <point x="201" y="503"/>
-      <point x="201" y="544" type="curve" smooth="yes"/>
-      <point x="201" y="591"/>
-      <point x="231" y="634"/>
-      <point x="286" y="634" type="curve" smooth="yes"/>
-      <point x="324" y="634"/>
-      <point x="350" y="607"/>
-      <point x="350" y="567" type="curve" smooth="yes"/>
-      <point x="350" y="519"/>
-      <point x="321" y="476"/>
+      <point x="261" y="476" type="curve" smooth="yes"/>
+      <point x="223" y="476"/>
+      <point x="197" y="503"/>
+      <point x="197" y="543" type="curve" smooth="yes"/>
+      <point x="197" y="591"/>
+      <point x="226" y="634"/>
+      <point x="282" y="634" type="curve" smooth="yes"/>
+      <point x="320" y="634"/>
+      <point x="346" y="607"/>
+      <point x="346" y="567" type="curve" smooth="yes"/>
+      <point x="346" y="519"/>
+      <point x="317" y="476"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -62,6 +62,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/F_ivethousand-roman.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/F_ivethousand-roman.glif
@@ -30,24 +30,24 @@
       <point x="191" y="61" type="line"/>
     </contour>
     <contour>
-      <point x="183" y="195" type="line"/>
-      <point x="270" y="195" type="line" smooth="yes"/>
-      <point x="381" y="195"/>
-      <point x="465" y="269"/>
-      <point x="465" y="374" type="curve" smooth="yes"/>
-      <point x="465" y="466"/>
-      <point x="408" y="519"/>
-      <point x="321" y="519" type="curve" smooth="yes"/>
-      <point x="242" y="519" type="line"/>
-      <point x="230" y="460" type="line"/>
-      <point x="315" y="460" type="line" smooth="yes"/>
-      <point x="370" y="460"/>
-      <point x="403" y="421"/>
-      <point x="403" y="370" type="curve" smooth="yes"/>
-      <point x="403" y="302"/>
-      <point x="356" y="254"/>
-      <point x="287" y="254" type="curve" smooth="yes"/>
-      <point x="195" y="254" type="line"/>
+      <point x="183" y="196" type="line"/>
+      <point x="270" y="196" type="line" smooth="yes"/>
+      <point x="381" y="196"/>
+      <point x="465" y="270"/>
+      <point x="465" y="375" type="curve" smooth="yes"/>
+      <point x="465" y="467"/>
+      <point x="408" y="520"/>
+      <point x="321" y="520" type="curve" smooth="yes"/>
+      <point x="242" y="520" type="line"/>
+      <point x="230" y="461" type="line"/>
+      <point x="315" y="461" type="line" smooth="yes"/>
+      <point x="370" y="461"/>
+      <point x="403" y="422"/>
+      <point x="403" y="371" type="curve" smooth="yes"/>
+      <point x="403" y="303"/>
+      <point x="356" y="255"/>
+      <point x="287" y="255" type="curve" smooth="yes"/>
+      <point x="195" y="255" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/baht.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/baht.glif
@@ -27,7 +27,7 @@
       <point x="420" y="333"/>
       <point x="454" y="273"/>
       <point x="454" y="209" type="curve" smooth="yes"/>
-      <point x="454" y="110.99999999999999"/>
+      <point x="454" y="110"/>
       <point x="379" y="61"/>
       <point x="301" y="61" type="curve" smooth="yes"/>
       <point x="106" y="61" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="634" y="315" type="line"/>
+      <point x="653" y="315" type="line" smooth="yes"/>
+      <point x="820" y="315"/>
+      <point x="948" y="433"/>
+      <point x="948" y="587" type="curve" smooth="yes"/>
+      <point x="948" y="683"/>
+      <point x="887" y="751"/>
+      <point x="776" y="751" type="curve" smooth="yes"/>
+      <point x="656" y="751"/>
+      <point x="558" y="662"/>
+      <point x="558" y="554" type="curve" smooth="yes"/>
+      <point x="558" y="499"/>
+      <point x="589" y="465"/>
+      <point x="639" y="465" type="curve" smooth="yes"/>
+      <point x="689" y="465"/>
+      <point x="731" y="505"/>
+      <point x="731" y="551" type="curve" smooth="yes"/>
+      <point x="731" y="586"/>
+      <point x="707" y="609"/>
+      <point x="673" y="609" type="curve" smooth="yes"/>
+      <point x="650" y="609"/>
+      <point x="627" y="599"/>
+      <point x="613" y="577" type="curve"/>
+      <point x="627" y="576" type="line"/>
+      <point x="629" y="586" type="line" smooth="yes"/>
+      <point x="642" y="651"/>
+      <point x="706" y="686"/>
+      <point x="764" y="686" type="curve" smooth="yes"/>
+      <point x="835" y="686"/>
+      <point x="874" y="643"/>
+      <point x="874" y="577" type="curve" smooth="yes"/>
+      <point x="874" y="464"/>
+      <point x="784" y="379"/>
+      <point x="665" y="379" type="curve" smooth="yes"/>
+      <point x="646" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="489" y="-250" type="line"/>
       <point x="560" y="-250" type="line"/>
       <point x="636" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="506" y="-12"/>
       <point x="532" y="16" type="curve"/>
       <point x="536" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="190" y="506" type="curve" smooth="yes"/>
+      <point x="175" y="506"/>
+      <point x="165" y="518"/>
+      <point x="165" y="532" type="curve" smooth="yes"/>
+      <point x="165" y="550"/>
+      <point x="183" y="569"/>
+      <point x="201" y="569" type="curve" smooth="yes"/>
+      <point x="216" y="569"/>
+      <point x="226" y="557"/>
+      <point x="226" y="543" type="curve" smooth="yes"/>
+      <point x="226" y="524"/>
+      <point x="208" y="506"/>
     </contour>
     <contour>
       <point x="174" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="324" y="379"/>
       <point x="205" y="379" type="curve" smooth="yes"/>
       <point x="186" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="190" y="506" type="curve" smooth="yes"/>
-      <point x="175" y="506"/>
-      <point x="165" y="518"/>
-      <point x="165" y="532" type="curve" smooth="yes"/>
-      <point x="165" y="550"/>
-      <point x="183" y="569"/>
-      <point x="201" y="569" type="curve" smooth="yes"/>
-      <point x="216" y="569"/>
-      <point x="226" y="557"/>
-      <point x="226" y="543" type="curve" smooth="yes"/>
-      <point x="226" y="524"/>
-      <point x="208" y="506"/>
-    </contour>
-    <contour>
-      <point x="634" y="315" type="line"/>
-      <point x="653" y="315" type="line" smooth="yes"/>
-      <point x="820" y="315"/>
-      <point x="948" y="433"/>
-      <point x="948" y="587" type="curve" smooth="yes"/>
-      <point x="948" y="683"/>
-      <point x="887" y="751"/>
-      <point x="776" y="751" type="curve" smooth="yes"/>
-      <point x="656" y="751"/>
-      <point x="558" y="662"/>
-      <point x="558" y="554" type="curve" smooth="yes"/>
-      <point x="558" y="499"/>
-      <point x="589" y="465"/>
-      <point x="639" y="465" type="curve" smooth="yes"/>
-      <point x="689" y="465"/>
-      <point x="731" y="505"/>
-      <point x="731" y="551" type="curve" smooth="yes"/>
-      <point x="731" y="586"/>
-      <point x="707" y="609"/>
-      <point x="673" y="609" type="curve" smooth="yes"/>
-      <point x="650" y="609"/>
-      <point x="627" y="599"/>
-      <point x="613" y="577" type="curve"/>
-      <point x="627" y="576" type="line"/>
-      <point x="629" y="586" type="line" smooth="yes"/>
-      <point x="642" y="651"/>
-      <point x="706" y="686"/>
-      <point x="764" y="686" type="curve" smooth="yes"/>
-      <point x="835" y="686"/>
-      <point x="874" y="643"/>
-      <point x="874" y="577" type="curve" smooth="yes"/>
-      <point x="874" y="464"/>
-      <point x="784" y="379"/>
-      <point x="665" y="379" type="curve" smooth="yes"/>
-      <point x="646" y="379" type="line"/>
     </contour>
     <contour>
       <point x="650" y="506" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="75" y="-250" type="line"/>
-      <point x="94" y="-250" type="line" smooth="yes"/>
-      <point x="261" y="-250"/>
-      <point x="389" y="-132"/>
-      <point x="389" y="22" type="curve" smooth="yes"/>
-      <point x="389" y="118"/>
-      <point x="328" y="186"/>
-      <point x="217" y="186" type="curve" smooth="yes"/>
-      <point x="97" y="186"/>
-      <point x="-1" y="97"/>
-      <point x="-1" y="-11" type="curve" smooth="yes"/>
-      <point x="-1" y="-66"/>
-      <point x="30" y="-100"/>
-      <point x="80" y="-100" type="curve" smooth="yes"/>
-      <point x="130" y="-100"/>
-      <point x="172" y="-60"/>
-      <point x="172" y="-14" type="curve" smooth="yes"/>
-      <point x="172" y="21"/>
-      <point x="148" y="44"/>
-      <point x="114" y="44" type="curve" smooth="yes"/>
-      <point x="91" y="44"/>
-      <point x="68" y="34"/>
-      <point x="54" y="12" type="curve"/>
-      <point x="68" y="11" type="line"/>
-      <point x="70" y="21" type="line" smooth="yes"/>
-      <point x="83" y="86"/>
-      <point x="147" y="121"/>
-      <point x="205" y="121" type="curve" smooth="yes"/>
-      <point x="276" y="121"/>
-      <point x="315" y="78"/>
-      <point x="315" y="12" type="curve" smooth="yes"/>
-      <point x="315" y="-101"/>
-      <point x="225" y="-186"/>
-      <point x="106" y="-186" type="curve" smooth="yes"/>
-      <point x="87" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="91" y="-59" type="curve" smooth="yes"/>
-      <point x="76" y="-59"/>
-      <point x="66" y="-47"/>
-      <point x="66" y="-33" type="curve" smooth="yes"/>
-      <point x="66" y="-15"/>
-      <point x="84" y="4"/>
-      <point x="102" y="4" type="curve" smooth="yes"/>
-      <point x="117" y="4"/>
-      <point x="127" y="-8"/>
-      <point x="127" y="-22" type="curve" smooth="yes"/>
-      <point x="127" y="-41"/>
-      <point x="109" y="-59"/>
-    </contour>
-    <contour>
       <point x="535" y="-250" type="line"/>
       <point x="554" y="-250" type="line" smooth="yes"/>
       <point x="721" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="685" y="-186"/>
       <point x="566" y="-186" type="curve" smooth="yes"/>
       <point x="547" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="91" y="-59" type="curve" smooth="yes"/>
+      <point x="76" y="-59"/>
+      <point x="66" y="-47"/>
+      <point x="66" y="-33" type="curve" smooth="yes"/>
+      <point x="66" y="-15"/>
+      <point x="84" y="4"/>
+      <point x="102" y="4" type="curve" smooth="yes"/>
+      <point x="117" y="4"/>
+      <point x="127" y="-8"/>
+      <point x="127" y="-22" type="curve" smooth="yes"/>
+      <point x="127" y="-41"/>
+      <point x="109" y="-59"/>
+    </contour>
+    <contour>
+      <point x="75" y="-250" type="line"/>
+      <point x="94" y="-250" type="line" smooth="yes"/>
+      <point x="261" y="-250"/>
+      <point x="389" y="-132"/>
+      <point x="389" y="22" type="curve" smooth="yes"/>
+      <point x="389" y="118"/>
+      <point x="328" y="186"/>
+      <point x="217" y="186" type="curve" smooth="yes"/>
+      <point x="97" y="186"/>
+      <point x="-1" y="97"/>
+      <point x="-1" y="-11" type="curve" smooth="yes"/>
+      <point x="-1" y="-66"/>
+      <point x="30" y="-100"/>
+      <point x="80" y="-100" type="curve" smooth="yes"/>
+      <point x="130" y="-100"/>
+      <point x="172" y="-60"/>
+      <point x="172" y="-14" type="curve" smooth="yes"/>
+      <point x="172" y="21"/>
+      <point x="148" y="44"/>
+      <point x="114" y="44" type="curve" smooth="yes"/>
+      <point x="91" y="44"/>
+      <point x="68" y="34"/>
+      <point x="54" y="12" type="curve"/>
+      <point x="68" y="11" type="line"/>
+      <point x="70" y="21" type="line" smooth="yes"/>
+      <point x="83" y="86"/>
+      <point x="147" y="121"/>
+      <point x="205" y="121" type="curve" smooth="yes"/>
+      <point x="276" y="121"/>
+      <point x="315" y="78"/>
+      <point x="315" y="12" type="curve" smooth="yes"/>
+      <point x="315" y="-101"/>
+      <point x="225" y="-186"/>
+      <point x="106" y="-186" type="curve" smooth="yes"/>
+      <point x="87" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="551" y="-59" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
-  <advance width="969"/>
-  <anchor x="197" y="0" name="bottom_1"/>
-  <anchor x="682" y="0" name="bottom_2"/>
-  <anchor x="484.5" y="0" name="caret_1"/>
-  <anchor x="323" y="716" name="top_1"/>
-  <anchor x="808" y="716" name="top_2"/>
+  <advance width="970"/>
+  <anchor x="265" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="370"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="690"/>
   <anchor x="274" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="311"/>
     <component base="flig2"/>
+    <component base="f" xOffset="311"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1279"/>
-  <anchor x="168" y="0" name="bottom_1"/>
-  <anchor x="595" y="0" name="bottom_2"/>
-  <anchor x="1021" y="0" name="bottom_3"/>
-  <anchor x="426.333" y="0" name="caret_1"/>
-  <anchor x="852.667" y="0" name="caret_2"/>
-  <anchor x="294" y="716" name="top_1"/>
-  <anchor x="721" y="716" name="top_2"/>
-  <anchor x="1147" y="716" name="top_3"/>
+  <anchor x="268" y="0" name="caret_1"/>
+  <anchor x="583" y="0" name="caret_2"/>
   <outline>
     <component base="flig2" xOffset="1"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1241"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="576" y="0" name="bottom_2"/>
-  <anchor x="989" y="0" name="bottom_3"/>
-  <anchor x="413.667" y="0" name="caret_1"/>
-  <anchor x="827.333" y="0" name="caret_2"/>
-  <anchor x="288" y="716" name="top_1"/>
-  <anchor x="702" y="716" name="top_2"/>
-  <anchor x="1115" y="716" name="top_3"/>
+  <anchor x="268" y="0" name="caret_1"/>
+  <anchor x="578" y="0" name="caret_2"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="895"/>
+  <advance width="899"/>
+  <anchor x="118" y="0" name="bottom_1"/>
+  <anchor x="428" y="0" name="bottom_2"/>
+  <anchor x="739" y="0" name="bottom_3"/>
   <anchor x="276" y="0" name="caret_1"/>
   <anchor x="585" y="0" name="caret_2"/>
+  <anchor x="244" y="716" name="top_1"/>
+  <anchor x="554" y="716" name="top_2"/>
+  <anchor x="865" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="311"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="311"/>
     <component base="i" xOffset="673"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_j.glif
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_j" format="2">
-  <advance width="895"/>
+  <advance width="898"/>
   <anchor x="104" y="0" name="bottom_1"/>
   <anchor x="403" y="0" name="bottom_2"/>
-  <anchor x="701" y="0" name="bottom_3"/>
+  <anchor x="701" y="-216" name="bottom_3"/>
   <anchor x="298.333" y="0" name="caret_1"/>
   <anchor x="596.667" y="0" name="caret_2"/>
   <anchor x="230" y="716" name="top_1"/>
   <anchor x="529" y="716" name="top_2"/>
   <anchor x="827" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="310"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="310"/>
     <component base="j" xOffset="672"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1185"/>
-  <anchor x="153" y="0" name="bottom_1"/>
-  <anchor x="548" y="0" name="bottom_2"/>
-  <anchor x="943" y="0" name="bottom_3"/>
-  <anchor x="395" y="0" name="caret_1"/>
-  <anchor x="790" y="0" name="caret_2"/>
-  <anchor x="279" y="716" name="top_1"/>
-  <anchor x="674" y="716" name="top_2"/>
-  <anchor x="1069" y="716" name="top_3"/>
+  <anchor x="266" y="0" name="caret_1"/>
+  <anchor x="580" y="0" name="caret_2"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="991"/>
-  <anchor x="120" y="0" name="bottom_1"/>
-  <anchor x="451" y="0" name="bottom_2"/>
-  <anchor x="781" y="0" name="bottom_3"/>
-  <anchor x="330.333" y="0" name="caret_1"/>
-  <anchor x="660.667" y="0" name="caret_2"/>
-  <anchor x="246" y="716" name="top_1"/>
-  <anchor x="577" y="716" name="top_2"/>
-  <anchor x="907" y="716" name="top_3"/>
+  <anchor x="273" y="0" name="caret_1"/>
+  <anchor x="591" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="310"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="310"/>
     <component base="t" xOffset="625"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
-  <advance width="930"/>
-  <anchor x="188" y="0" name="bottom_1"/>
-  <anchor x="653" y="0" name="bottom_2"/>
-  <anchor x="465" y="0" name="caret_1"/>
-  <anchor x="314" y="716" name="top_1"/>
-  <anchor x="779" y="716" name="top_2"/>
+  <advance width="931"/>
+  <anchor x="268" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="370"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_i.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_i" format="2">
-  <advance width="585"/>
+  <advance width="589"/>
   <anchor x="101" y="0" name="bottom_1"/>
   <anchor x="394" y="0" name="bottom_2"/>
-  <anchor x="292.5" y="0" name="caret_1"/>
+  <anchor x="263" y="0" name="caret_1"/>
   <anchor x="227" y="716" name="top_1"/>
   <anchor x="520" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_j.glif
@@ -2,8 +2,8 @@
 <glyph name="f_j" format="2">
   <advance width="588"/>
   <anchor x="102" y="0" name="bottom_1"/>
-  <anchor x="396" y="0" name="bottom_2"/>
-  <anchor x="294" y="0" name="caret_1"/>
+  <anchor x="396" y="-216" name="bottom_2"/>
+  <anchor x="262" y="0" name="caret_1"/>
   <anchor x="228" y="716" name="top_1"/>
   <anchor x="522" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="875"/>
-  <anchor x="174" y="0" name="bottom_1"/>
-  <anchor x="611" y="0" name="bottom_2"/>
-  <anchor x="437.5" y="0" name="caret_1"/>
-  <anchor x="300" y="716" name="top_1"/>
-  <anchor x="737" y="716" name="top_2"/>
+  <anchor x="268" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="368"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
-  <advance width="582"/>
-  <anchor x="101" y="0" name="bottom_1"/>
-  <anchor x="392" y="0" name="bottom_2"/>
+  <advance width="583"/>
   <anchor x="291" y="0" name="caret_1"/>
-  <anchor x="227" y="716" name="top_1"/>
-  <anchor x="518" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="370"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="681"/>
-  <anchor x="125" y="0" name="bottom_1"/>
-  <anchor x="466" y="0" name="bottom_2"/>
-  <anchor x="340.5" y="0" name="caret_1"/>
-  <anchor x="251" y="716" name="top_1"/>
-  <anchor x="592" y="716" name="top_2"/>
+  <advance width="682"/>
+  <anchor x="291" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="316"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="315" y="366"/>
       <point x="343" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="308" yOffset="-111"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="308" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="315" y="366"/>
       <point x="343" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="308" yOffset="-111"/>
+    <component base="geez-part-4" xOffset="308" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="785"/>
+  <advance width="786"/>
   <unicode hex="044E"/>
   <anchor x="450" y="510" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -1,8 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.loclBGR" format="2">
-  <advance width="787"/>
+  <advance width="786"/>
   <anchor x="438" y="510" name="top"/>
   <outline>
+    <contour>
+      <point x="30" y="0" type="line"/>
+      <point x="95" y="0" type="line"/>
+      <point x="220" y="716" type="line"/>
+      <point x="155" y="716" type="line"/>
+    </contour>
     <contour>
       <point x="466" y="-16" type="curve" smooth="yes"/>
       <point x="639" y="-16"/>
@@ -18,18 +24,6 @@
       <point x="338" y="-16"/>
     </contour>
     <contour>
-      <point x="108" y="229" type="line"/>
-      <point x="280" y="229" type="line"/>
-      <point x="282" y="286" type="line"/>
-      <point x="117" y="286" type="line"/>
-    </contour>
-    <contour>
-      <point x="30" y="0" type="line"/>
-      <point x="95" y="0" type="line"/>
-      <point x="220" y="716" type="line"/>
-      <point x="155" y="716" type="line"/>
-    </contour>
-    <contour>
       <point x="482" y="41" type="curve" smooth="yes"/>
       <point x="378" y="41"/>
       <point x="322" y="114"/>
@@ -42,6 +36,12 @@
       <point x="675" y="278" type="curve" smooth="yes"/>
       <point x="675" y="140"/>
       <point x="600" y="41"/>
+    </contour>
+    <contour>
+      <point x="108" y="229" type="line"/>
+      <point x="280" y="229" type="line"/>
+      <point x="282" y="286" type="line"/>
+      <point x="117" y="286" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.sc.glif
@@ -26,8 +26,8 @@
     <contour>
       <point x="128" y="268" type="line"/>
       <point x="310" y="268" type="line"/>
-      <point x="318" y="330" type="line"/>
-      <point x="142" y="330" type="line"/>
+      <point x="318" y="326" type="line"/>
+      <point x="142" y="326" type="line"/>
     </contour>
     <contour>
       <point x="537" y="43" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="710" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="356" y="-391" type="curve" smooth="yes"/>
-      <point x="422" y="-391"/>
-      <point x="480" y="-335"/>
-      <point x="480" y="-261" type="curve" smooth="yes"/>
-      <point x="480" y="-201"/>
-      <point x="436" y="-156"/>
-      <point x="373" y="-156" type="curve" smooth="yes"/>
-      <point x="305" y="-156"/>
-      <point x="247" y="-212"/>
-      <point x="247" y="-286" type="curve" smooth="yes"/>
-      <point x="247" y="-347"/>
-      <point x="291" y="-391"/>
-    </contour>
-    <contour>
       <point x="494" y="-385" type="line"/>
       <point x="574" y="-385" type="line"/>
       <point x="677" y="202" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="531" y="-169"/>
       <point x="530" y="-179"/>
       <point x="528" y="-190" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="356" y="-391" type="curve" smooth="yes"/>
+      <point x="422" y="-391"/>
+      <point x="480" y="-335"/>
+      <point x="480" y="-261" type="curve" smooth="yes"/>
+      <point x="480" y="-201"/>
+      <point x="436" y="-156"/>
+      <point x="373" y="-156" type="curve" smooth="yes"/>
+      <point x="305" y="-156"/>
+      <point x="247" y="-212"/>
+      <point x="247" y="-286" type="curve" smooth="yes"/>
+      <point x="247" y="-347"/>
+      <point x="291" y="-391"/>
     </contour>
     <contour>
       <point x="357" y="-322" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-6"/>
-    <component base="zeropercent" xOffset="669" yOffset="31"/>
+    <component base="zeropercent" xOffset="663"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="827"/>
+  <advance width="825"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" xOffset="10"/>
-    <component base="zeropercent" xOffset="343" yOffset="-406"/>
-    <component base="percentbar" xOffset="-19" yOffset="-13"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="333" yOffset="-406"/>
+    <component base="percentbar" xOffset="-13"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/percentbar.glif
@@ -3,8 +3,8 @@
   <advance width="826"/>
   <outline>
     <contour>
-      <point x="163" y="-3" type="line"/>
-      <point x="755" y="689" type="line"/>
+      <point x="162" y="-3" type="line"/>
+      <point x="755" y="690" type="line"/>
       <point x="724" y="719" type="line"/>
       <point x="131" y="26" type="line"/>
     </contour>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1388"/>
+  <advance width="1357"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="percentbar" xOffset="-23" yOffset="-14"/>
-    <component base="zeropercent" xOffset="343" yOffset="-406"/>
-    <component base="zeropercent" xOffset="618" yOffset="-406"/>
-    <component base="zeropercent" xOffset="893" yOffset="-405"/>
+    <component base="zeropercent" xOffset="333" yOffset="-406"/>
+    <component base="percentbar" xOffset="-13"/>
+    <component base="zeropercent" xOffset="599" yOffset="-406"/>
+    <component base="zeropercent" xOffset="865" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1107"/>
+  <advance width="1091"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="342" yOffset="-406"/>
-    <component base="percentbar" xOffset="-11" yOffset="1"/>
-    <component base="zeropercent" xOffset="623" yOffset="-406"/>
+    <component base="zeropercent" xOffset="333" yOffset="-406"/>
+    <component base="percentbar" xOffset="-13"/>
+    <component base="zeropercent" xOffset="599" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="749"/>
-  <anchor x="142" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
-  <anchor x="374.5" y="0" name="caret_1"/>
-  <anchor x="232" y="510" name="top_1"/>
-  <anchor x="607" y="510" name="top_2"/>
+  <anchor x="305" y="0" name="caret_1"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
-  <advance width="1059"/>
-  <anchor x="132" y="0" name="bottom_1"/>
-  <anchor x="485" y="0" name="bottom_2"/>
-  <anchor x="838" y="0" name="bottom_3"/>
+  <advance width="1060"/>
   <anchor x="353" y="0" name="caret_1"/>
-  <anchor x="706" y="0" name="caret_2"/>
-  <anchor x="222" y="510" name="top_1"/>
-  <anchor x="575" y="510" name="top_2"/>
-  <anchor x="928" y="510" name="top_3"/>
+  <anchor x="639" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="745"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="514" y="0" name="bottom_2"/>
   <anchor x="372.5" y="0" name="caret_1"/>
-  <anchor x="231" y="510" name="top_1"/>
-  <anchor x="604" y="510" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="537" y="352" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="468" y="-202" type="curve" smooth="yes"/>
-      <point x="536" y="-202"/>
-      <point x="597" y="-145"/>
-      <point x="597" y="-71" type="curve" smooth="yes"/>
-      <point x="597" y="-10"/>
-      <point x="551" y="37"/>
-      <point x="485" y="37" type="curve" smooth="yes"/>
-      <point x="415" y="37"/>
-      <point x="355" y="-19"/>
-      <point x="355" y="-95" type="curve" smooth="yes"/>
-      <point x="355" y="-157"/>
-      <point x="401" y="-202"/>
-    </contour>
-    <contour>
       <point x="373" y="58" type="line"/>
       <point x="387" y="138" type="line"/>
       <point x="322" y="170" type="line"/>
@@ -94,6 +80,20 @@
       <point x="320" y="35" type="curve" smooth="yes"/>
       <point x="320" y="-16"/>
       <point x="345" y="-59"/>
+    </contour>
+    <contour>
+      <point x="468" y="-202" type="curve" smooth="yes"/>
+      <point x="536" y="-202"/>
+      <point x="597" y="-145"/>
+      <point x="597" y="-71" type="curve" smooth="yes"/>
+      <point x="597" y="-10"/>
+      <point x="551" y="37"/>
+      <point x="485" y="37" type="curve" smooth="yes"/>
+      <point x="415" y="37"/>
+      <point x="355" y="-19"/>
+      <point x="355" y="-95" type="curve" smooth="yes"/>
+      <point x="355" y="-157"/>
+      <point x="401" y="-202"/>
     </contour>
     <contour>
       <point x="467" y="-133" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/t_f.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="686"/>
-  <anchor x="127" y="0" name="bottom_1"/>
-  <anchor x="470" y="0" name="bottom_2"/>
-  <anchor x="343" y="0" name="caret_1"/>
-  <anchor x="172" y="255" name="center_1"/>
-  <anchor x="515" y="255" name="center_2"/>
-  <anchor x="217" y="510" name="top_1"/>
-  <anchor x="560" y="510" name="top_2"/>
-  <anchor x="711" y="510" name="topright_1"/>
-  <anchor x="711" y="510" name="topright_2"/>
+  <advance width="689"/>
+  <anchor x="347" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="f" xOffset="307"/>
+    <component base="tlig" xOffset="2"/>
+    <component base="f" xOffset="309"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/t_t.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="677"/>
-  <anchor x="124" y="0" name="bottom_1"/>
-  <anchor x="463" y="0" name="bottom_2"/>
-  <anchor x="338.5" y="0" name="caret_1"/>
-  <anchor x="169" y="255" name="center_1"/>
-  <anchor x="508" y="255" name="center_2"/>
-  <anchor x="214" y="510" name="top_1"/>
-  <anchor x="553" y="510" name="top_2"/>
-  <anchor x="702" y="510" name="topright_1"/>
-  <anchor x="702" y="510" name="topright_2"/>
+  <advance width="680"/>
+  <anchor x="351" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="t" xOffset="312"/>
+    <component base="tlig" xOffset="2"/>
+    <component base="t" xOffset="314"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ustraight-cy.glif
@@ -18,6 +18,8 @@
   </outline>
   <lib>
     <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
       <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="232" y="390" type="curve" smooth="yes"/>
-      <point x="345" y="390"/>
-      <point x="425" y="475"/>
-      <point x="425" y="583" type="curve" smooth="yes"/>
-      <point x="425" y="669"/>
-      <point x="369" y="732"/>
-      <point x="282" y="732" type="curve" smooth="yes"/>
-      <point x="169" y="732"/>
-      <point x="88" y="647"/>
-      <point x="88" y="539" type="curve" smooth="yes"/>
-      <point x="88" y="453"/>
-      <point x="146" y="390"/>
+      <point x="242" y="390" type="curve" smooth="yes"/>
+      <point x="351" y="390"/>
+      <point x="428" y="475"/>
+      <point x="428" y="583" type="curve" smooth="yes"/>
+      <point x="428" y="669"/>
+      <point x="371" y="732"/>
+      <point x="285" y="732" type="curve" smooth="yes"/>
+      <point x="176" y="732"/>
+      <point x="99" y="647"/>
+      <point x="99" y="539" type="curve" smooth="yes"/>
+      <point x="99" y="453"/>
+      <point x="156" y="390"/>
     </contour>
     <contour>
-      <point x="239" y="443" type="curve" smooth="yes"/>
-      <point x="186" y="443"/>
-      <point x="150" y="483"/>
-      <point x="150" y="544" type="curve" smooth="yes"/>
-      <point x="150" y="621"/>
-      <point x="200" y="679"/>
-      <point x="275" y="679" type="curve" smooth="yes"/>
-      <point x="327" y="679"/>
-      <point x="364" y="639"/>
-      <point x="364" y="578" type="curve" smooth="yes"/>
-      <point x="364" y="501"/>
-      <point x="313" y="443"/>
+      <point x="249" y="443" type="curve" smooth="yes"/>
+      <point x="197" y="443"/>
+      <point x="160" y="483"/>
+      <point x="160" y="544" type="curve" smooth="yes"/>
+      <point x="160" y="621"/>
+      <point x="208" y="679"/>
+      <point x="278" y="679" type="curve" smooth="yes"/>
+      <point x="330" y="679"/>
+      <point x="367" y="639"/>
+      <point x="367" y="578" type="curve" smooth="yes"/>
+      <point x="367" y="501"/>
+      <point x="319" y="443"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -62,6 +62,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="634" y="315" type="line"/>
+      <point x="653" y="315" type="line" smooth="yes"/>
+      <point x="820" y="315"/>
+      <point x="948" y="433"/>
+      <point x="948" y="587" type="curve" smooth="yes"/>
+      <point x="948" y="683"/>
+      <point x="887" y="751"/>
+      <point x="776" y="751" type="curve" smooth="yes"/>
+      <point x="656" y="751"/>
+      <point x="558" y="662"/>
+      <point x="558" y="554" type="curve" smooth="yes"/>
+      <point x="558" y="499"/>
+      <point x="589" y="465"/>
+      <point x="639" y="465" type="curve" smooth="yes"/>
+      <point x="689" y="465"/>
+      <point x="731" y="505"/>
+      <point x="731" y="551" type="curve" smooth="yes"/>
+      <point x="731" y="586"/>
+      <point x="707" y="609"/>
+      <point x="673" y="609" type="curve" smooth="yes"/>
+      <point x="650" y="609"/>
+      <point x="627" y="599"/>
+      <point x="613" y="577" type="curve"/>
+      <point x="627" y="576" type="line"/>
+      <point x="629" y="586" type="line" smooth="yes"/>
+      <point x="642" y="651"/>
+      <point x="706" y="686"/>
+      <point x="764" y="686" type="curve" smooth="yes"/>
+      <point x="835" y="686"/>
+      <point x="874" y="643"/>
+      <point x="874" y="577" type="curve" smooth="yes"/>
+      <point x="874" y="464"/>
+      <point x="784" y="379"/>
+      <point x="665" y="379" type="curve" smooth="yes"/>
+      <point x="646" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="489" y="-250" type="line"/>
       <point x="560" y="-250" type="line"/>
       <point x="636" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="506" y="-12"/>
       <point x="532" y="16" type="curve"/>
       <point x="536" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="190" y="506" type="curve" smooth="yes"/>
+      <point x="175" y="506"/>
+      <point x="165" y="518"/>
+      <point x="165" y="532" type="curve" smooth="yes"/>
+      <point x="165" y="550"/>
+      <point x="183" y="569"/>
+      <point x="201" y="569" type="curve" smooth="yes"/>
+      <point x="216" y="569"/>
+      <point x="226" y="557"/>
+      <point x="226" y="543" type="curve" smooth="yes"/>
+      <point x="226" y="524"/>
+      <point x="208" y="506"/>
     </contour>
     <contour>
       <point x="174" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="324" y="379"/>
       <point x="205" y="379" type="curve" smooth="yes"/>
       <point x="186" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="190" y="506" type="curve" smooth="yes"/>
-      <point x="175" y="506"/>
-      <point x="165" y="518"/>
-      <point x="165" y="532" type="curve" smooth="yes"/>
-      <point x="165" y="550"/>
-      <point x="183" y="569"/>
-      <point x="201" y="569" type="curve" smooth="yes"/>
-      <point x="216" y="569"/>
-      <point x="226" y="557"/>
-      <point x="226" y="543" type="curve" smooth="yes"/>
-      <point x="226" y="524"/>
-      <point x="208" y="506"/>
-    </contour>
-    <contour>
-      <point x="634" y="315" type="line"/>
-      <point x="653" y="315" type="line" smooth="yes"/>
-      <point x="820" y="315"/>
-      <point x="948" y="433"/>
-      <point x="948" y="587" type="curve" smooth="yes"/>
-      <point x="948" y="683"/>
-      <point x="887" y="751"/>
-      <point x="776" y="751" type="curve" smooth="yes"/>
-      <point x="656" y="751"/>
-      <point x="558" y="662"/>
-      <point x="558" y="554" type="curve" smooth="yes"/>
-      <point x="558" y="499"/>
-      <point x="589" y="465"/>
-      <point x="639" y="465" type="curve" smooth="yes"/>
-      <point x="689" y="465"/>
-      <point x="731" y="505"/>
-      <point x="731" y="551" type="curve" smooth="yes"/>
-      <point x="731" y="586"/>
-      <point x="707" y="609"/>
-      <point x="673" y="609" type="curve" smooth="yes"/>
-      <point x="650" y="609"/>
-      <point x="627" y="599"/>
-      <point x="613" y="577" type="curve"/>
-      <point x="627" y="576" type="line"/>
-      <point x="629" y="586" type="line" smooth="yes"/>
-      <point x="642" y="651"/>
-      <point x="706" y="686"/>
-      <point x="764" y="686" type="curve" smooth="yes"/>
-      <point x="835" y="686"/>
-      <point x="874" y="643"/>
-      <point x="874" y="577" type="curve" smooth="yes"/>
-      <point x="874" y="464"/>
-      <point x="784" y="379"/>
-      <point x="665" y="379" type="curve" smooth="yes"/>
-      <point x="646" y="379" type="line"/>
     </contour>
     <contour>
       <point x="650" y="506" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="75" y="-250" type="line"/>
-      <point x="94" y="-250" type="line" smooth="yes"/>
-      <point x="261" y="-250"/>
-      <point x="389" y="-132"/>
-      <point x="389" y="22" type="curve" smooth="yes"/>
-      <point x="389" y="118"/>
-      <point x="328" y="186"/>
-      <point x="217" y="186" type="curve" smooth="yes"/>
-      <point x="97" y="186"/>
-      <point x="-1" y="97"/>
-      <point x="-1" y="-11" type="curve" smooth="yes"/>
-      <point x="-1" y="-66"/>
-      <point x="30" y="-100"/>
-      <point x="80" y="-100" type="curve" smooth="yes"/>
-      <point x="130" y="-100"/>
-      <point x="172" y="-60"/>
-      <point x="172" y="-14" type="curve" smooth="yes"/>
-      <point x="172" y="21"/>
-      <point x="148" y="44"/>
-      <point x="114" y="44" type="curve" smooth="yes"/>
-      <point x="91" y="44"/>
-      <point x="68" y="34"/>
-      <point x="54" y="12" type="curve"/>
-      <point x="68" y="11" type="line"/>
-      <point x="70" y="21" type="line" smooth="yes"/>
-      <point x="83" y="86"/>
-      <point x="147" y="121"/>
-      <point x="205" y="121" type="curve" smooth="yes"/>
-      <point x="276" y="121"/>
-      <point x="315" y="78"/>
-      <point x="315" y="12" type="curve" smooth="yes"/>
-      <point x="315" y="-101"/>
-      <point x="225" y="-186"/>
-      <point x="106" y="-186" type="curve" smooth="yes"/>
-      <point x="87" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="91" y="-59" type="curve" smooth="yes"/>
-      <point x="76" y="-59"/>
-      <point x="66" y="-47"/>
-      <point x="66" y="-33" type="curve" smooth="yes"/>
-      <point x="66" y="-15"/>
-      <point x="84" y="4"/>
-      <point x="102" y="4" type="curve" smooth="yes"/>
-      <point x="117" y="4"/>
-      <point x="127" y="-8"/>
-      <point x="127" y="-22" type="curve" smooth="yes"/>
-      <point x="127" y="-41"/>
-      <point x="109" y="-59"/>
-    </contour>
-    <contour>
       <point x="535" y="-250" type="line"/>
       <point x="554" y="-250" type="line" smooth="yes"/>
       <point x="721" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="685" y="-186"/>
       <point x="566" y="-186" type="curve" smooth="yes"/>
       <point x="547" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="91" y="-59" type="curve" smooth="yes"/>
+      <point x="76" y="-59"/>
+      <point x="66" y="-47"/>
+      <point x="66" y="-33" type="curve" smooth="yes"/>
+      <point x="66" y="-15"/>
+      <point x="84" y="4"/>
+      <point x="102" y="4" type="curve" smooth="yes"/>
+      <point x="117" y="4"/>
+      <point x="127" y="-8"/>
+      <point x="127" y="-22" type="curve" smooth="yes"/>
+      <point x="127" y="-41"/>
+      <point x="109" y="-59"/>
+    </contour>
+    <contour>
+      <point x="75" y="-250" type="line"/>
+      <point x="94" y="-250" type="line" smooth="yes"/>
+      <point x="261" y="-250"/>
+      <point x="389" y="-132"/>
+      <point x="389" y="22" type="curve" smooth="yes"/>
+      <point x="389" y="118"/>
+      <point x="328" y="186"/>
+      <point x="217" y="186" type="curve" smooth="yes"/>
+      <point x="97" y="186"/>
+      <point x="-1" y="97"/>
+      <point x="-1" y="-11" type="curve" smooth="yes"/>
+      <point x="-1" y="-66"/>
+      <point x="30" y="-100"/>
+      <point x="80" y="-100" type="curve" smooth="yes"/>
+      <point x="130" y="-100"/>
+      <point x="172" y="-60"/>
+      <point x="172" y="-14" type="curve" smooth="yes"/>
+      <point x="172" y="21"/>
+      <point x="148" y="44"/>
+      <point x="114" y="44" type="curve" smooth="yes"/>
+      <point x="91" y="44"/>
+      <point x="68" y="34"/>
+      <point x="54" y="12" type="curve"/>
+      <point x="68" y="11" type="line"/>
+      <point x="70" y="21" type="line" smooth="yes"/>
+      <point x="83" y="86"/>
+      <point x="147" y="121"/>
+      <point x="205" y="121" type="curve" smooth="yes"/>
+      <point x="276" y="121"/>
+      <point x="315" y="78"/>
+      <point x="315" y="12" type="curve" smooth="yes"/>
+      <point x="315" y="-101"/>
+      <point x="225" y="-186"/>
+      <point x="106" y="-186" type="curve" smooth="yes"/>
+      <point x="87" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="551" y="-59" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
-  <advance width="969"/>
-  <anchor x="197" y="0" name="bottom_1"/>
-  <anchor x="682" y="0" name="bottom_2"/>
-  <anchor x="484.5" y="0" name="caret_1"/>
-  <anchor x="323" y="716" name="top_1"/>
-  <anchor x="808" y="716" name="top_2"/>
+  <advance width="970"/>
+  <anchor x="275" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="370"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="690"/>
   <anchor x="274" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="311"/>
     <component base="flig2"/>
+    <component base="f" xOffset="311"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1279"/>
-  <anchor x="168" y="0" name="bottom_1"/>
-  <anchor x="595" y="0" name="bottom_2"/>
-  <anchor x="1021" y="0" name="bottom_3"/>
-  <anchor x="426.333" y="0" name="caret_1"/>
-  <anchor x="852.667" y="0" name="caret_2"/>
-  <anchor x="294" y="716" name="top_1"/>
-  <anchor x="721" y="716" name="top_2"/>
-  <anchor x="1147" y="716" name="top_3"/>
+  <anchor x="274" y="0" name="caret_1"/>
+  <anchor x="583" y="0" name="caret_2"/>
   <outline>
     <component base="flig2" xOffset="1"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1241"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="576" y="0" name="bottom_2"/>
-  <anchor x="989" y="0" name="bottom_3"/>
-  <anchor x="413.667" y="0" name="caret_1"/>
-  <anchor x="827.333" y="0" name="caret_2"/>
-  <anchor x="288" y="716" name="top_1"/>
-  <anchor x="702" y="716" name="top_2"/>
-  <anchor x="1115" y="716" name="top_3"/>
+  <anchor x="266" y="0" name="caret_1"/>
+  <anchor x="578" y="0" name="caret_2"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="895"/>
+  <advance width="899"/>
+  <anchor x="117" y="0" name="bottom_1"/>
+  <anchor x="429" y="0" name="bottom_2"/>
+  <anchor x="738" y="0" name="bottom_3"/>
   <anchor x="276" y="0" name="caret_1"/>
   <anchor x="585" y="0" name="caret_2"/>
+  <anchor x="251" y="716" name="top_1"/>
+  <anchor x="550" y="716" name="top_2"/>
+  <anchor x="863" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="311"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="311"/>
     <component base="i" xOffset="673"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_j.glif
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_j" format="2">
-  <advance width="895"/>
+  <advance width="898"/>
   <anchor x="104" y="0" name="bottom_1"/>
   <anchor x="403" y="0" name="bottom_2"/>
-  <anchor x="701" y="0" name="bottom_3"/>
+  <anchor x="701" y="-216" name="bottom_3"/>
   <anchor x="298.333" y="0" name="caret_1"/>
   <anchor x="596.667" y="0" name="caret_2"/>
   <anchor x="230" y="716" name="top_1"/>
   <anchor x="529" y="716" name="top_2"/>
   <anchor x="827" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="310"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="310"/>
     <component base="j" xOffset="672"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1185"/>
-  <anchor x="153" y="0" name="bottom_1"/>
-  <anchor x="548" y="0" name="bottom_2"/>
-  <anchor x="943" y="0" name="bottom_3"/>
   <anchor x="395" y="0" name="caret_1"/>
   <anchor x="790" y="0" name="caret_2"/>
-  <anchor x="279" y="716" name="top_1"/>
-  <anchor x="674" y="716" name="top_2"/>
-  <anchor x="1069" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="991"/>
-  <anchor x="120" y="0" name="bottom_1"/>
-  <anchor x="451" y="0" name="bottom_2"/>
-  <anchor x="781" y="0" name="bottom_3"/>
-  <anchor x="330.333" y="0" name="caret_1"/>
-  <anchor x="660.667" y="0" name="caret_2"/>
-  <anchor x="246" y="716" name="top_1"/>
-  <anchor x="577" y="716" name="top_2"/>
-  <anchor x="907" y="716" name="top_3"/>
+  <anchor x="270" y="0" name="caret_1"/>
+  <anchor x="601" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="310"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="310"/>
     <component base="t" xOffset="625"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
-  <advance width="930"/>
-  <anchor x="188" y="0" name="bottom_1"/>
-  <anchor x="653" y="0" name="bottom_2"/>
-  <anchor x="465" y="0" name="caret_1"/>
-  <anchor x="314" y="716" name="top_1"/>
-  <anchor x="779" y="716" name="top_2"/>
+  <advance width="931"/>
+  <anchor x="268" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="370"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_i.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_i" format="2">
-  <advance width="585"/>
+  <advance width="589"/>
   <anchor x="101" y="0" name="bottom_1"/>
   <anchor x="394" y="0" name="bottom_2"/>
-  <anchor x="292.5" y="0" name="caret_1"/>
+  <anchor x="273" y="0" name="caret_1"/>
   <anchor x="227" y="716" name="top_1"/>
   <anchor x="520" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_j.glif
@@ -2,8 +2,8 @@
 <glyph name="f_j" format="2">
   <advance width="588"/>
   <anchor x="102" y="0" name="bottom_1"/>
-  <anchor x="396" y="0" name="bottom_2"/>
-  <anchor x="294" y="0" name="caret_1"/>
+  <anchor x="396" y="-216" name="bottom_2"/>
+  <anchor x="271" y="0" name="caret_1"/>
   <anchor x="228" y="716" name="top_1"/>
   <anchor x="522" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="875"/>
-  <anchor x="174" y="0" name="bottom_1"/>
-  <anchor x="611" y="0" name="bottom_2"/>
-  <anchor x="437.5" y="0" name="caret_1"/>
-  <anchor x="300" y="716" name="top_1"/>
-  <anchor x="737" y="716" name="top_2"/>
+  <anchor x="270" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="368"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
-  <advance width="582"/>
-  <anchor x="101" y="0" name="bottom_1"/>
-  <anchor x="392" y="0" name="bottom_2"/>
+  <advance width="583"/>
   <anchor x="291" y="0" name="caret_1"/>
-  <anchor x="227" y="716" name="top_1"/>
-  <anchor x="518" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="370"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="681"/>
-  <anchor x="125" y="0" name="bottom_1"/>
-  <anchor x="466" y="0" name="bottom_2"/>
-  <anchor x="340.5" y="0" name="caret_1"/>
-  <anchor x="251" y="716" name="top_1"/>
-  <anchor x="592" y="716" name="top_2"/>
+  <advance width="682"/>
+  <anchor x="301" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="316"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="315" y="366"/>
       <point x="343" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="308" yOffset="-111"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="308" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="315" y="366"/>
       <point x="343" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="308" yOffset="-111"/>
+    <component base="geez-part-4" xOffset="308" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="438" y="510" name="top"/>
   <outline>
     <contour>
+      <point x="20" y="0" type="line"/>
+      <point x="105" y="0" type="line"/>
+      <point x="230" y="716" type="line"/>
+      <point x="145" y="716" type="line"/>
+    </contour>
+    <contour>
       <point x="466" y="-16" type="curve" smooth="yes"/>
       <point x="639" y="-16"/>
       <point x="751" y="117"/>
@@ -18,18 +24,6 @@
       <point x="338" y="-16"/>
     </contour>
     <contour>
-      <point x="104" y="219" type="line"/>
-      <point x="276" y="219" type="line"/>
-      <point x="282" y="296" type="line"/>
-      <point x="117" y="296" type="line"/>
-    </contour>
-    <contour>
-      <point x="20" y="0" type="line"/>
-      <point x="105" y="0" type="line"/>
-      <point x="230" y="716" type="line"/>
-      <point x="145" y="716" type="line"/>
-    </contour>
-    <contour>
       <point x="476" y="61" type="curve" smooth="yes"/>
       <point x="388" y="61"/>
       <point x="332" y="134"/>
@@ -42,6 +36,12 @@
       <point x="665" y="278" type="curve" smooth="yes"/>
       <point x="665" y="160"/>
       <point x="590" y="61"/>
+    </contour>
+    <contour>
+      <point x="104" y="219" type="line"/>
+      <point x="276" y="219" type="line"/>
+      <point x="282" y="296" type="line"/>
+      <point x="117" y="296" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="710" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="356" y="-391" type="curve" smooth="yes"/>
-      <point x="422" y="-391"/>
-      <point x="480" y="-335"/>
-      <point x="480" y="-261" type="curve" smooth="yes"/>
-      <point x="480" y="-201"/>
-      <point x="436" y="-156"/>
-      <point x="373" y="-156" type="curve" smooth="yes"/>
-      <point x="305" y="-156"/>
-      <point x="247" y="-212"/>
-      <point x="247" y="-286" type="curve" smooth="yes"/>
-      <point x="247" y="-347"/>
-      <point x="291" y="-391"/>
-    </contour>
-    <contour>
       <point x="494" y="-385" type="line"/>
       <point x="574" y="-385" type="line"/>
       <point x="677" y="202" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="531" y="-169"/>
       <point x="530" y="-179"/>
       <point x="528" y="-190" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="356" y="-391" type="curve" smooth="yes"/>
+      <point x="422" y="-391"/>
+      <point x="480" y="-335"/>
+      <point x="480" y="-261" type="curve" smooth="yes"/>
+      <point x="480" y="-201"/>
+      <point x="436" y="-156"/>
+      <point x="373" y="-156" type="curve" smooth="yes"/>
+      <point x="305" y="-156"/>
+      <point x="247" y="-212"/>
+      <point x="247" y="-286" type="curve" smooth="yes"/>
+      <point x="247" y="-347"/>
+      <point x="291" y="-391"/>
     </contour>
     <contour>
       <point x="357" y="-322" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-6"/>
-    <component base="zeropercent" xOffset="669" yOffset="31"/>
+    <component base="zeropercent" xOffset="664"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="827"/>
+  <advance width="825"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" xOffset="11" yOffset="-1"/>
-    <component base="zeropercent" xOffset="343" yOffset="-407"/>
-    <component base="percentbar" xOffset="-19" yOffset="-14"/>
+    <component base="zeropercent" xOffset="1"/>
+    <component base="zeropercent" xOffset="333" yOffset="-406"/>
+    <component base="percentbar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="825"/>
   <outline>
     <contour>
-      <point x="171" y="-7" type="line"/>
-      <point x="763" y="685" type="line"/>
-      <point x="716" y="725" type="line"/>
-      <point x="123" y="32" type="line"/>
+      <point x="158" y="-8" type="line"/>
+      <point x="750" y="684" type="line"/>
+      <point x="703" y="724" type="line"/>
+      <point x="110" y="31" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1388"/>
+  <advance width="1357"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="percentbar" xOffset="-22" yOffset="-14"/>
-    <component base="zeropercent" xOffset="343" yOffset="-406"/>
-    <component base="zeropercent" xOffset="618" yOffset="-406"/>
-    <component base="zeropercent" xOffset="893" yOffset="-405"/>
+    <component base="zeropercent" xOffset="1"/>
+    <component base="zeropercent" xOffset="333" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="599" yOffset="-406"/>
+    <component base="zeropercent" xOffset="865" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1107"/>
+  <advance width="1091"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="342" yOffset="-406"/>
-    <component base="percentbar" xOffset="-12"/>
-    <component base="zeropercent" xOffset="623" yOffset="-406"/>
+    <component base="zeropercent" xOffset="1"/>
+    <component base="zeropercent" xOffset="333" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="599" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="749"/>
-  <anchor x="142" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
-  <anchor x="374.5" y="0" name="caret_1"/>
-  <anchor x="232" y="510" name="top_1"/>
-  <anchor x="607" y="510" name="top_2"/>
+  <anchor x="291" y="0" name="caret_1"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
-  <advance width="1059"/>
-  <anchor x="132" y="0" name="bottom_1"/>
-  <anchor x="485" y="0" name="bottom_2"/>
-  <anchor x="838" y="0" name="bottom_3"/>
+  <advance width="1060"/>
   <anchor x="353" y="0" name="caret_1"/>
-  <anchor x="706" y="0" name="caret_2"/>
-  <anchor x="222" y="510" name="top_1"/>
-  <anchor x="575" y="510" name="top_2"/>
-  <anchor x="928" y="510" name="top_3"/>
+  <anchor x="641" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="745"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="514" y="0" name="bottom_2"/>
   <anchor x="372.5" y="0" name="caret_1"/>
-  <anchor x="231" y="510" name="top_1"/>
-  <anchor x="604" y="510" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="537" y="352" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="468" y="-202" type="curve" smooth="yes"/>
-      <point x="536" y="-202"/>
-      <point x="597" y="-145"/>
-      <point x="597" y="-71" type="curve" smooth="yes"/>
-      <point x="597" y="-10"/>
-      <point x="551" y="37"/>
-      <point x="485" y="37" type="curve" smooth="yes"/>
-      <point x="415" y="37"/>
-      <point x="355" y="-19"/>
-      <point x="355" y="-95" type="curve" smooth="yes"/>
-      <point x="355" y="-157"/>
-      <point x="401" y="-202"/>
-    </contour>
-    <contour>
       <point x="373" y="58" type="line"/>
       <point x="387" y="138" type="line"/>
       <point x="322" y="170" type="line"/>
@@ -94,6 +80,20 @@
       <point x="320" y="35" type="curve" smooth="yes"/>
       <point x="320" y="-16"/>
       <point x="345" y="-59"/>
+    </contour>
+    <contour>
+      <point x="468" y="-202" type="curve" smooth="yes"/>
+      <point x="536" y="-202"/>
+      <point x="597" y="-145"/>
+      <point x="597" y="-71" type="curve" smooth="yes"/>
+      <point x="597" y="-10"/>
+      <point x="551" y="37"/>
+      <point x="485" y="37" type="curve" smooth="yes"/>
+      <point x="415" y="37"/>
+      <point x="355" y="-19"/>
+      <point x="355" y="-95" type="curve" smooth="yes"/>
+      <point x="355" y="-157"/>
+      <point x="401" y="-202"/>
     </contour>
     <contour>
       <point x="467" y="-133" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="686"/>
-  <anchor x="127" y="0" name="bottom_1"/>
-  <anchor x="470" y="0" name="bottom_2"/>
-  <anchor x="343" y="0" name="caret_1"/>
-  <anchor x="172" y="255" name="center_1"/>
-  <anchor x="515" y="255" name="center_2"/>
-  <anchor x="217" y="510" name="top_1"/>
-  <anchor x="560" y="510" name="top_2"/>
-  <anchor x="711" y="510" name="topright_1"/>
-  <anchor x="711" y="510" name="topright_2"/>
+  <advance width="687"/>
+  <anchor x="325" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="307"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="677"/>
-  <anchor x="124" y="0" name="bottom_1"/>
-  <anchor x="463" y="0" name="bottom_2"/>
-  <anchor x="338.5" y="0" name="caret_1"/>
-  <anchor x="169" y="255" name="center_1"/>
-  <anchor x="508" y="255" name="center_2"/>
-  <anchor x="214" y="510" name="top_1"/>
-  <anchor x="553" y="510" name="top_2"/>
-  <anchor x="702" y="510" name="topright_1"/>
-  <anchor x="702" y="510" name="topright_2"/>
+  <advance width="678"/>
+  <anchor x="349" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="312"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="232" y="390" type="curve" smooth="yes"/>
-      <point x="345" y="390"/>
-      <point x="429" y="475"/>
-      <point x="429" y="583" type="curve" smooth="yes"/>
-      <point x="429" y="669"/>
-      <point x="369" y="732"/>
-      <point x="282" y="732" type="curve" smooth="yes"/>
-      <point x="169" y="732"/>
-      <point x="84" y="647"/>
-      <point x="84" y="539" type="curve" smooth="yes"/>
-      <point x="84" y="453"/>
-      <point x="146" y="390"/>
+      <point x="238" y="390" type="curve" smooth="yes"/>
+      <point x="352" y="390"/>
+      <point x="436" y="475"/>
+      <point x="436" y="583" type="curve" smooth="yes"/>
+      <point x="436" y="669"/>
+      <point x="375" y="732"/>
+      <point x="289" y="732" type="curve" smooth="yes"/>
+      <point x="175" y="732"/>
+      <point x="91" y="647"/>
+      <point x="91" y="539" type="curve" smooth="yes"/>
+      <point x="91" y="453"/>
+      <point x="152" y="390"/>
     </contour>
     <contour>
-      <point x="240" y="460" type="curve" smooth="yes"/>
-      <point x="191" y="460"/>
-      <point x="162" y="489"/>
-      <point x="162" y="545" type="curve" smooth="yes"/>
-      <point x="162" y="616"/>
-      <point x="204" y="662"/>
-      <point x="274" y="662" type="curve" smooth="yes"/>
-      <point x="322" y="662"/>
-      <point x="352" y="633"/>
-      <point x="352" y="577" type="curve" smooth="yes"/>
-      <point x="352" y="506"/>
-      <point x="309" y="460"/>
+      <point x="246" y="460" type="curve" smooth="yes"/>
+      <point x="198" y="460"/>
+      <point x="168" y="489"/>
+      <point x="168" y="545" type="curve" smooth="yes"/>
+      <point x="168" y="616"/>
+      <point x="211" y="662"/>
+      <point x="281" y="662" type="curve" smooth="yes"/>
+      <point x="329" y="662"/>
+      <point x="359" y="633"/>
+      <point x="359" y="577" type="curve" smooth="yes"/>
+      <point x="359" y="506"/>
+      <point x="316" y="460"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -62,6 +62,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="634" y="315" type="line"/>
+      <point x="653" y="315" type="line" smooth="yes"/>
+      <point x="820" y="315"/>
+      <point x="948" y="433"/>
+      <point x="948" y="587" type="curve" smooth="yes"/>
+      <point x="948" y="683"/>
+      <point x="887" y="751"/>
+      <point x="776" y="751" type="curve" smooth="yes"/>
+      <point x="656" y="751"/>
+      <point x="558" y="662"/>
+      <point x="558" y="554" type="curve" smooth="yes"/>
+      <point x="558" y="499"/>
+      <point x="589" y="465"/>
+      <point x="639" y="465" type="curve" smooth="yes"/>
+      <point x="689" y="465"/>
+      <point x="731" y="505"/>
+      <point x="731" y="551" type="curve" smooth="yes"/>
+      <point x="731" y="586"/>
+      <point x="707" y="609"/>
+      <point x="673" y="609" type="curve" smooth="yes"/>
+      <point x="650" y="609"/>
+      <point x="627" y="599"/>
+      <point x="613" y="577" type="curve"/>
+      <point x="627" y="576" type="line"/>
+      <point x="629" y="586" type="line" smooth="yes"/>
+      <point x="642" y="651"/>
+      <point x="706" y="686"/>
+      <point x="764" y="686" type="curve" smooth="yes"/>
+      <point x="835" y="686"/>
+      <point x="874" y="643"/>
+      <point x="874" y="577" type="curve" smooth="yes"/>
+      <point x="874" y="464"/>
+      <point x="784" y="379"/>
+      <point x="665" y="379" type="curve" smooth="yes"/>
+      <point x="646" y="379" type="line"/>
+    </contour>
+    <contour>
       <point x="489" y="-250" type="line"/>
       <point x="560" y="-250" type="line"/>
       <point x="636" y="182" type="line"/>
@@ -29,6 +66,20 @@
       <point x="506" y="-12"/>
       <point x="532" y="16" type="curve"/>
       <point x="536" y="16" type="line"/>
+    </contour>
+    <contour>
+      <point x="190" y="506" type="curve" smooth="yes"/>
+      <point x="175" y="506"/>
+      <point x="165" y="518"/>
+      <point x="165" y="532" type="curve" smooth="yes"/>
+      <point x="165" y="550"/>
+      <point x="183" y="569"/>
+      <point x="201" y="569" type="curve" smooth="yes"/>
+      <point x="216" y="569"/>
+      <point x="226" y="557"/>
+      <point x="226" y="543" type="curve" smooth="yes"/>
+      <point x="226" y="524"/>
+      <point x="208" y="506"/>
     </contour>
     <contour>
       <point x="174" y="315" type="line"/>
@@ -66,57 +117,6 @@
       <point x="324" y="379"/>
       <point x="205" y="379" type="curve" smooth="yes"/>
       <point x="186" y="379" type="line"/>
-    </contour>
-    <contour>
-      <point x="190" y="506" type="curve" smooth="yes"/>
-      <point x="175" y="506"/>
-      <point x="165" y="518"/>
-      <point x="165" y="532" type="curve" smooth="yes"/>
-      <point x="165" y="550"/>
-      <point x="183" y="569"/>
-      <point x="201" y="569" type="curve" smooth="yes"/>
-      <point x="216" y="569"/>
-      <point x="226" y="557"/>
-      <point x="226" y="543" type="curve" smooth="yes"/>
-      <point x="226" y="524"/>
-      <point x="208" y="506"/>
-    </contour>
-    <contour>
-      <point x="634" y="315" type="line"/>
-      <point x="653" y="315" type="line" smooth="yes"/>
-      <point x="820" y="315"/>
-      <point x="948" y="433"/>
-      <point x="948" y="587" type="curve" smooth="yes"/>
-      <point x="948" y="683"/>
-      <point x="887" y="751"/>
-      <point x="776" y="751" type="curve" smooth="yes"/>
-      <point x="656" y="751"/>
-      <point x="558" y="662"/>
-      <point x="558" y="554" type="curve" smooth="yes"/>
-      <point x="558" y="499"/>
-      <point x="589" y="465"/>
-      <point x="639" y="465" type="curve" smooth="yes"/>
-      <point x="689" y="465"/>
-      <point x="731" y="505"/>
-      <point x="731" y="551" type="curve" smooth="yes"/>
-      <point x="731" y="586"/>
-      <point x="707" y="609"/>
-      <point x="673" y="609" type="curve" smooth="yes"/>
-      <point x="650" y="609"/>
-      <point x="627" y="599"/>
-      <point x="613" y="577" type="curve"/>
-      <point x="627" y="576" type="line"/>
-      <point x="629" y="586" type="line" smooth="yes"/>
-      <point x="642" y="651"/>
-      <point x="706" y="686"/>
-      <point x="764" y="686" type="curve" smooth="yes"/>
-      <point x="835" y="686"/>
-      <point x="874" y="643"/>
-      <point x="874" y="577" type="curve" smooth="yes"/>
-      <point x="874" y="464"/>
-      <point x="784" y="379"/>
-      <point x="665" y="379" type="curve" smooth="yes"/>
-      <point x="646" y="379" type="line"/>
     </contour>
     <contour>
       <point x="650" y="506" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="75" y="-250" type="line"/>
-      <point x="94" y="-250" type="line" smooth="yes"/>
-      <point x="261" y="-250"/>
-      <point x="389" y="-132"/>
-      <point x="389" y="22" type="curve" smooth="yes"/>
-      <point x="389" y="118"/>
-      <point x="328" y="186"/>
-      <point x="217" y="186" type="curve" smooth="yes"/>
-      <point x="97" y="186"/>
-      <point x="-1" y="97"/>
-      <point x="-1" y="-11" type="curve" smooth="yes"/>
-      <point x="-1" y="-66"/>
-      <point x="30" y="-100"/>
-      <point x="80" y="-100" type="curve" smooth="yes"/>
-      <point x="130" y="-100"/>
-      <point x="172" y="-60"/>
-      <point x="172" y="-14" type="curve" smooth="yes"/>
-      <point x="172" y="21"/>
-      <point x="148" y="44"/>
-      <point x="114" y="44" type="curve" smooth="yes"/>
-      <point x="91" y="44"/>
-      <point x="68" y="34"/>
-      <point x="54" y="12" type="curve"/>
-      <point x="68" y="11" type="line"/>
-      <point x="70" y="21" type="line" smooth="yes"/>
-      <point x="83" y="86"/>
-      <point x="147" y="121"/>
-      <point x="205" y="121" type="curve" smooth="yes"/>
-      <point x="276" y="121"/>
-      <point x="315" y="78"/>
-      <point x="315" y="12" type="curve" smooth="yes"/>
-      <point x="315" y="-101"/>
-      <point x="225" y="-186"/>
-      <point x="106" y="-186" type="curve" smooth="yes"/>
-      <point x="87" y="-186" type="line"/>
-    </contour>
-    <contour>
-      <point x="91" y="-59" type="curve" smooth="yes"/>
-      <point x="76" y="-59"/>
-      <point x="66" y="-47"/>
-      <point x="66" y="-33" type="curve" smooth="yes"/>
-      <point x="66" y="-15"/>
-      <point x="84" y="4"/>
-      <point x="102" y="4" type="curve" smooth="yes"/>
-      <point x="117" y="4"/>
-      <point x="127" y="-8"/>
-      <point x="127" y="-22" type="curve" smooth="yes"/>
-      <point x="127" y="-41"/>
-      <point x="109" y="-59"/>
-    </contour>
-    <contour>
       <point x="535" y="-250" type="line"/>
       <point x="554" y="-250" type="line" smooth="yes"/>
       <point x="721" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="685" y="-186"/>
       <point x="566" y="-186" type="curve" smooth="yes"/>
       <point x="547" y="-186" type="line"/>
+    </contour>
+    <contour>
+      <point x="91" y="-59" type="curve" smooth="yes"/>
+      <point x="76" y="-59"/>
+      <point x="66" y="-47"/>
+      <point x="66" y="-33" type="curve" smooth="yes"/>
+      <point x="66" y="-15"/>
+      <point x="84" y="4"/>
+      <point x="102" y="4" type="curve" smooth="yes"/>
+      <point x="117" y="4"/>
+      <point x="127" y="-8"/>
+      <point x="127" y="-22" type="curve" smooth="yes"/>
+      <point x="127" y="-41"/>
+      <point x="109" y="-59"/>
+    </contour>
+    <contour>
+      <point x="75" y="-250" type="line"/>
+      <point x="94" y="-250" type="line" smooth="yes"/>
+      <point x="261" y="-250"/>
+      <point x="389" y="-132"/>
+      <point x="389" y="22" type="curve" smooth="yes"/>
+      <point x="389" y="118"/>
+      <point x="328" y="186"/>
+      <point x="217" y="186" type="curve" smooth="yes"/>
+      <point x="97" y="186"/>
+      <point x="-1" y="97"/>
+      <point x="-1" y="-11" type="curve" smooth="yes"/>
+      <point x="-1" y="-66"/>
+      <point x="30" y="-100"/>
+      <point x="80" y="-100" type="curve" smooth="yes"/>
+      <point x="130" y="-100"/>
+      <point x="172" y="-60"/>
+      <point x="172" y="-14" type="curve" smooth="yes"/>
+      <point x="172" y="21"/>
+      <point x="148" y="44"/>
+      <point x="114" y="44" type="curve" smooth="yes"/>
+      <point x="91" y="44"/>
+      <point x="68" y="34"/>
+      <point x="54" y="12" type="curve"/>
+      <point x="68" y="11" type="line"/>
+      <point x="70" y="21" type="line" smooth="yes"/>
+      <point x="83" y="86"/>
+      <point x="147" y="121"/>
+      <point x="205" y="121" type="curve" smooth="yes"/>
+      <point x="276" y="121"/>
+      <point x="315" y="78"/>
+      <point x="315" y="12" type="curve" smooth="yes"/>
+      <point x="315" y="-101"/>
+      <point x="225" y="-186"/>
+      <point x="106" y="-186" type="curve" smooth="yes"/>
+      <point x="87" y="-186" type="line"/>
     </contour>
     <contour>
       <point x="551" y="-59" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_b.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="969"/>
-  <anchor x="197" y="0" name="bottom_1"/>
-  <anchor x="682" y="0" name="bottom_2"/>
-  <anchor x="484.5" y="0" name="caret_1"/>
-  <anchor x="323" y="716" name="top_1"/>
-  <anchor x="808" y="716" name="top_2"/>
+  <anchor x="272" y="0" name="caret_1"/>
   <outline>
-    <component base="flig1"/>
-    <component base="b" xOffset="370"/>
+    <component base="flig1" xOffset="-1"/>
+    <component base="b" xOffset="369"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="690"/>
   <anchor x="274" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="311"/>
     <component base="flig2"/>
+    <component base="f" xOffset="311"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1279"/>
-  <anchor x="168" y="0" name="bottom_1"/>
-  <anchor x="595" y="0" name="bottom_2"/>
-  <anchor x="1021" y="0" name="bottom_3"/>
-  <anchor x="426.333" y="0" name="caret_1"/>
-  <anchor x="852.667" y="0" name="caret_2"/>
-  <anchor x="294" y="716" name="top_1"/>
-  <anchor x="721" y="716" name="top_2"/>
-  <anchor x="1147" y="716" name="top_3"/>
+  <anchor x="273" y="0" name="caret_1"/>
+  <anchor x="587" y="0" name="caret_2"/>
   <outline>
     <component base="flig2" xOffset="1"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1241"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="576" y="0" name="bottom_2"/>
-  <anchor x="989" y="0" name="bottom_3"/>
-  <anchor x="413.667" y="0" name="caret_1"/>
-  <anchor x="827.333" y="0" name="caret_2"/>
-  <anchor x="288" y="716" name="top_1"/>
-  <anchor x="702" y="716" name="top_2"/>
-  <anchor x="1115" y="716" name="top_3"/>
+  <anchor x="267" y="0" name="caret_1"/>
+  <anchor x="581" y="0" name="caret_2"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="895"/>
+  <advance width="899"/>
+  <anchor x="116" y="0" name="bottom_1"/>
+  <anchor x="425" y="0" name="bottom_2"/>
+  <anchor x="726" y="0" name="bottom_3"/>
   <anchor x="276" y="0" name="caret_1"/>
   <anchor x="585" y="0" name="caret_2"/>
+  <anchor x="242" y="716" name="top_1"/>
+  <anchor x="551" y="716" name="top_2"/>
+  <anchor x="852" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="311"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="311"/>
     <component base="i" xOffset="673"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_j.glif
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_j" format="2">
-  <advance width="895"/>
-  <anchor x="104" y="0" name="bottom_1"/>
-  <anchor x="403" y="0" name="bottom_2"/>
-  <anchor x="701" y="0" name="bottom_3"/>
+  <advance width="898"/>
+  <anchor x="116" y="0" name="bottom_1"/>
+  <anchor x="425" y="0" name="bottom_2"/>
+  <anchor x="726" y="-216" name="bottom_3"/>
   <anchor x="298.333" y="0" name="caret_1"/>
   <anchor x="596.667" y="0" name="caret_2"/>
-  <anchor x="230" y="716" name="top_1"/>
-  <anchor x="529" y="716" name="top_2"/>
-  <anchor x="827" y="716" name="top_3"/>
+  <anchor x="242" y="716" name="top_1"/>
+  <anchor x="551" y="716" name="top_2"/>
+  <anchor x="852" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="310"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="310"/>
     <component base="j" xOffset="672"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1185"/>
-  <anchor x="153" y="0" name="bottom_1"/>
-  <anchor x="548" y="0" name="bottom_2"/>
-  <anchor x="943" y="0" name="bottom_3"/>
-  <anchor x="395" y="0" name="caret_1"/>
-  <anchor x="790" y="0" name="caret_2"/>
-  <anchor x="279" y="716" name="top_1"/>
-  <anchor x="674" y="716" name="top_2"/>
-  <anchor x="1069" y="716" name="top_3"/>
+  <anchor x="265" y="0" name="caret_1"/>
+  <anchor x="580" y="0" name="caret_2"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="310"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
   <advance width="991"/>
-  <anchor x="120" y="0" name="bottom_1"/>
-  <anchor x="451" y="0" name="bottom_2"/>
-  <anchor x="781" y="0" name="bottom_3"/>
-  <anchor x="330.333" y="0" name="caret_1"/>
-  <anchor x="660.667" y="0" name="caret_2"/>
-  <anchor x="246" y="716" name="top_1"/>
-  <anchor x="577" y="716" name="top_2"/>
-  <anchor x="907" y="716" name="top_3"/>
+  <anchor x="270" y="0" name="caret_1"/>
+  <anchor x="601" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="310"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="310"/>
     <component base="t" xOffset="625"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_h.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="930"/>
-  <anchor x="188" y="0" name="bottom_1"/>
-  <anchor x="653" y="0" name="bottom_2"/>
-  <anchor x="465" y="0" name="caret_1"/>
-  <anchor x="314" y="716" name="top_1"/>
-  <anchor x="779" y="716" name="top_2"/>
+  <anchor x="265" y="0" name="caret_1"/>
   <outline>
-    <component base="flig1"/>
-    <component base="h" xOffset="370"/>
+    <component base="flig1" xOffset="-1"/>
+    <component base="h" xOffset="369"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_i.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_i" format="2">
-  <advance width="585"/>
+  <advance width="589"/>
   <anchor x="101" y="0" name="bottom_1"/>
   <anchor x="394" y="0" name="bottom_2"/>
-  <anchor x="292.5" y="0" name="caret_1"/>
+  <anchor x="273" y="0" name="caret_1"/>
   <anchor x="227" y="716" name="top_1"/>
   <anchor x="520" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_j.glif
@@ -2,8 +2,8 @@
 <glyph name="f_j" format="2">
   <advance width="588"/>
   <anchor x="102" y="0" name="bottom_1"/>
-  <anchor x="396" y="0" name="bottom_2"/>
-  <anchor x="294" y="0" name="caret_1"/>
+  <anchor x="396" y="-216" name="bottom_2"/>
+  <anchor x="264" y="0" name="caret_1"/>
   <anchor x="228" y="716" name="top_1"/>
   <anchor x="522" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="875"/>
-  <anchor x="174" y="0" name="bottom_1"/>
-  <anchor x="611" y="0" name="bottom_2"/>
-  <anchor x="437.5" y="0" name="caret_1"/>
-  <anchor x="300" y="716" name="top_1"/>
-  <anchor x="737" y="716" name="top_2"/>
+  <anchor x="271" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="368"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_l.glif
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
-  <advance width="582"/>
-  <anchor x="101" y="0" name="bottom_1"/>
-  <anchor x="392" y="0" name="bottom_2"/>
-  <anchor x="291" y="0" name="caret_1"/>
-  <anchor x="227" y="716" name="top_1"/>
-  <anchor x="518" y="716" name="top_2"/>
+  <advance width="581"/>
+  <anchor x="290" y="0" name="caret_1"/>
   <outline>
-    <component base="flig1"/>
-    <component base="l" xOffset="370"/>
+    <component base="flig1" xOffset="-1"/>
+    <component base="l" xOffset="369"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
-  <advance width="681"/>
-  <anchor x="125" y="0" name="bottom_1"/>
-  <anchor x="466" y="0" name="bottom_2"/>
-  <anchor x="340.5" y="0" name="caret_1"/>
-  <anchor x="251" y="716" name="top_1"/>
-  <anchor x="592" y="716" name="top_2"/>
+  <advance width="682"/>
+  <anchor x="291" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="316"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="315" y="366"/>
       <point x="343" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="308" yOffset="-111"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="308" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="315" y="366"/>
       <point x="343" y="380" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="308" yOffset="-111"/>
+    <component base="geez-part-4" xOffset="308" yOffset="-111"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.glif
@@ -1,22 +1,22 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="785"/>
+  <advance width="786"/>
   <unicode hex="044E"/>
   <anchor x="450" y="510" name="top"/>
   <outline>
     <contour>
-      <point x="473" y="-16" type="curve" smooth="yes"/>
+      <point x="465" y="-16" type="curve" smooth="yes"/>
       <point x="638" y="-16"/>
       <point x="760" y="117"/>
       <point x="760" y="283" type="curve" smooth="yes"/>
       <point x="760" y="419"/>
-      <point x="674" y="526"/>
-      <point x="520" y="526" type="curve" smooth="yes"/>
-      <point x="356" y="526"/>
-      <point x="235" y="392"/>
-      <point x="235" y="227" type="curve" smooth="yes"/>
-      <point x="235" y="91"/>
-      <point x="321" y="-16"/>
+      <point x="683" y="526"/>
+      <point x="530" y="526" type="curve" smooth="yes"/>
+      <point x="371" y="526"/>
+      <point x="235" y="414"/>
+      <point x="235" y="232" type="curve" smooth="yes"/>
+      <point x="235" y="90"/>
+      <point x="317" y="-16"/>
     </contour>
     <contour>
       <point x="9" y="0" type="line"/>
@@ -25,24 +25,24 @@
       <point x="99" y="510" type="line"/>
     </contour>
     <contour>
-      <point x="102" y="207" type="line"/>
-      <point x="284" y="207" type="line"/>
-      <point x="292" y="312" type="line"/>
-      <point x="117" y="312" type="line"/>
+      <point x="103" y="219" type="line"/>
+      <point x="285" y="219" type="line"/>
+      <point x="291" y="296" type="line"/>
+      <point x="116" y="296" type="line"/>
     </contour>
     <contour>
-      <point x="475" y="81" type="curve" smooth="yes"/>
-      <point x="388" y="81"/>
-      <point x="351" y="154"/>
+      <point x="475" y="91" type="curve" smooth="yes"/>
+      <point x="397" y="91"/>
+      <point x="351" y="134"/>
       <point x="351" y="232" type="curve" smooth="yes"/>
-      <point x="351" y="339"/>
-      <point x="408" y="419"/>
+      <point x="351" y="349"/>
+      <point x="417" y="419"/>
       <point x="520" y="419" type="curve" smooth="yes"/>
-      <point x="607" y="419"/>
-      <point x="644" y="365"/>
+      <point x="598" y="419"/>
+      <point x="644" y="375"/>
       <point x="644" y="278" type="curve" smooth="yes"/>
-      <point x="644" y="180"/>
-      <point x="588" y="81"/>
+      <point x="644" y="160"/>
+      <point x="579" y="91"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -1,47 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy.loclBGR" format="2">
-  <advance width="787"/>
-  <anchor x="438" y="510" name="top"/>
+  <advance width="781"/>
+  <anchor x="433" y="510" name="top"/>
   <outline>
     <contour>
-      <point x="473" y="-16" type="curve" smooth="yes"/>
-      <point x="638" y="-16"/>
-      <point x="760" y="117"/>
-      <point x="760" y="283" type="curve" smooth="yes"/>
-      <point x="760" y="419"/>
-      <point x="674" y="526"/>
-      <point x="520" y="526" type="curve" smooth="yes"/>
-      <point x="356" y="526"/>
-      <point x="235" y="392"/>
-      <point x="235" y="227" type="curve" smooth="yes"/>
-      <point x="235" y="91"/>
-      <point x="321" y="-16"/>
+      <point x="5" y="0" type="line"/>
+      <point x="120" y="0" type="line"/>
+      <point x="245" y="716" type="line"/>
+      <point x="130" y="716" type="line"/>
     </contour>
     <contour>
-      <point x="102" y="207" type="line"/>
-      <point x="284" y="207" type="line"/>
-      <point x="292" y="312" type="line"/>
-      <point x="117" y="312" type="line"/>
+      <point x="461" y="-16" type="curve" smooth="yes"/>
+      <point x="634" y="-16"/>
+      <point x="756" y="117"/>
+      <point x="756" y="283" type="curve" smooth="yes"/>
+      <point x="756" y="419"/>
+      <point x="669" y="526"/>
+      <point x="526" y="526" type="curve" smooth="yes"/>
+      <point x="377" y="526"/>
+      <point x="231" y="414"/>
+      <point x="231" y="231" type="curve" smooth="yes"/>
+      <point x="231" y="85"/>
+      <point x="323" y="-16"/>
     </contour>
     <contour>
-      <point x="9" y="0" type="line"/>
-      <point x="124" y="0" type="line"/>
-      <point x="250" y="716" type="line"/>
-      <point x="135" y="716" type="line"/>
+      <point x="471" y="83" type="curve" smooth="yes"/>
+      <point x="383" y="83"/>
+      <point x="347" y="147"/>
+      <point x="347" y="232" type="curve" smooth="yes"/>
+      <point x="347" y="335"/>
+      <point x="403" y="423"/>
+      <point x="516" y="423" type="curve" smooth="yes"/>
+      <point x="604" y="423"/>
+      <point x="640" y="358"/>
+      <point x="640" y="273" type="curve" smooth="yes"/>
+      <point x="640" y="170"/>
+      <point x="585" y="83"/>
     </contour>
     <contour>
-      <point x="475" y="81" type="curve" smooth="yes"/>
-      <point x="388" y="81"/>
-      <point x="351" y="154"/>
-      <point x="351" y="232" type="curve" smooth="yes"/>
-      <point x="351" y="339"/>
-      <point x="408" y="419"/>
-      <point x="520" y="419" type="curve" smooth="yes"/>
-      <point x="607" y="419"/>
-      <point x="644" y="365"/>
-      <point x="644" y="278" type="curve" smooth="yes"/>
-      <point x="644" y="180"/>
-      <point x="588" y="81"/>
+      <point x="99" y="207" type="line"/>
+      <point x="271" y="207" type="line"/>
+      <point x="277" y="314" type="line"/>
+      <point x="112" y="314" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.sc.glif
@@ -4,18 +4,18 @@
   <anchor x="374" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="529" y="-16" type="curve" smooth="yes"/>
-      <point x="733" y="-16"/>
-      <point x="857" y="142"/>
-      <point x="857" y="323" type="curve" smooth="yes"/>
-      <point x="857" y="477"/>
-      <point x="747" y="596"/>
-      <point x="595" y="596" type="curve" smooth="yes"/>
-      <point x="390" y="596"/>
-      <point x="266" y="438"/>
-      <point x="266" y="257" type="curve" smooth="yes"/>
-      <point x="266" y="103"/>
-      <point x="376" y="-16"/>
+      <point x="528" y="-16" type="curve" smooth="yes"/>
+      <point x="737" y="-16"/>
+      <point x="856" y="142"/>
+      <point x="856" y="323" type="curve" smooth="yes"/>
+      <point x="856" y="467"/>
+      <point x="751" y="596"/>
+      <point x="594" y="596" type="curve" smooth="yes"/>
+      <point x="409" y="596"/>
+      <point x="264" y="457"/>
+      <point x="264" y="266" type="curve" smooth="yes"/>
+      <point x="264" y="113"/>
+      <point x="375" y="-16"/>
     </contour>
     <contour>
       <point x="18" y="0" type="line"/>
@@ -30,18 +30,18 @@
       <point x="144" y="346" type="line"/>
     </contour>
     <contour>
-      <point x="538" y="83" type="curve" smooth="yes"/>
-      <point x="436" y="83"/>
-      <point x="371" y="156"/>
-      <point x="371" y="268" type="curve" smooth="yes"/>
-      <point x="371" y="396"/>
-      <point x="450" y="497"/>
-      <point x="586" y="497" type="curve" smooth="yes"/>
-      <point x="687" y="497"/>
-      <point x="753" y="422"/>
-      <point x="753" y="311" type="curve" smooth="yes"/>
-      <point x="753" y="184"/>
-      <point x="674" y="83"/>
+      <point x="537" y="83" type="curve" smooth="yes"/>
+      <point x="440" y="83"/>
+      <point x="370" y="156"/>
+      <point x="370" y="268" type="curve" smooth="yes"/>
+      <point x="370" y="396"/>
+      <point x="444" y="497"/>
+      <point x="585" y="497" type="curve" smooth="yes"/>
+      <point x="671" y="497"/>
+      <point x="752" y="425"/>
+      <point x="752" y="311" type="curve" smooth="yes"/>
+      <point x="752" y="184"/>
+      <point x="668" y="83"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="710" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="356" y="-391" type="curve" smooth="yes"/>
-      <point x="422" y="-391"/>
-      <point x="480" y="-335"/>
-      <point x="480" y="-261" type="curve" smooth="yes"/>
-      <point x="480" y="-201"/>
-      <point x="436" y="-156"/>
-      <point x="373" y="-156" type="curve" smooth="yes"/>
-      <point x="305" y="-156"/>
-      <point x="247" y="-212"/>
-      <point x="247" y="-286" type="curve" smooth="yes"/>
-      <point x="247" y="-347"/>
-      <point x="291" y="-391"/>
-    </contour>
-    <contour>
       <point x="494" y="-385" type="line"/>
       <point x="574" y="-385" type="line"/>
       <point x="677" y="202" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="531" y="-169"/>
       <point x="530" y="-179"/>
       <point x="528" y="-190" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="356" y="-391" type="curve" smooth="yes"/>
+      <point x="422" y="-391"/>
+      <point x="480" y="-335"/>
+      <point x="480" y="-261" type="curve" smooth="yes"/>
+      <point x="480" y="-201"/>
+      <point x="436" y="-156"/>
+      <point x="373" y="-156" type="curve" smooth="yes"/>
+      <point x="305" y="-156"/>
+      <point x="247" y="-212"/>
+      <point x="247" y="-286" type="curve" smooth="yes"/>
+      <point x="247" y="-347"/>
+      <point x="291" y="-391"/>
     </contour>
     <contour>
       <point x="357" y="-322" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-6"/>
-    <component base="zeropercent" xOffset="669" yOffset="31"/>
+    <component base="zeropercent" xOffset="664"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="827"/>
+  <advance width="825"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" xOffset="13"/>
-    <component base="zeropercent" xOffset="344" yOffset="-406"/>
-    <component base="percentbar" xOffset="-15" yOffset="-13"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="331" yOffset="-406"/>
+    <component base="percentbar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/percentbar.glif
@@ -3,10 +3,10 @@
   <advance width="826"/>
   <outline>
     <contour>
-      <point x="177" y="-14" type="line"/>
-      <point x="769" y="678" type="line"/>
-      <point x="707" y="733" type="line"/>
-      <point x="114" y="40" type="line"/>
+      <point x="164" y="-16" type="line"/>
+      <point x="757" y="678" type="line"/>
+      <point x="695" y="732" type="line"/>
+      <point x="102" y="38" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1388"/>
+  <advance width="1357"/>
   <unicode hex="2031"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="percentbar" xOffset="-17" yOffset="-14"/>
-    <component base="zeropercent" xOffset="343" yOffset="-406"/>
-    <component base="zeropercent" xOffset="618" yOffset="-406"/>
-    <component base="zeropercent" xOffset="893" yOffset="-405"/>
+    <component base="zeropercent" xOffset="331" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="597" yOffset="-406"/>
+    <component base="zeropercent" xOffset="863" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1107"/>
+  <advance width="1091"/>
   <unicode hex="2030"/>
   <outline>
     <component base="zeropercent"/>
-    <component base="zeropercent" xOffset="342" yOffset="-406"/>
-    <component base="percentbar" xOffset="-8"/>
-    <component base="zeropercent" xOffset="623" yOffset="-406"/>
+    <component base="zeropercent" xOffset="331" yOffset="-406"/>
+    <component base="percentbar"/>
+    <component base="zeropercent" xOffset="597" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="749"/>
-  <anchor x="142" y="0" name="bottom_1"/>
-  <anchor x="517" y="0" name="bottom_2"/>
-  <anchor x="374.5" y="0" name="caret_1"/>
-  <anchor x="232" y="510" name="top_1"/>
-  <anchor x="607" y="510" name="top_2"/>
+  <anchor x="285" y="0" name="caret_1"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
-  <advance width="1059"/>
-  <anchor x="132" y="0" name="bottom_1"/>
-  <anchor x="485" y="0" name="bottom_2"/>
-  <anchor x="838" y="0" name="bottom_3"/>
+  <advance width="1060"/>
   <anchor x="353" y="0" name="caret_1"/>
-  <anchor x="706" y="0" name="caret_2"/>
-  <anchor x="222" y="510" name="top_1"/>
-  <anchor x="575" y="510" name="top_2"/>
-  <anchor x="928" y="510" name="top_3"/>
+  <anchor x="646" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="369"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="745"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="514" y="0" name="bottom_2"/>
   <anchor x="372.5" y="0" name="caret_1"/>
-  <anchor x="231" y="510" name="top_1"/>
-  <anchor x="604" y="510" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="537" y="352" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="468" y="-202" type="curve" smooth="yes"/>
-      <point x="536" y="-202"/>
-      <point x="597" y="-145"/>
-      <point x="597" y="-71" type="curve" smooth="yes"/>
-      <point x="597" y="-10"/>
-      <point x="551" y="37"/>
-      <point x="485" y="37" type="curve" smooth="yes"/>
-      <point x="415" y="37"/>
-      <point x="355" y="-19"/>
-      <point x="355" y="-95" type="curve" smooth="yes"/>
-      <point x="355" y="-157"/>
-      <point x="401" y="-202"/>
-    </contour>
-    <contour>
       <point x="373" y="58" type="line"/>
       <point x="387" y="138" type="line"/>
       <point x="322" y="170" type="line"/>
@@ -94,6 +80,20 @@
       <point x="320" y="35" type="curve" smooth="yes"/>
       <point x="320" y="-16"/>
       <point x="345" y="-59"/>
+    </contour>
+    <contour>
+      <point x="468" y="-202" type="curve" smooth="yes"/>
+      <point x="536" y="-202"/>
+      <point x="597" y="-145"/>
+      <point x="597" y="-71" type="curve" smooth="yes"/>
+      <point x="597" y="-10"/>
+      <point x="551" y="37"/>
+      <point x="485" y="37" type="curve" smooth="yes"/>
+      <point x="415" y="37"/>
+      <point x="355" y="-19"/>
+      <point x="355" y="-95" type="curve" smooth="yes"/>
+      <point x="355" y="-157"/>
+      <point x="401" y="-202"/>
     </contour>
     <contour>
       <point x="467" y="-133" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/t_f.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
   <advance width="686"/>
-  <anchor x="127" y="0" name="bottom_1"/>
-  <anchor x="470" y="0" name="bottom_2"/>
-  <anchor x="343" y="0" name="caret_1"/>
-  <anchor x="172" y="255" name="center_1"/>
-  <anchor x="515" y="255" name="center_2"/>
-  <anchor x="217" y="510" name="top_1"/>
-  <anchor x="560" y="510" name="top_2"/>
-  <anchor x="711" y="510" name="topright_1"/>
-  <anchor x="711" y="510" name="topright_2"/>
+  <anchor x="324" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="f" xOffset="307"/>
+    <component base="tlig" xOffset="-1"/>
+    <component base="f" xOffset="306"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/t_t.glif
@@ -1,18 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
   <advance width="677"/>
-  <anchor x="124" y="0" name="bottom_1"/>
-  <anchor x="463" y="0" name="bottom_2"/>
-  <anchor x="338.5" y="0" name="caret_1"/>
-  <anchor x="169" y="255" name="center_1"/>
-  <anchor x="508" y="255" name="center_2"/>
-  <anchor x="214" y="510" name="top_1"/>
-  <anchor x="553" y="510" name="top_2"/>
-  <anchor x="702" y="510" name="topright_1"/>
-  <anchor x="702" y="510" name="topright_2"/>
+  <anchor x="338" y="0" name="caret_1"/>
   <outline>
-    <component base="tlig"/>
-    <component base="t" xOffset="312"/>
+    <component base="tlig" xOffset="-1"/>
+    <component base="t" xOffset="311"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ustraight-cy.glif
@@ -18,6 +18,8 @@
   </outline>
   <lib>
     <dict>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|</string>
       <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
       <string>=|</string>
     </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="231" y="390" type="curve" smooth="yes"/>
-      <point x="354" y="390"/>
-      <point x="433" y="475"/>
-      <point x="433" y="583" type="curve" smooth="yes"/>
-      <point x="433" y="669"/>
-      <point x="368" y="732"/>
-      <point x="281" y="732" type="curve" smooth="yes"/>
-      <point x="158" y="732"/>
-      <point x="78" y="647"/>
-      <point x="78" y="539" type="curve" smooth="yes"/>
-      <point x="78" y="453"/>
-      <point x="145" y="390"/>
+      <point x="239" y="390" type="curve" smooth="yes"/>
+      <point x="363" y="390"/>
+      <point x="442" y="475"/>
+      <point x="442" y="583" type="curve" smooth="yes"/>
+      <point x="442" y="669"/>
+      <point x="376" y="732"/>
+      <point x="290" y="732" type="curve" smooth="yes"/>
+      <point x="166" y="732"/>
+      <point x="87" y="647"/>
+      <point x="87" y="539" type="curve" smooth="yes"/>
+      <point x="87" y="453"/>
+      <point x="153" y="390"/>
     </contour>
     <contour>
-      <point x="244" y="480" type="curve" smooth="yes"/>
-      <point x="205" y="480"/>
-      <point x="182" y="507"/>
-      <point x="182" y="549" type="curve" smooth="yes"/>
-      <point x="182" y="603"/>
-      <point x="218" y="642"/>
-      <point x="268" y="642" type="curve" smooth="yes"/>
-      <point x="307" y="642"/>
-      <point x="330" y="615"/>
-      <point x="330" y="573" type="curve" smooth="yes"/>
-      <point x="330" y="519"/>
-      <point x="293" y="480"/>
+      <point x="252" y="480" type="curve" smooth="yes"/>
+      <point x="213" y="480"/>
+      <point x="190" y="507"/>
+      <point x="190" y="549" type="curve" smooth="yes"/>
+      <point x="190" y="603"/>
+      <point x="227" y="642"/>
+      <point x="277" y="642" type="curve" smooth="yes"/>
+      <point x="316" y="642"/>
+      <point x="339" y="615"/>
+      <point x="339" y="573" type="curve" smooth="yes"/>
+      <point x="339" y="519"/>
+      <point x="302" y="480"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -62,6 +62,8 @@
       <integer>596</integer>
       <integer>716</integer>
       <integer>732</integer>
+      <integer>716</integer>
+      <integer>732</integer>
     </array>
     <key>postscriptOtherBlues</key>
     <array>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoykoet-khmer.glif
@@ -4,6 +4,43 @@
   <unicode hex="19EB"/>
   <outline>
     <contour>
+      <point x="704" y="330" type="line"/>
+      <point x="714" y="330" type="line" smooth="yes"/>
+      <point x="893" y="330"/>
+      <point x="1027" y="448"/>
+      <point x="1027" y="603" type="curve" smooth="yes"/>
+      <point x="1027" y="704"/>
+      <point x="960" y="781"/>
+      <point x="846" y="781" type="curve" smooth="yes"/>
+      <point x="709" y="781"/>
+      <point x="594" y="682"/>
+      <point x="594" y="563" type="curve" smooth="yes"/>
+      <point x="594" y="501"/>
+      <point x="631" y="463"/>
+      <point x="689" y="463" type="curve" smooth="yes"/>
+      <point x="745" y="463"/>
+      <point x="796" y="511"/>
+      <point x="796" y="563" type="curve" smooth="yes"/>
+      <point x="796" y="599"/>
+      <point x="769" y="627"/>
+      <point x="729" y="627" type="curve" smooth="yes"/>
+      <point x="710" y="627"/>
+      <point x="692" y="621"/>
+      <point x="679" y="615" type="curve"/>
+      <point x="697" y="594" type="line"/>
+      <point x="699" y="603" type="line" smooth="yes"/>
+      <point x="705" y="631"/>
+      <point x="751" y="682"/>
+      <point x="822" y="682" type="curve" smooth="yes"/>
+      <point x="879" y="682"/>
+      <point x="913" y="640"/>
+      <point x="913" y="587" type="curve" smooth="yes"/>
+      <point x="913" y="498"/>
+      <point x="832" y="428"/>
+      <point x="732" y="428" type="curve" smooth="yes"/>
+      <point x="722" y="428" type="line"/>
+    </contour>
+    <contour>
       <point x="487" y="-250" type="line"/>
       <point x="598" y="-250" type="line"/>
       <point x="677" y="197" type="line"/>
@@ -29,6 +66,20 @@
       <point x="496" y="-31"/>
       <point x="525" y="-4" type="curve"/>
       <point x="530" y="-4" type="line"/>
+    </contour>
+    <contour>
+      <point x="208" y="518" type="curve" smooth="yes"/>
+      <point x="194" y="518"/>
+      <point x="183" y="529"/>
+      <point x="183" y="543" type="curve" smooth="yes"/>
+      <point x="183" y="561"/>
+      <point x="201" y="579"/>
+      <point x="219" y="579" type="curve" smooth="yes"/>
+      <point x="234" y="579"/>
+      <point x="245" y="568"/>
+      <point x="245" y="554" type="curve" smooth="yes"/>
+      <point x="245" y="536"/>
+      <point x="227" y="518"/>
     </contour>
     <contour>
       <point x="210" y="330" type="line"/>
@@ -66,57 +117,6 @@
       <point x="338" y="428"/>
       <point x="238" y="428" type="curve" smooth="yes"/>
       <point x="228" y="428" type="line"/>
-    </contour>
-    <contour>
-      <point x="208" y="518" type="curve" smooth="yes"/>
-      <point x="194" y="518"/>
-      <point x="183" y="529"/>
-      <point x="183" y="543" type="curve" smooth="yes"/>
-      <point x="183" y="561"/>
-      <point x="201" y="579"/>
-      <point x="219" y="579" type="curve" smooth="yes"/>
-      <point x="234" y="579"/>
-      <point x="245" y="568"/>
-      <point x="245" y="554" type="curve" smooth="yes"/>
-      <point x="245" y="536"/>
-      <point x="227" y="518"/>
-    </contour>
-    <contour>
-      <point x="704" y="330" type="line"/>
-      <point x="714" y="330" type="line" smooth="yes"/>
-      <point x="893" y="330"/>
-      <point x="1027" y="448"/>
-      <point x="1027" y="603" type="curve" smooth="yes"/>
-      <point x="1027" y="704"/>
-      <point x="960" y="781"/>
-      <point x="846" y="781" type="curve" smooth="yes"/>
-      <point x="709" y="781"/>
-      <point x="594" y="682"/>
-      <point x="594" y="563" type="curve" smooth="yes"/>
-      <point x="594" y="501"/>
-      <point x="631" y="463"/>
-      <point x="689" y="463" type="curve" smooth="yes"/>
-      <point x="745" y="463"/>
-      <point x="796" y="511"/>
-      <point x="796" y="563" type="curve" smooth="yes"/>
-      <point x="796" y="599"/>
-      <point x="769" y="627"/>
-      <point x="729" y="627" type="curve" smooth="yes"/>
-      <point x="710" y="627"/>
-      <point x="692" y="621"/>
-      <point x="679" y="615" type="curve"/>
-      <point x="697" y="594" type="line"/>
-      <point x="699" y="603" type="line" smooth="yes"/>
-      <point x="705" y="631"/>
-      <point x="751" y="682"/>
-      <point x="822" y="682" type="curve" smooth="yes"/>
-      <point x="879" y="682"/>
-      <point x="913" y="640"/>
-      <point x="913" y="587" type="curve" smooth="yes"/>
-      <point x="913" y="498"/>
-      <point x="832" y="428"/>
-      <point x="732" y="428" type="curve" smooth="yes"/>
-      <point x="722" y="428" type="line"/>
     </contour>
     <contour>
       <point x="698" y="518" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/dapM_uoyroc-khmer.glif
@@ -4,57 +4,6 @@
   <unicode hex="19FB"/>
   <outline>
     <contour>
-      <point x="108" y="-250" type="line"/>
-      <point x="118" y="-250" type="line" smooth="yes"/>
-      <point x="297" y="-250"/>
-      <point x="431" y="-132"/>
-      <point x="431" y="23" type="curve" smooth="yes"/>
-      <point x="431" y="124"/>
-      <point x="364" y="201"/>
-      <point x="250" y="201" type="curve" smooth="yes"/>
-      <point x="113" y="201"/>
-      <point x="-2" y="102"/>
-      <point x="-2" y="-17" type="curve" smooth="yes"/>
-      <point x="-2" y="-79"/>
-      <point x="35" y="-117"/>
-      <point x="93" y="-117" type="curve" smooth="yes"/>
-      <point x="149" y="-117"/>
-      <point x="200" y="-69"/>
-      <point x="200" y="-17" type="curve" smooth="yes"/>
-      <point x="200" y="19"/>
-      <point x="173" y="47"/>
-      <point x="133" y="47" type="curve" smooth="yes"/>
-      <point x="114" y="47"/>
-      <point x="96" y="41"/>
-      <point x="83" y="35" type="curve"/>
-      <point x="101" y="14" type="line"/>
-      <point x="103" y="23" type="line" smooth="yes"/>
-      <point x="109" y="51"/>
-      <point x="155" y="102"/>
-      <point x="226" y="102" type="curve" smooth="yes"/>
-      <point x="283" y="102"/>
-      <point x="317" y="60"/>
-      <point x="317" y="7" type="curve" smooth="yes"/>
-      <point x="317" y="-82"/>
-      <point x="236" y="-152"/>
-      <point x="136" y="-152" type="curve" smooth="yes"/>
-      <point x="126" y="-152" type="line"/>
-    </contour>
-    <contour>
-      <point x="106" y="-62" type="curve" smooth="yes"/>
-      <point x="92" y="-62"/>
-      <point x="81" y="-51"/>
-      <point x="81" y="-37" type="curve" smooth="yes"/>
-      <point x="81" y="-19"/>
-      <point x="99" y="-1"/>
-      <point x="117" y="-1" type="curve" smooth="yes"/>
-      <point x="132" y="-1"/>
-      <point x="143" y="-12"/>
-      <point x="143" y="-26" type="curve" smooth="yes"/>
-      <point x="143" y="-44"/>
-      <point x="125" y="-62"/>
-    </contour>
-    <contour>
       <point x="602" y="-250" type="line"/>
       <point x="612" y="-250" type="line" smooth="yes"/>
       <point x="791" y="-250"/>
@@ -90,6 +39,57 @@
       <point x="730" y="-152"/>
       <point x="630" y="-152" type="curve" smooth="yes"/>
       <point x="620" y="-152" type="line"/>
+    </contour>
+    <contour>
+      <point x="106" y="-62" type="curve" smooth="yes"/>
+      <point x="92" y="-62"/>
+      <point x="81" y="-51"/>
+      <point x="81" y="-37" type="curve" smooth="yes"/>
+      <point x="81" y="-19"/>
+      <point x="99" y="-1"/>
+      <point x="117" y="-1" type="curve" smooth="yes"/>
+      <point x="132" y="-1"/>
+      <point x="143" y="-12"/>
+      <point x="143" y="-26" type="curve" smooth="yes"/>
+      <point x="143" y="-44"/>
+      <point x="125" y="-62"/>
+    </contour>
+    <contour>
+      <point x="108" y="-250" type="line"/>
+      <point x="118" y="-250" type="line" smooth="yes"/>
+      <point x="297" y="-250"/>
+      <point x="431" y="-132"/>
+      <point x="431" y="23" type="curve" smooth="yes"/>
+      <point x="431" y="124"/>
+      <point x="364" y="201"/>
+      <point x="250" y="201" type="curve" smooth="yes"/>
+      <point x="113" y="201"/>
+      <point x="-2" y="102"/>
+      <point x="-2" y="-17" type="curve" smooth="yes"/>
+      <point x="-2" y="-79"/>
+      <point x="35" y="-117"/>
+      <point x="93" y="-117" type="curve" smooth="yes"/>
+      <point x="149" y="-117"/>
+      <point x="200" y="-69"/>
+      <point x="200" y="-17" type="curve" smooth="yes"/>
+      <point x="200" y="19"/>
+      <point x="173" y="47"/>
+      <point x="133" y="47" type="curve" smooth="yes"/>
+      <point x="114" y="47"/>
+      <point x="96" y="41"/>
+      <point x="83" y="35" type="curve"/>
+      <point x="101" y="14" type="line"/>
+      <point x="103" y="23" type="line" smooth="yes"/>
+      <point x="109" y="51"/>
+      <point x="155" y="102"/>
+      <point x="226" y="102" type="curve" smooth="yes"/>
+      <point x="283" y="102"/>
+      <point x="317" y="60"/>
+      <point x="317" y="7" type="curve" smooth="yes"/>
+      <point x="317" y="-82"/>
+      <point x="236" y="-152"/>
+      <point x="136" y="-152" type="curve" smooth="yes"/>
+      <point x="126" y="-152" type="line"/>
     </contour>
     <contour>
       <point x="596" y="-62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_b.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_b" format="2">
   <advance width="1006"/>
-  <anchor x="207" y="0" name="bottom_1"/>
-  <anchor x="710" y="0" name="bottom_2"/>
-  <anchor x="503" y="0" name="caret_1"/>
-  <anchor x="333" y="716" name="top_1"/>
-  <anchor x="836" y="716" name="top_2"/>
+  <anchor x="301" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="b" xOffset="376"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f.glif
@@ -3,8 +3,8 @@
   <advance width="735"/>
   <anchor x="298" y="0" name="caret_1"/>
   <outline>
-    <component base="f" xOffset="322"/>
     <component base="flig2"/>
+    <component base="f" xOffset="322"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_b.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_b.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_b" format="2">
   <advance width="1327"/>
-  <anchor x="176" y="0" name="bottom_1"/>
-  <anchor x="619" y="0" name="bottom_2"/>
-  <anchor x="1061" y="0" name="bottom_3"/>
-  <anchor x="442.333" y="0" name="caret_1"/>
-  <anchor x="884.667" y="0" name="caret_2"/>
-  <anchor x="302" y="716" name="top_1"/>
-  <anchor x="745" y="716" name="top_2"/>
-  <anchor x="1187" y="716" name="top_3"/>
+  <anchor x="295" y="0" name="caret_1"/>
+  <anchor x="618" y="0" name="caret_2"/>
   <outline>
     <component base="flig2" xOffset="1"/>
     <component base="flig1" xOffset="320"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_h.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_h" format="2">
   <advance width="1297"/>
-  <anchor x="171" y="0" name="bottom_1"/>
-  <anchor x="604" y="0" name="bottom_2"/>
-  <anchor x="1036" y="0" name="bottom_3"/>
-  <anchor x="432.333" y="0" name="caret_1"/>
-  <anchor x="864.667" y="0" name="caret_2"/>
-  <anchor x="297" y="716" name="top_1"/>
-  <anchor x="730" y="716" name="top_2"/>
-  <anchor x="1162" y="716" name="top_3"/>
+  <anchor x="294" y="0" name="caret_1"/>
+  <anchor x="616" y="0" name="caret_2"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="320"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_i.glif
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_i" format="2">
-  <advance width="961"/>
+  <advance width="964"/>
+  <anchor x="135" y="0" name="bottom_1"/>
+  <anchor x="456" y="0" name="bottom_2"/>
+  <anchor x="776" y="0" name="bottom_3"/>
   <anchor x="301" y="0" name="caret_1"/>
   <anchor x="620" y="0" name="caret_2"/>
+  <anchor x="261" y="716" name="top_1"/>
+  <anchor x="582" y="716" name="top_2"/>
+  <anchor x="902" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="321"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="321"/>
     <component base="i" xOffset="688"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_j.glif
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_j" format="2">
-  <advance width="961"/>
-  <anchor x="115" y="0" name="bottom_1"/>
-  <anchor x="436" y="0" name="bottom_2"/>
-  <anchor x="756" y="0" name="bottom_3"/>
+  <advance width="964"/>
+  <anchor x="135" y="0" name="bottom_1"/>
+  <anchor x="456" y="0" name="bottom_2"/>
+  <anchor x="776" y="-216" name="bottom_3"/>
   <anchor x="320.333" y="0" name="caret_1"/>
   <anchor x="640.667" y="0" name="caret_2"/>
-  <anchor x="241" y="716" name="top_1"/>
-  <anchor x="562" y="716" name="top_2"/>
-  <anchor x="882" y="716" name="top_3"/>
+  <anchor x="261" y="716" name="top_1"/>
+  <anchor x="582" y="716" name="top_2"/>
+  <anchor x="902" y="716" name="top_3"/>
   <outline>
-    <component base="flig2" xOffset="321"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="321"/>
     <component base="j" xOffset="688"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_k.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_k" format="2">
   <advance width="1257"/>
-  <anchor x="165" y="0" name="bottom_1"/>
-  <anchor x="584" y="0" name="bottom_2"/>
-  <anchor x="1003" y="0" name="bottom_3"/>
   <anchor x="419" y="0" name="caret_1"/>
   <anchor x="838" y="0" name="caret_2"/>
-  <anchor x="291" y="716" name="top_1"/>
-  <anchor x="710" y="716" name="top_2"/>
-  <anchor x="1129" y="716" name="top_3"/>
   <outline>
     <component base="flig2"/>
     <component base="flig1" xOffset="320"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_f_t.glif
@@ -1,17 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_f_t" format="2">
-  <advance width="1078"/>
-  <anchor x="135" y="0" name="bottom_1"/>
-  <anchor x="494" y="0" name="bottom_2"/>
-  <anchor x="853" y="0" name="bottom_3"/>
-  <anchor x="359.333" y="0" name="caret_1"/>
-  <anchor x="718.667" y="0" name="caret_2"/>
-  <anchor x="261" y="716" name="top_1"/>
-  <anchor x="620" y="716" name="top_2"/>
-  <anchor x="979" y="716" name="top_3"/>
+  <advance width="1063"/>
+  <anchor x="296" y="0" name="caret_1"/>
+  <anchor x="656" y="0" name="caret_2"/>
   <outline>
-    <component base="flig2" xOffset="321"/>
     <component base="flig2"/>
+    <component base="flig2" xOffset="321"/>
     <component base="t" xOffset="645"/>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_h.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_h.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_h" format="2">
   <advance width="977"/>
-  <anchor x="199" y="0" name="bottom_1"/>
-  <anchor x="688" y="0" name="bottom_2"/>
-  <anchor x="488.5" y="0" name="caret_1"/>
-  <anchor x="325" y="716" name="top_1"/>
-  <anchor x="814" y="716" name="top_2"/>
+  <anchor x="301" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="h" xOffset="377"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_i.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_i.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_i" format="2">
-  <advance width="641"/>
+  <advance width="644"/>
   <anchor x="115" y="0" name="bottom_1"/>
   <anchor x="436" y="0" name="bottom_2"/>
-  <anchor x="320.5" y="0" name="caret_1"/>
+  <anchor x="291" y="0" name="caret_1"/>
   <anchor x="241" y="716" name="top_1"/>
   <anchor x="562" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_j.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_j.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_j" format="2">
-  <advance width="643"/>
+  <advance width="644"/>
   <anchor x="116" y="0" name="bottom_1"/>
-  <anchor x="437" y="0" name="bottom_2"/>
-  <anchor x="321.5" y="0" name="caret_1"/>
+  <anchor x="422" y="-216" name="bottom_2"/>
+  <anchor x="292" y="0" name="caret_1"/>
   <anchor x="242" y="716" name="top_1"/>
   <anchor x="563" y="716" name="top_2"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_k.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_k.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_k" format="2">
   <advance width="936"/>
-  <anchor x="189" y="0" name="bottom_1"/>
-  <anchor x="657" y="0" name="bottom_2"/>
-  <anchor x="468" y="0" name="caret_1"/>
-  <anchor x="315" y="716" name="top_1"/>
-  <anchor x="783" y="716" name="top_2"/>
+  <anchor x="295" y="0" name="caret_1"/>
   <outline>
     <component base="flig1"/>
     <component base="k" xOffset="375"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_l.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_l.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_l" format="2">
   <advance width="636"/>
-  <anchor x="114" y="0" name="bottom_1"/>
-  <anchor x="432" y="0" name="bottom_2"/>
   <anchor x="318" y="0" name="caret_1"/>
-  <anchor x="240" y="716" name="top_1"/>
-  <anchor x="558" y="716" name="top_2"/>
   <outline>
     <component base="flig1"/>
     <component base="l" xOffset="376"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/f_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f_t" format="2">
   <advance width="742"/>
-  <anchor x="141" y="0" name="bottom_1"/>
-  <anchor x="512" y="0" name="bottom_2"/>
-  <anchor x="371" y="0" name="caret_1"/>
-  <anchor x="267" y="716" name="top_1"/>
-  <anchor x="638" y="716" name="top_2"/>
+  <anchor x="321" y="0" name="caret_1"/>
   <outline>
     <component base="flig2"/>
     <component base="t" xOffset="324"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="283" y="355"/>
       <point x="305" y="366" type="curve"/>
     </contour>
-    <component base="geez-part-4" xOffset="293" yOffset="-124"/>
+    <component base="geez-part-4" yxScale="0.17633" xOffset="293" yOffset="-124"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/hi-ethiopic.glif
@@ -68,6 +68,6 @@
       <point x="283" y="355"/>
       <point x="305" y="366" type="curve"/>
     </contour>
-    <component base="geez-part-4" yxScale="0.17633" xOffset="293" yOffset="-124"/>
+    <component base="geez-part-4" xOffset="293" yOffset="-124"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.glif
@@ -10,9 +10,9 @@
       <point x="795" y="117"/>
       <point x="795" y="288" type="curve" smooth="yes"/>
       <point x="795" y="422"/>
-      <point x="705" y="526"/>
+      <point x="705" y="528"/>
       <point x="565" y="526" type="curve" smooth="yes"/>
-      <point x="415" y="526"/>
+      <point x="415" y="524"/>
       <point x="272" y="414"/>
       <point x="272" y="229" type="curve" smooth="yes"/>
       <point x="272" y="75"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/iu-cy.loclB_G_R_.glif
@@ -4,6 +4,12 @@
   <anchor x="459" y="510" name="top"/>
   <outline>
     <contour>
+      <point x="20" y="0" type="line"/>
+      <point x="152" y="0" type="line"/>
+      <point x="279" y="716" type="line"/>
+      <point x="148" y="716" type="line"/>
+    </contour>
+    <contour>
       <point x="501" y="-16" type="curve" smooth="yes"/>
       <point x="679" y="-16"/>
       <point x="795" y="117"/>
@@ -18,18 +24,6 @@
       <point x="370" y="-16"/>
     </contour>
     <contour>
-      <point x="133" y="202" type="line"/>
-      <point x="333" y="202" type="line"/>
-      <point x="344" y="314" type="line"/>
-      <point x="152" y="314" type="line"/>
-    </contour>
-    <contour>
-      <point x="20" y="0" type="line"/>
-      <point x="152" y="0" type="line"/>
-      <point x="279" y="716" type="line"/>
-      <point x="148" y="716" type="line"/>
-    </contour>
-    <contour>
       <point x="516" y="105" type="curve" smooth="yes"/>
       <point x="445" y="105"/>
       <point x="403" y="161"/>
@@ -42,6 +36,12 @@
       <point x="663" y="274" type="curve" smooth="yes"/>
       <point x="663" y="177"/>
       <point x="597" y="105"/>
+    </contour>
+    <contour>
+      <point x="133" y="202" type="line"/>
+      <point x="333" y="202" type="line"/>
+      <point x="344" y="314" type="line"/>
+      <point x="152" y="314" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/l_ga-oriya.glif
@@ -39,20 +39,6 @@
       <point x="722" y="171" type="curve"/>
     </contour>
     <contour>
-      <point x="350" y="-405" type="curve" smooth="yes"/>
-      <point x="421" y="-405"/>
-      <point x="481" y="-347"/>
-      <point x="481" y="-268" type="curve" smooth="yes"/>
-      <point x="481" y="-205"/>
-      <point x="435" y="-158"/>
-      <point x="368" y="-158" type="curve" smooth="yes"/>
-      <point x="295" y="-158"/>
-      <point x="235" y="-217"/>
-      <point x="235" y="-295" type="curve" smooth="yes"/>
-      <point x="235" y="-358"/>
-      <point x="281" y="-405"/>
-    </contour>
-    <contour>
       <point x="496" y="-400" type="line"/>
       <point x="595" y="-400" type="line"/>
       <point x="701" y="208" type="line" smooth="yes"/>
@@ -123,6 +109,20 @@
       <point x="534" y="-179"/>
       <point x="533" y="-189"/>
       <point x="531" y="-201" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="350" y="-405" type="curve" smooth="yes"/>
+      <point x="421" y="-405"/>
+      <point x="481" y="-347"/>
+      <point x="481" y="-268" type="curve" smooth="yes"/>
+      <point x="481" y="-205"/>
+      <point x="435" y="-158"/>
+      <point x="368" y="-158" type="curve" smooth="yes"/>
+      <point x="295" y="-158"/>
+      <point x="235" y="-217"/>
+      <point x="235" y="-295" type="curve" smooth="yes"/>
+      <point x="235" y="-358"/>
+      <point x="281" y="-405"/>
     </contour>
     <contour>
       <point x="353" y="-323" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/numero.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/numero.glif
@@ -4,7 +4,7 @@
   <unicode hex="2116"/>
   <outline>
     <component base="N" xOffset="-9"/>
-    <component base="zeropercent" xOffset="678" yOffset="31"/>
+    <component base="zeropercent" xOffset="673"/>
     <component base="numero-bar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/percent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/percent.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percent" format="2">
-  <advance width="858"/>
+  <advance width="853"/>
   <unicode hex="0025"/>
   <outline>
-    <component base="zeropercent" yOffset="-1"/>
-    <component base="zeropercent" xOffset="361" yOffset="-407"/>
-    <component base="percentbar" xOffset="-13" yOffset="-14"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="361" yOffset="-406"/>
+    <component base="percentbar"/>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/percentbar.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/percentbar.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="percentbar" format="2">
-  <advance width="826"/>
+  <advance width="853"/>
   <outline>
     <contour>
-      <point x="196" y="-19" type="line"/>
-      <point x="776" y="666" type="line"/>
-      <point x="709" y="724" type="line"/>
-      <point x="129" y="39" type="line"/>
+      <point x="188" y="-16" type="line"/>
+      <point x="768" y="674" type="line"/>
+      <point x="701" y="732" type="line"/>
+      <point x="121" y="42" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/pertenthousand.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="pertenthousand" format="2">
-  <advance width="1359"/>
+  <advance width="1357"/>
   <unicode hex="2031"/>
   <outline>
-    <component base="zeropercent" xOffset="-20"/>
-    <component base="percentbar" xOffset="-32" yOffset="-7"/>
-    <component base="zeropercent" xOffset="325" yOffset="-406"/>
-    <component base="zeropercent" xOffset="597" yOffset="-406"/>
-    <component base="zeropercent" xOffset="864" yOffset="-405"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="361" yOffset="-406"/>
+    <component base="percentbar" xOffset="-8"/>
+    <component base="zeropercent" xOffset="613" yOffset="-406"/>
+    <component base="zeropercent" xOffset="865" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/perthousand.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/perthousand.glif
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="perthousand" format="2">
-  <advance width="1108"/>
+  <advance width="1101"/>
   <unicode hex="2030"/>
   <outline>
-    <component base="zeropercent" xOffset="-10"/>
-    <component base="zeropercent" xOffset="330" yOffset="-407"/>
-    <component base="percentbar" xOffset="-20"/>
-    <component base="zeropercent" xOffset="621" yOffset="-407"/>
+    <component base="zeropercent"/>
+    <component base="zeropercent" xOffset="361" yOffset="-406"/>
+    <component base="percentbar" xOffset="-8"/>
+    <component base="zeropercent" xOffset="609" yOffset="-406"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/r_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/r_f.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f" format="2">
   <advance width="841"/>
-  <anchor x="162" y="0" name="bottom_1"/>
-  <anchor x="577" y="0" name="bottom_2"/>
-  <anchor x="414.5" y="0" name="caret_1"/>
-  <anchor x="252" y="510" name="top_1"/>
-  <anchor x="667" y="510" name="top_2"/>
+  <anchor x="385" y="0" name="caret_1"/>
   <outline>
     <component base="rlig"/>
     <component base="f" xOffset="427"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/r_f_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/r_f_f.glif
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_f_f" format="2">
-  <advance width="1146"/>
-  <anchor x="146" y="0" name="bottom_1"/>
-  <anchor x="528" y="0" name="bottom_2"/>
-  <anchor x="910" y="0" name="bottom_3"/>
+  <advance width="1147"/>
   <anchor x="382" y="0" name="caret_1"/>
-  <anchor x="764" y="0" name="caret_2"/>
-  <anchor x="236" y="510" name="top_1"/>
-  <anchor x="618" y="510" name="top_2"/>
-  <anchor x="1000" y="510" name="top_3"/>
+  <anchor x="714" y="0" name="caret_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="f_f" xOffset="411"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/r_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/r_t.glif
@@ -1,11 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="r_t" format="2">
   <advance width="850"/>
-  <anchor x="168" y="0" name="bottom_1"/>
-  <anchor x="593" y="0" name="bottom_2"/>
   <anchor x="425" y="0" name="caret_1"/>
-  <anchor x="258" y="510" name="top_1"/>
-  <anchor x="683" y="510" name="top_2"/>
   <outline>
     <component base="r.alt"/>
     <component base="t" xOffset="432"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/s_tta-oriya.glif
@@ -40,20 +40,6 @@
       <point x="538" y="349" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="479" y="-215" type="curve" smooth="yes"/>
-      <point x="553" y="-215"/>
-      <point x="615" y="-153"/>
-      <point x="615" y="-76" type="curve" smooth="yes"/>
-      <point x="615" y="-12"/>
-      <point x="567" y="38"/>
-      <point x="496" y="38" type="curve" smooth="yes"/>
-      <point x="421" y="38"/>
-      <point x="359" y="-22"/>
-      <point x="359" y="-102" type="curve" smooth="yes"/>
-      <point x="359" y="-166"/>
-      <point x="406" y="-215"/>
-    </contour>
-    <contour>
       <point x="390" y="52" type="line"/>
       <point x="408" y="157" type="line"/>
       <point x="339" y="190" type="line"/>
@@ -94,6 +80,20 @@
       <point x="319" y="37" type="curve" smooth="yes"/>
       <point x="319" y="-20"/>
       <point x="349" y="-66"/>
+    </contour>
+    <contour>
+      <point x="479" y="-215" type="curve" smooth="yes"/>
+      <point x="553" y="-215"/>
+      <point x="615" y="-153"/>
+      <point x="615" y="-76" type="curve" smooth="yes"/>
+      <point x="615" y="-12"/>
+      <point x="567" y="38"/>
+      <point x="496" y="38" type="curve" smooth="yes"/>
+      <point x="421" y="38"/>
+      <point x="359" y="-22"/>
+      <point x="359" y="-102" type="curve" smooth="yes"/>
+      <point x="359" y="-166"/>
+      <point x="406" y="-215"/>
     </contour>
     <contour>
       <point x="478" y="-133" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/t_f.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/t_f.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_f" format="2">
-  <advance width="736"/>
-  <anchor x="139" y="0" name="bottom_1"/>
-  <anchor x="507" y="0" name="bottom_2"/>
-  <anchor x="368" y="0" name="caret_1"/>
-  <anchor x="184" y="255" name="center_1"/>
-  <anchor x="552" y="255" name="center_2"/>
-  <anchor x="229" y="510" name="top_1"/>
-  <anchor x="597" y="510" name="top_2"/>
-  <anchor x="761" y="510" name="topright_1"/>
-  <anchor x="761" y="510" name="topright_2"/>
+  <advance width="735"/>
+  <anchor x="357" y="0" name="caret_1"/>
   <outline>
     <component base="tlig"/>
     <component base="f" xOffset="321"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/t_t.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/t_t.glif
@@ -1,15 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_t" format="2">
-  <advance width="753"/>
-  <anchor x="143" y="0" name="bottom_1"/>
-  <anchor x="520" y="0" name="bottom_2"/>
+  <advance width="738"/>
   <anchor x="376.5" y="0" name="caret_1"/>
-  <anchor x="188" y="255" name="center_1"/>
-  <anchor x="565" y="255" name="center_2"/>
-  <anchor x="233" y="510" name="top_1"/>
-  <anchor x="610" y="510" name="top_2"/>
-  <anchor x="778" y="510" name="topright_1"/>
-  <anchor x="778" y="510" name="topright_2"/>
   <outline>
     <component base="tlig"/>
     <component base="t" xOffset="320"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/yhook.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/yhook.sc.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="yhook.sc" format="2">
   <advance width="670"/>
-  <guideline x="354" y="235" angle="52.507346666949665"/>
+  <guideline x="354" y="235" angle="52.5073466669"/>
   <outline>
     <contour>
       <point x="526" y="460" type="line" smooth="yes"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/zeropercent.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/zeropercent.glif
@@ -3,32 +3,32 @@
   <advance width="420"/>
   <outline>
     <contour>
-      <point x="245" y="390" type="curve" smooth="yes"/>
-      <point x="355" y="390"/>
-      <point x="442" y="474"/>
-      <point x="442" y="581" type="curve" smooth="yes"/>
-      <point x="442" y="669"/>
-      <point x="377" y="732"/>
-      <point x="286" y="732" type="curve" smooth="yes"/>
-      <point x="165" y="732"/>
-      <point x="84" y="642"/>
-      <point x="84" y="540" type="curve" smooth="yes"/>
-      <point x="84" y="454"/>
-      <point x="149" y="390"/>
+      <point x="243" y="390" type="curve" smooth="yes"/>
+      <point x="359" y="390"/>
+      <point x="443" y="477"/>
+      <point x="443" y="582" type="curve" smooth="yes"/>
+      <point x="443" y="669"/>
+      <point x="378" y="732"/>
+      <point x="285" y="732" type="curve" smooth="yes"/>
+      <point x="169" y="732"/>
+      <point x="85" y="645"/>
+      <point x="85" y="540" type="curve" smooth="yes"/>
+      <point x="85" y="453"/>
+      <point x="150" y="390"/>
     </contour>
     <contour>
-      <point x="254" y="488" type="curve" smooth="yes"/>
-      <point x="221" y="488"/>
-      <point x="193" y="512"/>
-      <point x="193" y="551" type="curve" smooth="yes"/>
-      <point x="193" y="598"/>
-      <point x="226" y="634"/>
+      <point x="253" y="488" type="curve" smooth="yes"/>
+      <point x="220" y="488"/>
+      <point x="194" y="512"/>
+      <point x="194" y="550" type="curve" smooth="yes"/>
+      <point x="194" y="598"/>
+      <point x="227" y="634"/>
       <point x="275" y="634" type="curve" smooth="yes"/>
       <point x="308" y="634"/>
-      <point x="333" y="609"/>
-      <point x="333" y="572" type="curve" smooth="yes"/>
-      <point x="333" y="525"/>
-      <point x="299" y="488"/>
+      <point x="334" y="610"/>
+      <point x="334" y="572" type="curve" smooth="yes"/>
+      <point x="334" y="524"/>
+      <point x="301" y="488"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/groups.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/groups.plist
@@ -5,8 +5,10 @@
     <key>public.kern1.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -20,6 +22,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -28,17 +31,14 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
     <key>public.kern1.B</key>
     <array>
       <string>B</string>
-      <string>Ve-cy</string>
       <string>Bhook</string>
+      <string>Ve-cy</string>
     </array>
     <key>public.kern1.BNG_d-beng.half2_L</key>
     <array>
@@ -67,9 +67,9 @@
     <key>public.kern1.Ban-georgian</key>
     <array>
       <string>Ban-georgian</string>
-      <string>Zen-georgian</string>
       <string>Rae-georgian</string>
       <string>Xan-georgian</string>
+      <string>Zen-georgian</string>
     </array>
     <key>public.kern1.C</key>
     <array>
@@ -79,21 +79,21 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
-      <string>Es-cy</string>
       <string>E-cy</string>
+      <string>Eopen</string>
+      <string>Es-cy</string>
       <string>Esdescender-cy</string>
-      <string>Reversedze-cy</string>
       <string>Esdescender-cy.loclBSH</string>
       <string>Esdescender-cy.loclCHU</string>
-      <string>Eopen</string>
+      <string>Reversedze-cy</string>
     </array>
     <key>public.kern1.D</key>
     <array>
       <string>D</string>
-      <string>Eth</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
       <string>Dhook</string>
+      <string>Eth</string>
     </array>
     <key>public.kern1.DEV_b-deva.alt3_L</key>
     <array>
@@ -169,10 +169,10 @@
     </array>
     <key>public.kern1.DEV_ka-deva_L</key>
     <array>
+      <string>fa-deva</string>
       <string>ka-deva</string>
       <string>pha-deva</string>
       <string>qa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern1.DEV_kh-deva.alt3_L</key>
     <array>
@@ -234,13 +234,13 @@
     </array>
     <key>public.kern1.DEV_ph-deva.alt5_L</key>
     <array>
-      <string>ph-deva.alt5</string>
       <string>f-deva.alt5</string>
+      <string>ph-deva.alt5</string>
     </array>
     <key>public.kern1.DEV_ph-deva.alt6_L</key>
     <array>
-      <string>ph-deva.alt6</string>
       <string>f-deva.alt6</string>
+      <string>ph-deva.alt6</string>
     </array>
     <key>public.kern1.DEV_s-deva_L</key>
     <array>
@@ -296,6 +296,7 @@
     <array>
       <string>AE</string>
       <string>AEacute</string>
+      <string>Aie-cy</string>
       <string>E</string>
       <string>Eacute</string>
       <string>Ebreve</string>
@@ -314,19 +315,18 @@
       <string>Emacron</string>
       <string>Eogonek</string>
       <string>Etilde</string>
-      <string>OE</string>
       <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
       <string>Iegrave-cy</string>
       <string>Io-cy</string>
-      <string>Aie-cy</string>
-      <string>Iebreve-cy</string>
+      <string>OE</string>
     </array>
     <key>public.kern1.En-georgian</key>
     <array>
       <string>En-georgian</string>
       <string>Man-georgian</string>
-      <string>Un-georgian</string>
       <string>Shin-georgian</string>
+      <string>Un-georgian</string>
     </array>
     <key>public.kern1.F</key>
     <array>
@@ -344,30 +344,30 @@
     <key>public.kern1.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphatonos</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphatonos</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
     </array>
     <key>public.kern1.GRK_Beta</key>
     <array>
@@ -380,58 +380,58 @@
     <key>public.kern1.GRK_Epsilon</key>
     <array>
       <string>Epsilon</string>
-      <string>Xi</string>
-      <string>Epsilontonos</string>
-      <string>Epsilonpsili</string>
       <string>Epsilondasia</string>
-      <string>Epsilonpsilivaria</string>
-      <string>Epsilondasiavaria</string>
-      <string>Epsilonpsilioxia</string>
       <string>Epsilondasiaoxia</string>
-      <string>Epsilonvaria</string>
+      <string>Epsilondasiavaria</string>
       <string>Epsilonoxia</string>
+      <string>Epsilonpsili</string>
+      <string>Epsilonpsilioxia</string>
+      <string>Epsilonpsilivaria</string>
+      <string>Epsilontonos</string>
+      <string>Epsilonvaria</string>
+      <string>Xi</string>
     </array>
     <key>public.kern1.GRK_Eta</key>
     <array>
       <string>Eta</string>
+      <string>Etadasia</string>
+      <string>Etadasiaoxia</string>
+      <string>Etadasiaoxiaprosgegrammeni</string>
+      <string>Etadasiaperispomeni</string>
+      <string>Etadasiaperispomeniprosgegrammeni</string>
+      <string>Etadasiaprosgegrammeni</string>
+      <string>Etadasiavaria</string>
+      <string>Etadasiavariaprosgegrammeni</string>
+      <string>Etaoxia</string>
+      <string>Etaprosgegrammeni</string>
+      <string>Etapsili</string>
+      <string>Etapsilioxia</string>
+      <string>Etapsilioxiaprosgegrammeni</string>
+      <string>Etapsiliperispomeni</string>
+      <string>Etapsiliperispomeniprosgegrammeni</string>
+      <string>Etapsiliprosgegrammeni</string>
+      <string>Etapsilivaria</string>
+      <string>Etapsilivariaprosgegrammeni</string>
+      <string>Etatonos</string>
+      <string>Etavaria</string>
       <string>Iota</string>
+      <string>Iotadasia</string>
+      <string>Iotadasiaoxia</string>
+      <string>Iotadasiaperispomeni</string>
+      <string>Iotadasiavaria</string>
+      <string>Iotadieresis</string>
+      <string>Iotamacron</string>
+      <string>Iotaoxia</string>
+      <string>Iotapsili</string>
+      <string>Iotapsilioxia</string>
+      <string>Iotapsiliperispomeni</string>
+      <string>Iotapsilivaria</string>
+      <string>Iotatonos</string>
+      <string>Iotavaria</string>
+      <string>Iotavrachy</string>
       <string>Mu</string>
       <string>Nu</string>
       <string>Pi</string>
-      <string>Etatonos</string>
-      <string>Iotatonos</string>
-      <string>Iotadieresis</string>
-      <string>Etapsili</string>
-      <string>Etadasia</string>
-      <string>Etapsilivaria</string>
-      <string>Etadasiavaria</string>
-      <string>Etapsilioxia</string>
-      <string>Etadasiaoxia</string>
-      <string>Etapsiliperispomeni</string>
-      <string>Etadasiaperispomeni</string>
-      <string>Etavaria</string>
-      <string>Etaoxia</string>
-      <string>Etaprosgegrammeni</string>
-      <string>Etapsiliprosgegrammeni</string>
-      <string>Etadasiaprosgegrammeni</string>
-      <string>Etapsilivariaprosgegrammeni</string>
-      <string>Etadasiavariaprosgegrammeni</string>
-      <string>Etapsilioxiaprosgegrammeni</string>
-      <string>Etadasiaoxiaprosgegrammeni</string>
-      <string>Etapsiliperispomeniprosgegrammeni</string>
-      <string>Etadasiaperispomeniprosgegrammeni</string>
-      <string>Iotapsili</string>
-      <string>Iotadasia</string>
-      <string>Iotapsilivaria</string>
-      <string>Iotadasiavaria</string>
-      <string>Iotapsilioxia</string>
-      <string>Iotadasiaoxia</string>
-      <string>Iotapsiliperispomeni</string>
-      <string>Iotadasiaperispomeni</string>
-      <string>Iotavaria</string>
-      <string>Iotaoxia</string>
-      <string>Iotavrachy</string>
-      <string>Iotamacron</string>
     </array>
     <key>public.kern1.GRK_Gamma</key>
     <array>
@@ -439,39 +439,39 @@
     </array>
     <key>public.kern1.GRK_Kappa</key>
     <array>
-      <string>Kappa</string>
       <string>KaiSymbol</string>
+      <string>Kappa</string>
     </array>
     <key>public.kern1.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegatonos</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
       <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegapsiliperispomeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegatonos</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern1.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
-      <string>Phi</string>
       <string>Omicrontonos</string>
+      <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern1.GRK_Psi</key>
     <array>
@@ -493,16 +493,16 @@
     <key>public.kern1.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilontonos</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilontonos</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern1.GRK_Zeta</key>
     <array>
@@ -511,115 +511,115 @@
     <key>public.kern1.GRK_alpha</key>
     <array>
       <string>alpha</string>
-      <string>mu</string>
-      <string>alphatonos</string>
-      <string>alphapsili</string>
       <string>alphadasia</string>
-      <string>alphapsilivaria</string>
-      <string>alphadasiavaria</string>
-      <string>alphapsilioxia</string>
-      <string>alphadasiaoxia</string>
-      <string>alphapsiliperispomeni</string>
-      <string>alphadasiaperispomeni</string>
-      <string>alphavaria</string>
-      <string>alphaoxia</string>
-      <string>alphaperispomeni</string>
-      <string>alphavrachy</string>
-      <string>alphamacron</string>
-      <string>alphaypogegrammeni</string>
-      <string>alphavariaypogegrammeni</string>
-      <string>alphaoxiaypogegrammeni</string>
-      <string>alphapsiliypogegrammeni</string>
-      <string>alphadasiaypogegrammeni</string>
-      <string>alphapsilivariaypogegrammeni</string>
-      <string>alphadasiavariaypogegrammeni</string>
-      <string>alphapsilioxiaypogegrammeni</string>
-      <string>alphadasiaoxiaypogegrammeni</string>
-      <string>alphapsiliperispomeniypogegrammeni</string>
-      <string>alphadasiaperispomeniypogegrammeni</string>
-      <string>alphaperispomeniypogegrammeni</string>
-      <string>alphaypogegrammeni.sc.ad</string>
-      <string>alphavariaypogegrammeni.sc.ad</string>
-      <string>alphaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliypogegrammeni.sc.ad</string>
-      <string>alphadasiaypogegrammeni.sc.ad</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad</string>
-      <string>alphapsili.sc</string>
       <string>alphadasia.sc</string>
-      <string>alphapsilivaria.sc</string>
-      <string>alphadasiavaria.sc</string>
-      <string>alphapsilioxia.sc</string>
-      <string>alphadasiaoxia.sc</string>
-      <string>alphapsiliperispomeni.sc</string>
-      <string>alphadasiaperispomeni.sc</string>
-      <string>alphavaria.sc</string>
-      <string>alphaoxia.sc</string>
-      <string>alphaperispomeni.sc</string>
-      <string>alphavrachy.sc</string>
-      <string>alphamacron.sc</string>
-      <string>alphaypogegrammeni.sc</string>
-      <string>alphavariaypogegrammeni.sc</string>
-      <string>alphaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliypogegrammeni.sc</string>
-      <string>alphadasiaypogegrammeni.sc</string>
-      <string>alphapsilivariaypogegrammeni.sc</string>
-      <string>alphadasiavariaypogegrammeni.sc</string>
-      <string>alphapsilioxiaypogegrammeni.sc</string>
-      <string>alphadasiaoxiaypogegrammeni.sc</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc</string>
-      <string>alphaperispomeniypogegrammeni.sc</string>
-      <string>alphaypogegrammeni.sc.ad.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>alphapsili.sc.ss06</string>
       <string>alphadasia.sc.ss06</string>
-      <string>alphapsilivaria.sc.ss06</string>
-      <string>alphadasiavaria.sc.ss06</string>
-      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphadasiaoxia</string>
+      <string>alphadasiaoxia.sc</string>
       <string>alphadasiaoxia.sc.ss06</string>
-      <string>alphapsiliperispomeni.sc.ss06</string>
-      <string>alphadasiaperispomeni.sc.ss06</string>
-      <string>alphavaria.sc.ss06</string>
-      <string>alphaoxia.sc.ss06</string>
-      <string>alphaperispomeni.sc.ss06</string>
-      <string>alphavrachy.sc.ss06</string>
-      <string>alphamacron.sc.ss06</string>
-      <string>alphaypogegrammeni.sc.ss06</string>
-      <string>alphavariaypogegrammeni.sc.ss06</string>
-      <string>alphaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliypogegrammeni.sc.ss06</string>
-      <string>alphadasiaypogegrammeni.sc.ss06</string>
-      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
-      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
-      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaoxiaypogegrammeni</string>
+      <string>alphadasiaoxiaypogegrammeni.sc</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiaperispomeni</string>
+      <string>alphadasiaperispomeni.sc</string>
+      <string>alphadasiaperispomeni.sc.ss06</string>
+      <string>alphadasiaperispomeniypogegrammeni</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphadasiavaria</string>
+      <string>alphadasiavaria.sc</string>
+      <string>alphadasiavaria.sc.ss06</string>
+      <string>alphadasiavariaypogegrammeni</string>
+      <string>alphadasiavariaypogegrammeni.sc</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad</string>
+      <string>alphadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiavariaypogegrammeni.sc.ss06</string>
+      <string>alphadasiaypogegrammeni</string>
+      <string>alphadasiaypogegrammeni.sc</string>
+      <string>alphadasiaypogegrammeni.sc.ad</string>
+      <string>alphadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphadasiaypogegrammeni.sc.ss06</string>
+      <string>alphamacron</string>
+      <string>alphamacron.sc</string>
+      <string>alphamacron.sc.ss06</string>
+      <string>alphaoxia</string>
+      <string>alphaoxia.sc</string>
+      <string>alphaoxia.sc.ss06</string>
+      <string>alphaoxiaypogegrammeni</string>
+      <string>alphaoxiaypogegrammeni.sc</string>
+      <string>alphaoxiaypogegrammeni.sc.ad</string>
+      <string>alphaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaoxiaypogegrammeni.sc.ss06</string>
+      <string>alphaperispomeni</string>
+      <string>alphaperispomeni.sc</string>
+      <string>alphaperispomeni.sc.ss06</string>
+      <string>alphaperispomeniypogegrammeni</string>
+      <string>alphaperispomeniypogegrammeni.sc</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad</string>
+      <string>alphaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>alphaperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsili</string>
+      <string>alphapsili.sc</string>
+      <string>alphapsili.sc.ss06</string>
+      <string>alphapsilioxia</string>
+      <string>alphapsilioxia.sc</string>
+      <string>alphapsilioxia.sc.ss06</string>
+      <string>alphapsilioxiaypogegrammeni</string>
+      <string>alphapsilioxiaypogegrammeni.sc</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliperispomeni</string>
+      <string>alphapsiliperispomeni.sc</string>
+      <string>alphapsiliperispomeni.sc.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>alphapsilivaria</string>
+      <string>alphapsilivaria.sc</string>
+      <string>alphapsilivaria.sc.ss06</string>
+      <string>alphapsilivariaypogegrammeni</string>
+      <string>alphapsilivariaypogegrammeni.sc</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad</string>
+      <string>alphapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsilivariaypogegrammeni.sc.ss06</string>
+      <string>alphapsiliypogegrammeni</string>
+      <string>alphapsiliypogegrammeni.sc</string>
+      <string>alphapsiliypogegrammeni.sc.ad</string>
+      <string>alphapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>alphapsiliypogegrammeni.sc.ss06</string>
+      <string>alphatonos</string>
+      <string>alphavaria</string>
+      <string>alphavaria.sc</string>
+      <string>alphavaria.sc.ss06</string>
+      <string>alphavariaypogegrammeni</string>
+      <string>alphavariaypogegrammeni.sc</string>
+      <string>alphavariaypogegrammeni.sc.ad</string>
+      <string>alphavariaypogegrammeni.sc.ad.ss06</string>
+      <string>alphavariaypogegrammeni.sc.ss06</string>
+      <string>alphavrachy</string>
+      <string>alphavrachy.sc</string>
+      <string>alphavrachy.sc.ss06</string>
+      <string>alphaypogegrammeni</string>
+      <string>alphaypogegrammeni.sc</string>
+      <string>alphaypogegrammeni.sc.ad</string>
+      <string>alphaypogegrammeni.sc.ad.ss06</string>
+      <string>alphaypogegrammeni.sc.ss06</string>
+      <string>mu</string>
     </array>
     <key>public.kern1.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern1.GRK_beta</key>
     <array>
@@ -640,152 +640,152 @@
     <key>public.kern1.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_epsilon.sc</key>
     <array>
       <string>epsilon.sc</string>
-      <string>xi.sc</string>
       <string>epsilontonos.sc</string>
       <string>epsilontonos.sc.ss06</string>
+      <string>xi.sc</string>
     </array>
     <key>public.kern1.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_eta.sc</key>
     <array>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_gamma</key>
     <array>
@@ -798,95 +798,95 @@
     </array>
     <key>public.kern1.GRK_iota</key>
     <array>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
       <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
       <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Etaprosgegrammeni.ad</string>
-      <string>Etapsiliprosgegrammeni.ad</string>
-      <string>Etadasiaprosgegrammeni.ad</string>
-      <string>Etapsilivariaprosgegrammeni.ad</string>
-      <string>Etadasiavariaprosgegrammeni.ad</string>
-      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
       <string>Etadasiaoxiaprosgegrammeni.ad</string>
-      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
       <string>Etadasiaperispomeniprosgegrammeni.ad</string>
-      <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
-      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Etadasiaprosgegrammeni.ad</string>
+      <string>Etadasiavariaprosgegrammeni.ad</string>
+      <string>Etaprosgegrammeni.ad</string>
+      <string>Etapsilioxiaprosgegrammeni.ad</string>
+      <string>Etapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Etapsiliprosgegrammeni.ad</string>
+      <string>Etapsilivariaprosgegrammeni.ad</string>
       <string>Omegadasiaoxiaprosgegrammeni.ad</string>
-      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegaprosgegrammeni.ad</string>
+      <string>Omegapsilioxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_kappa</key>
     <array>
-      <string>kappa</string>
       <string>kaiSymbol</string>
+      <string>kappa</string>
     </array>
     <key>public.kern1.GRK_kappa.sc</key>
     <array>
-      <string>kappa.sc</string>
       <string>kaiSymbol.sc</string>
+      <string>kappa.sc</string>
     </array>
     <key>public.kern1.GRK_lambda</key>
     <array>
@@ -895,145 +895,145 @@
     <key>public.kern1.GRK_omicron</key>
     <array>
       <string>delta</string>
-      <string>omicron</string>
-      <string>rho</string>
-      <string>phi</string>
       <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>rhopsili</string>
-      <string>rhodasia</string>
-      <string>omegapsili</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>rhopsili.sc</string>
-      <string>rhodasia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>rhopsili.sc.ss06</string>
-      <string>rhodasia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>rho</string>
+      <string>rhodasia</string>
+      <string>rhodasia.sc</string>
+      <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern1.GRK_phi.sc</key>
     <array>
@@ -1057,8 +1057,8 @@
     </array>
     <key>public.kern1.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern1.GRK_tau</key>
     <array>
@@ -1074,69 +1074,69 @@
     </array>
     <key>public.kern1.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern1.GRK_xi</key>
     <array>
@@ -1152,9 +1152,9 @@
     </array>
     <key>public.kern1.GUJ_h_nna-gujarati_R</key>
     <array>
-      <string>h_nna-gujarati</string>
-      <string>h_na-gujarati</string>
       <string>h_la-gujarati</string>
+      <string>h_na-gujarati</string>
+      <string>h_nna-gujarati</string>
       <string>h_va-gujarati</string>
     </array>
     <key>public.kern1.GUJ_j-gujarati_R</key>
@@ -1214,21 +1214,21 @@
     <key>public.kern1.GUR_ca-gurmukhi_R</key>
     <array>
       <string>ca-gurmukhi</string>
-      <string>ra-gurmukhi</string>
       <string>ha-gurmukhi</string>
+      <string>ra-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_cha-gurmukhi_R</key>
     <array>
       <string>cha-gurmukhi</string>
       <string>ddha-gurmukhi</string>
-      <string>pha-gurmukhi</string>
       <string>fa-gurmukhi</string>
+      <string>pha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_i-gurmukhi_R</key>
     <array>
-      <string>i-gurmukhi</string>
-      <string>ee-gurmukhi</string>
       <string>da-gurmukhi</string>
+      <string>ee-gurmukhi</string>
+      <string>i-gurmukhi</string>
       <string>iri-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_jha-gurmukhi_R</key>
@@ -1262,30 +1262,31 @@
     </array>
     <key>public.kern1.GUR_tta-gurmukhi_R</key>
     <array>
-      <string>tta-gurmukhi</string>
       <string>nna-gurmukhi</string>
+      <string>tta-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_ttha-gurmukhi_R</key>
     <array>
-      <string>ttha-gurmukhi</string>
       <string>na-gurmukhi</string>
+      <string>ttha-gurmukhi</string>
     </array>
     <key>public.kern1.GUR_u-gurmukhi_R</key>
     <array>
-      <string>u-gurmukhi</string>
-      <string>uu-gurmukhi</string>
-      <string>oo-gurmukhi</string>
       <string>dda-gurmukhi</string>
+      <string>oo-gurmukhi</string>
+      <string>u-gurmukhi</string>
       <string>ura-gurmukhi</string>
+      <string>uu-gurmukhi</string>
     </array>
     <key>public.kern1.Gan-georgian</key>
     <array>
-      <string>Gan-georgian</string>
       <string>Chin-georgian</string>
+      <string>Gan-georgian</string>
       <string>Yn-georgian</string>
     </array>
     <key>public.kern1.H</key>
     <array>
+      <string>Eng.alt</string>
       <string>H</string>
       <string>Hbar</string>
       <string>Hcircumflex</string>
@@ -1299,7 +1300,6 @@
       <string>Nacute</string>
       <string>Ncaron</string>
       <string>Ncommaaccent</string>
-      <string>Eng.alt</string>
       <string>Ntilde</string>
     </array>
     <key>public.kern1.I_right</key>
@@ -1314,24 +1314,24 @@
     </array>
     <key>public.kern1.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern1.J</key>
     <array>
+      <string>IJ</string>
       <string>J</string>
       <string>Jcircumflex</string>
       <string>Je-cy</string>
-      <string>IJ</string>
     </array>
     <key>public.kern1.K</key>
     <array>
       <string>K</string>
-      <string>Kcommaaccent</string>
       <string>K.alt</string>
+      <string>Kcommaaccent</string>
     </array>
     <key>public.kern1.KND-sha-kannada_L</key>
     <array>
@@ -1359,8 +1359,8 @@
     </array>
     <key>public.kern1.KND_bha-kannada_L</key>
     <array>
-      <string>bha-kannada</string>
       <string>be-kannada</string>
+      <string>bha-kannada</string>
       <string>bhe-kannada</string>
     </array>
     <key>public.kern1.KND_braceleft.loclKNDA_L</key>
@@ -1378,20 +1378,20 @@
     <key>public.kern1.KND_ca-kannada_L</key>
     <array>
       <string>ca-kannada</string>
-      <string>ci-kannada</string>
       <string>ce-kannada</string>
+      <string>ci-kannada</string>
     </array>
     <key>public.kern1.KND_cha-kannada.below_L</key>
     <array>
-      <string>cha-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>cha-kannada.below</string>
     </array>
     <key>public.kern1.KND_cha-kannada_L</key>
     <array>
       <string>cha-kannada</string>
-      <string>chi-kannada</string>
       <string>che-kannada</string>
+      <string>chi-kannada</string>
     </array>
     <key>public.kern1.KND_dda-kannada.below_L</key>
     <array>
@@ -1401,14 +1401,14 @@
     <key>public.kern1.KND_dda-kannada_L</key>
     <array>
       <string>dda-kannada</string>
-      <string>ddha-kannada</string>
       <string>dde-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhe-kannada</string>
     </array>
     <key>public.kern1.KND_ddi-kannada_L</key>
     <array>
-      <string>ddi-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddi-kannada</string>
     </array>
     <key>public.kern1.KND_e-kannada_L</key>
     <array>
@@ -1435,8 +1435,8 @@
     <key>public.kern1.KND_gha-kannada_L</key>
     <array>
       <string>gha-kannada</string>
-      <string>ghi-kannada</string>
       <string>ghe-kannada</string>
+      <string>ghi-kannada</string>
     </array>
     <key>public.kern1.KND_ha-kannada.below_L</key>
     <array>
@@ -1481,50 +1481,50 @@
     </array>
     <key>public.kern1.KND_k-kannada_L</key>
     <array>
-      <string>k-kannada</string>
-      <string>kh-kannada</string>
-      <string>g-kannada</string>
-      <string>gh-kannada</string>
-      <string>ng-kannada</string>
-      <string>c-kannada</string>
-      <string>ch-kannada</string>
-      <string>j-kannada</string>
-      <string>jh-kannada</string>
-      <string>ny-kannada</string>
-      <string>tt-kannada</string>
-      <string>tth-kannada</string>
-      <string>dd-kannada</string>
-      <string>ddh-kannada</string>
-      <string>nn-kannada</string>
-      <string>t-kannada</string>
-      <string>th-kannada</string>
-      <string>d-kannada</string>
-      <string>dh-kannada</string>
-      <string>n-kannada</string>
-      <string>p-kannada</string>
-      <string>ph-kannada</string>
       <string>b-kannada</string>
       <string>bh-kannada</string>
-      <string>m-kannada</string>
-      <string>y-kannada</string>
-      <string>r-kannada</string>
-      <string>rr-kannada</string>
+      <string>c-kannada</string>
+      <string>ch-kannada</string>
+      <string>d-kannada</string>
+      <string>dd-kannada</string>
+      <string>ddh-kannada</string>
+      <string>dh-kannada</string>
+      <string>g-kannada</string>
+      <string>gh-kannada</string>
+      <string>h-kannada</string>
+      <string>j-kannada</string>
+      <string>jh-kannada</string>
+      <string>k-kannada</string>
+      <string>k_ss-kannada</string>
+      <string>kh-kannada</string>
       <string>l-kannada</string>
       <string>ll-kannada</string>
       <string>lll-kannada</string>
-      <string>v-kannada</string>
+      <string>m-kannada</string>
+      <string>n-kannada</string>
+      <string>ng-kannada</string>
+      <string>nn-kannada</string>
+      <string>ny-kannada</string>
+      <string>p-kannada</string>
+      <string>ph-kannada</string>
+      <string>r-kannada</string>
+      <string>rr-kannada</string>
+      <string>s-kannada</string>
       <string>sh-kannada</string>
       <string>ss-kannada</string>
       <string>ss-kannada.short</string>
-      <string>s-kannada</string>
-      <string>h-kannada</string>
-      <string>k_ss-kannada</string>
+      <string>t-kannada</string>
+      <string>th-kannada</string>
+      <string>tt-kannada</string>
+      <string>tth-kannada</string>
+      <string>v-kannada</string>
+      <string>y-kannada</string>
     </array>
     <key>public.kern1.KND_k_ssa-kannada_L</key>
     <array>
       <string>k_ssa-kannada</string>
-      <string>k_ssi-kannada</string>
       <string>k_sse-kannada</string>
+      <string>k_ssi-kannada</string>
     </array>
     <key>public.kern1.KND_ka-kannada.below_L</key>
     <array>
@@ -1537,83 +1537,83 @@
     </array>
     <key>public.kern1.KND_kaa-kannada_L</key>
     <array>
-      <string>kaa-kannada</string>
-      <string>khaa-kannada</string>
-      <string>gaa-kannada</string>
-      <string>ghaa-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>caa-kannada</string>
-      <string>chaa-kannada</string>
-      <string>jaa-kannada</string>
-      <string>jhaa-kannada</string>
-      <string>nyaa-kannada</string>
-      <string>ttaa-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddhaa-kannada</string>
-      <string>nnaa-kannada</string>
-      <string>taa-kannada</string>
-      <string>thaa-kannada</string>
-      <string>daa-kannada</string>
-      <string>dhaa-kannada</string>
-      <string>naa-kannada</string>
-      <string>paa-kannada</string>
-      <string>phaa-kannada</string>
       <string>baa-kannada</string>
       <string>bhaa-kannada</string>
-      <string>maa-kannada</string>
-      <string>yaa-kannada</string>
-      <string>raa-kannada</string>
-      <string>rraa-kannada</string>
+      <string>caa-kannada</string>
+      <string>chaa-kannada</string>
+      <string>daa-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddhaa-kannada</string>
+      <string>dhaa-kannada</string>
+      <string>gaa-kannada</string>
+      <string>ghaa-kannada</string>
+      <string>haa-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jhaa-kannada</string>
+      <string>k_ssaa-kannada</string>
+      <string>kaa-kannada</string>
+      <string>khaa-kannada</string>
       <string>laa-kannada</string>
       <string>llaa-kannada</string>
       <string>lllaa-kannada</string>
-      <string>vaa-kannada</string>
+      <string>maa-kannada</string>
+      <string>naa-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>nnaa-kannada</string>
+      <string>nyaa-kannada</string>
+      <string>paa-kannada</string>
+      <string>phaa-kannada</string>
+      <string>raa-kannada</string>
+      <string>rraa-kannada</string>
+      <string>saa-kannada</string>
       <string>shaa-kannada</string>
       <string>ssaa-kannada</string>
-      <string>saa-kannada</string>
-      <string>haa-kannada</string>
-      <string>k_ssaa-kannada</string>
+      <string>taa-kannada</string>
+      <string>thaa-kannada</string>
+      <string>ttaa-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>vaa-kannada</string>
+      <string>yaa-kannada</string>
     </array>
     <key>public.kern1.KND_kau-kannada_L</key>
     <array>
-      <string>kau-kannada</string>
-      <string>khau-kannada</string>
-      <string>gau-kannada</string>
-      <string>ghau-kannada</string>
-      <string>ngau-kannada</string>
-      <string>cau-kannada</string>
-      <string>chau-kannada</string>
-      <string>jau-kannada</string>
-      <string>jhau-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tthau-kannada</string>
-      <string>ddau-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>nnau-kannada</string>
-      <string>tau-kannada</string>
-      <string>thau-kannada</string>
-      <string>dau-kannada</string>
-      <string>dhau-kannada</string>
-      <string>nau-kannada</string>
-      <string>pau-kannada</string>
-      <string>phau-kannada</string>
       <string>bau-kannada</string>
       <string>bhau-kannada</string>
-      <string>mau-kannada</string>
-      <string>yau-kannada</string>
-      <string>rau-kannada</string>
-      <string>rrau-kannada</string>
+      <string>cau-kannada</string>
+      <string>chau-kannada</string>
+      <string>dau-kannada</string>
+      <string>ddau-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>dhau-kannada</string>
+      <string>gau-kannada</string>
+      <string>ghau-kannada</string>
+      <string>hau-kannada</string>
+      <string>jau-kannada</string>
+      <string>jhau-kannada</string>
+      <string>k_ssau-kannada</string>
+      <string>kau-kannada</string>
+      <string>khau-kannada</string>
       <string>lau-kannada</string>
       <string>llau-kannada</string>
       <string>lllau-kannada</string>
-      <string>vau-kannada</string>
+      <string>mau-kannada</string>
+      <string>nau-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nnau-kannada</string>
+      <string>nyau-kannada</string>
+      <string>pau-kannada</string>
+      <string>phau-kannada</string>
+      <string>rau-kannada</string>
+      <string>rrau-kannada</string>
+      <string>sau-kannada</string>
       <string>shau-kannada</string>
       <string>ssau-kannada</string>
-      <string>sau-kannada</string>
-      <string>hau-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>tau-kannada</string>
+      <string>thau-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tthau-kannada</string>
+      <string>vau-kannada</string>
+      <string>yau-kannada</string>
     </array>
     <key>public.kern1.KND_kha-kannada.below_L</key>
     <array>
@@ -1621,9 +1621,9 @@
     </array>
     <key>public.kern1.KND_khi-kannada_L</key>
     <array>
-      <string>khi-kannada</string>
-      <string>bi-kannada</string>
       <string>bhi-kannada</string>
+      <string>bi-kannada</string>
+      <string>khi-kannada</string>
     </array>
     <key>public.kern1.KND_ki-kannada_L</key>
     <array>
@@ -1694,8 +1694,8 @@
     <key>public.kern1.KND_nge-kannada_L</key>
     <array>
       <string>nge-kannada</string>
-      <string>nyi-kannada</string>
       <string>nye-kannada</string>
+      <string>nyi-kannada</string>
     </array>
     <key>public.kern1.KND_ngi-kannada_L</key>
     <array>
@@ -1723,8 +1723,8 @@
     </array>
     <key>public.kern1.KND_nyi-kannada_L</key>
     <array>
-      <string>rri-kannada</string>
       <string>llli-kannada</string>
+      <string>rri-kannada</string>
     </array>
     <key>public.kern1.KND_o-kannada_L</key>
     <array>
@@ -1739,10 +1739,10 @@
     <key>public.kern1.KND_pa-kannada_L</key>
     <array>
       <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>sa-kannada</string>
       <string>pe-kannada</string>
+      <string>pha-kannada</string>
       <string>phe-kannada</string>
+      <string>sa-kannada</string>
       <string>se-kannada</string>
     </array>
     <key>public.kern1.KND_parenleft.loclKNDA_L</key>
@@ -1751,14 +1751,14 @@
     </array>
     <key>public.kern1.KND_pi-kannada_L</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>si-kannada</string>
     </array>
     <key>public.kern1.KND_pu-kannada_L</key>
     <array>
-      <string>pu-kannada</string>
       <string>phu-kannada</string>
+      <string>pu-kannada</string>
       <string>vu-kannada</string>
     </array>
     <key>public.kern1.KND_quoteleft.loclKNDA_L</key>
@@ -1776,81 +1776,81 @@
     </array>
     <key>public.kern1.KND_rrVocalic-kannada_L</key>
     <array>
-      <string>rrVocalic-kannada</string>
-      <string>kuu-kannada</string>
-      <string>ko-kannada</string>
-      <string>khuu-kannada</string>
-      <string>kho-kannada</string>
-      <string>guu-kannada</string>
-      <string>go-kannada</string>
-      <string>ghuu-kannada</string>
-      <string>gho-kannada</string>
-      <string>nguu-kannada</string>
-      <string>ngo-kannada</string>
-      <string>cuu-kannada</string>
-      <string>co-kannada</string>
-      <string>chuu-kannada</string>
-      <string>cho-kannada</string>
-      <string>juu-kannada</string>
-      <string>jo-kannada</string>
-      <string>jhuu-kannada</string>
-      <string>jho-kannada</string>
-      <string>nyuu-kannada</string>
-      <string>nyo-kannada</string>
-      <string>ttuu-kannada</string>
-      <string>tto-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>ttho-kannada</string>
-      <string>dduu-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddhuu-kannada</string>
-      <string>ddho-kannada</string>
-      <string>nnuu-kannada</string>
-      <string>nno-kannada</string>
-      <string>tuu-kannada</string>
-      <string>to-kannada</string>
-      <string>thuu-kannada</string>
-      <string>tho-kannada</string>
-      <string>duu-kannada</string>
-      <string>do-kannada</string>
-      <string>dhuu-kannada</string>
-      <string>dho-kannada</string>
-      <string>nuu-kannada</string>
-      <string>no-kannada</string>
-      <string>puu-kannada</string>
-      <string>po-kannada</string>
-      <string>phuu-kannada</string>
-      <string>pho-kannada</string>
-      <string>buu-kannada</string>
-      <string>bo-kannada</string>
-      <string>bhuu-kannada</string>
       <string>bho-kannada</string>
-      <string>muu-kannada</string>
-      <string>mo-kannada</string>
-      <string>yuu-kannada</string>
-      <string>yo-kannada</string>
-      <string>ruu-kannada</string>
-      <string>ro-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rro-kannada</string>
-      <string>luu-kannada</string>
-      <string>lo-kannada</string>
-      <string>lluu-kannada</string>
-      <string>llo-kannada</string>
-      <string>llluu-kannada</string>
-      <string>lllo-kannada</string>
-      <string>vuu-kannada</string>
-      <string>vo-kannada</string>
-      <string>shuu-kannada</string>
-      <string>sho-kannada</string>
-      <string>ssuu-kannada</string>
-      <string>sso-kannada</string>
-      <string>suu-kannada</string>
-      <string>so-kannada</string>
-      <string>huu-kannada</string>
+      <string>bhuu-kannada</string>
+      <string>bo-kannada</string>
+      <string>buu-kannada</string>
+      <string>cho-kannada</string>
+      <string>chuu-kannada</string>
+      <string>co-kannada</string>
+      <string>cuu-kannada</string>
+      <string>ddho-kannada</string>
+      <string>ddhuu-kannada</string>
+      <string>ddo-kannada</string>
+      <string>dduu-kannada</string>
+      <string>dho-kannada</string>
+      <string>dhuu-kannada</string>
+      <string>do-kannada</string>
+      <string>duu-kannada</string>
+      <string>gho-kannada</string>
+      <string>ghuu-kannada</string>
+      <string>go-kannada</string>
+      <string>guu-kannada</string>
       <string>ho-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>huu-kannada</string>
+      <string>jho-kannada</string>
+      <string>jhuu-kannada</string>
+      <string>jo-kannada</string>
+      <string>juu-kannada</string>
       <string>k_sso-kannada</string>
+      <string>k_ssuu-kannada</string>
+      <string>kho-kannada</string>
+      <string>khuu-kannada</string>
+      <string>ko-kannada</string>
+      <string>kuu-kannada</string>
+      <string>lllo-kannada</string>
+      <string>llluu-kannada</string>
+      <string>llo-kannada</string>
+      <string>lluu-kannada</string>
+      <string>lo-kannada</string>
+      <string>luu-kannada</string>
+      <string>mo-kannada</string>
+      <string>muu-kannada</string>
+      <string>ngo-kannada</string>
+      <string>nguu-kannada</string>
+      <string>nno-kannada</string>
+      <string>nnuu-kannada</string>
+      <string>no-kannada</string>
+      <string>nuu-kannada</string>
+      <string>nyo-kannada</string>
+      <string>nyuu-kannada</string>
+      <string>pho-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>puu-kannada</string>
+      <string>ro-kannada</string>
+      <string>rrVocalic-kannada</string>
+      <string>rro-kannada</string>
+      <string>rruu-kannada</string>
+      <string>ruu-kannada</string>
+      <string>sho-kannada</string>
+      <string>shuu-kannada</string>
+      <string>so-kannada</string>
+      <string>sso-kannada</string>
+      <string>ssuu-kannada</string>
+      <string>suu-kannada</string>
+      <string>tho-kannada</string>
+      <string>thuu-kannada</string>
+      <string>to-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthuu-kannada</string>
+      <string>tto-kannada</string>
+      <string>ttuu-kannada</string>
+      <string>tuu-kannada</string>
+      <string>vo-kannada</string>
+      <string>vuu-kannada</string>
+      <string>yo-kannada</string>
+      <string>yuu-kannada</string>
     </array>
     <key>public.kern1.KND_rrVocalicMatra-kannada_L</key>
     <array>
@@ -1858,13 +1858,13 @@
     </array>
     <key>public.kern1.KND_rra-kannada.below_L</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern1.KND_rra-kannada_L</key>
     <array>
-      <string>rra-kannada</string>
       <string>llla-kannada</string>
+      <string>rra-kannada</string>
     </array>
     <key>public.kern1.KND_sa-kannada.below_L</key>
     <array>
@@ -1902,29 +1902,29 @@
     <key>public.kern1.KND_ta-kannada_L</key>
     <array>
       <string>ta-kannada</string>
-      <string>ti-kannada</string>
       <string>te-kannada</string>
+      <string>ti-kannada</string>
     </array>
     <key>public.kern1.KND_tha-kannada.below_L</key>
     <array>
-      <string>tha-kannada.below</string>
       <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern1.KND_tha-kannada_L</key>
     <array>
-      <string>tha-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>the-kannada</string>
       <string>de-kannada</string>
+      <string>dha-kannada</string>
       <string>dhe-kannada</string>
+      <string>tha-kannada</string>
+      <string>the-kannada</string>
     </array>
     <key>public.kern1.KND_thi-kannada_L</key>
     <array>
-      <string>thi-kannada</string>
-      <string>di-kannada</string>
       <string>dhi-kannada</string>
+      <string>di-kannada</string>
+      <string>thi-kannada</string>
     </array>
     <key>public.kern1.KND_tta-kannada.below_L</key>
     <array>
@@ -1933,8 +1933,8 @@
     <key>public.kern1.KND_tta-kannada_L</key>
     <array>
       <string>tta-kannada</string>
-      <string>tti-kannada</string>
       <string>tte-kannada</string>
+      <string>tti-kannada</string>
     </array>
     <key>public.kern1.KND_ttha-kannada.below_L</key>
     <array>
@@ -1942,70 +1942,70 @@
     </array>
     <key>public.kern1.KND_ttha-kannada_L</key>
     <array>
-      <string>ttha-kannada</string>
       <string>ra-kannada</string>
-      <string>tthe-kannada</string>
       <string>re-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthe-kannada</string>
     </array>
     <key>public.kern1.KND_tthi-kannada_L</key>
     <array>
-      <string>tthi-kannada</string>
       <string>ri-kannada</string>
+      <string>tthi-kannada</string>
     </array>
     <key>public.kern1.KND_u-kannada_L</key>
     <array>
-      <string>u-kannada</string>
-      <string>rVocalic-kannada</string>
-      <string>kha-kannada</string>
-      <string>jha-kannada</string>
       <string>ba-kannada</string>
-      <string>ma-kannada</string>
-      <string>ya-kannada</string>
-      <string>ku-kannada</string>
-      <string>khu-kannada</string>
-      <string>gu-kannada</string>
-      <string>ghu-kannada</string>
-      <string>ngu-kannada</string>
-      <string>cu-kannada</string>
+      <string>bhu-kannada</string>
+      <string>bu-kannada</string>
       <string>chu-kannada</string>
-      <string>ju-kannada</string>
+      <string>cu-kannada</string>
+      <string>ddhu-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dhu-kannada</string>
+      <string>du-kannada</string>
+      <string>ghu-kannada</string>
+      <string>gu-kannada</string>
+      <string>hu-kannada</string>
+      <string>jha-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
       <string>jhu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>nyu-kannada</string>
-      <string>ttu-kannada</string>
-      <string>tthu-kannada</string>
-      <string>ddu-kannada</string>
-      <string>ddhu-kannada</string>
-      <string>nnu-kannada</string>
-      <string>tu-kannada</string>
-      <string>thu-kannada</string>
-      <string>du-kannada</string>
-      <string>dhu-kannada</string>
-      <string>nu-kannada</string>
-      <string>bu-kannada</string>
-      <string>bhu-kannada</string>
+      <string>ju-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>kha-kannada</string>
+      <string>khu-kannada</string>
+      <string>ku-kannada</string>
+      <string>lllu-kannada</string>
+      <string>llu-kannada</string>
+      <string>lu-kannada</string>
+      <string>ma-kannada</string>
+      <string>me-kannada</string>
       <string>mi-kannada</string>
       <string>mu-kannada</string>
-      <string>me-kannada</string>
-      <string>yi-kannada</string>
-      <string>yu-kannada</string>
-      <string>ye-kannada</string>
-      <string>ru-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nnu-kannada</string>
+      <string>nu-kannada</string>
+      <string>nyu-kannada</string>
+      <string>rVocalic-kannada</string>
       <string>rru-kannada</string>
-      <string>lu-kannada</string>
-      <string>llu-kannada</string>
-      <string>lllu-kannada</string>
+      <string>ru-kannada</string>
       <string>shu-kannada</string>
       <string>ssu-kannada</string>
       <string>su-kannada</string>
-      <string>hu-kannada</string>
-      <string>k_ssu-kannada</string>
+      <string>thu-kannada</string>
+      <string>tthu-kannada</string>
+      <string>ttu-kannada</string>
+      <string>tu-kannada</string>
+      <string>u-kannada</string>
+      <string>ya-kannada</string>
+      <string>ye-kannada</string>
+      <string>yi-kannada</string>
+      <string>yu-kannada</string>
     </array>
     <key>public.kern1.KND_uu-kannada_L</key>
     <array>
-      <string>uu-kannada</string>
       <string>nna-kannada</string>
+      <string>uu-kannada</string>
     </array>
     <key>public.kern1.KND_va-kannada.below_L</key>
     <array>
@@ -2037,8 +2037,8 @@
     </array>
     <key>public.kern1.Las-georgian</key>
     <array>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern1.MAL_a-malayalam_R</key>
     <array>
@@ -2056,8 +2056,8 @@
     </array>
     <key>public.kern1.MAL_aulengthmark-malayalam-R</key>
     <array>
-      <string>ii-malayalam</string>
       <string>aulengthmark-malayalam</string>
+      <string>ii-malayalam</string>
     </array>
     <key>public.kern1.MAL_b_da-malayalam_R</key>
     <array>
@@ -2091,8 +2091,8 @@
     </array>
     <key>public.kern1.MAL_c_ca-malayalam_R</key>
     <array>
-      <string>c_ca-malayalam</string>
       <string>b_ba-malayalam</string>
+      <string>c_ca-malayalam</string>
       <string>v_va-malayalam</string>
     </array>
     <key>public.kern1.MAL_c_cha-malayalam_R</key>
@@ -2106,12 +2106,12 @@
     <key>public.kern1.MAL_cha-malayalam_R</key>
     <array>
       <string>cha-malayalam</string>
-      <string>ra-malayalam</string>
-      <string>sha-malayalam</string>
       <string>four-malayalam</string>
       <string>nine-malayalam</string>
       <string>ny_cha-malayalam</string>
+      <string>ra-malayalam</string>
       <string>sh_cha-malayalam</string>
+      <string>sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_d_da-malayalam_R</key>
     <array>
@@ -2161,8 +2161,8 @@
     </array>
     <key>public.kern1.MAL_ee-malayalam_R</key>
     <array>
-      <string>ee-malayalam</string>
       <string>ai-malayalam</string>
+      <string>ee-malayalam</string>
     </array>
     <key>public.kern1.MAL_five-malayalam_R</key>
     <array>
@@ -2182,15 +2182,15 @@
     </array>
     <key>public.kern1.MAL_ga-malayalam_R</key>
     <array>
-      <string>ga-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>na-malayalam</string>
-      <string>nnna-malayalam</string>
       <string>g_na-malayalam</string>
-      <string>nn_dda-malayalam</string>
-      <string>t_na-malayalam</string>
-      <string>n_na-malayalam</string>
+      <string>ga-malayalam</string>
       <string>h_na-malayalam</string>
+      <string>n_na-malayalam</string>
+      <string>na-malayalam</string>
+      <string>nn_dda-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nnna-malayalam</string>
+      <string>t_na-malayalam</string>
     </array>
     <key>public.kern1.MAL_h_la-malayalam_R</key>
     <array>
@@ -2203,9 +2203,9 @@
     </array>
     <key>public.kern1.MAL_ii-malayalam-R</key>
     <array>
-      <string>uu-malayalam</string>
       <string>au-malayalam</string>
       <string>auMatra-malayalam</string>
+      <string>uu-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja-malayalam.half_R</key>
     <array>
@@ -2213,8 +2213,8 @@
     </array>
     <key>public.kern1.MAL_ja-malayalam_R</key>
     <array>
-      <string>ja-malayalam</string>
       <string>j_ja-malayalam</string>
+      <string>ja-malayalam</string>
       <string>ny_ja-malayalam</string>
     </array>
     <key>public.kern1.MAL_ja_lVocalicMatra-malayalam_R</key>
@@ -2227,22 +2227,22 @@
     </array>
     <key>public.kern1.MAL_jha-malayalam.half_R</key>
     <array>
-      <string>jha-malayalam.half</string>
       <string>dda-malayalam.half</string>
+      <string>jha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_jha-malayalam_R</key>
     <array>
-      <string>jha-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>dda-malayalam</string>
       <string>dha-malayalam</string>
-      <string>ya-malayalam</string>
-      <string>sa-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>n_dha-malayalam</string>
       <string>onetenth-malayalam</string>
       <string>onetwentieths-malayalam</string>
-      <string>ten-malayalam</string>
+      <string>sa-malayalam</string>
       <string>t_sa-malayalam</string>
-      <string>d_dha-malayalam</string>
-      <string>n_dha-malayalam</string>
+      <string>ten-malayalam</string>
+      <string>ya-malayalam</string>
     </array>
     <key>public.kern1.MAL_kChillu-malayalam_R</key>
     <array>
@@ -2267,30 +2267,30 @@
     </array>
     <key>public.kern1.MAL_kha-malayalam.half_R</key>
     <array>
-      <string>kha-malayalam.half</string>
-      <string>gha-malayalam.half</string>
-      <string>ca-malayalam.half</string>
-      <string>pa-malayalam.half</string>
       <string>ba-malayalam.half</string>
-      <string>la-malayalam.half</string>
-      <string>va-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
+      <string>ca-malayalam.half</string>
+      <string>gha-malayalam.half</string>
       <string>k_ssa-malayalam.half</string>
+      <string>kha-malayalam.half</string>
+      <string>la-malayalam.half</string>
+      <string>pa-malayalam.half</string>
+      <string>ssa-malayalam.half</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_kha-malayalam_R</key>
     <array>
-      <string>kha-malayalam</string>
-      <string>gha-malayalam</string>
-      <string>ca-malayalam</string>
-      <string>pa-malayalam</string>
       <string>ba-malayalam</string>
-      <string>la-malayalam</string>
-      <string>va-malayalam</string>
-      <string>ssa-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>gha-malayalam</string>
       <string>k_ssa-malayalam</string>
-      <string>ny_ca-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>la-malayalam</string>
       <string>m_pa-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>pa-malayalam</string>
       <string>sh_ca-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>va-malayalam</string>
     </array>
     <key>public.kern1.MAL_l_la-malayalam_R</key>
     <array>
@@ -2302,8 +2302,8 @@
     </array>
     <key>public.kern1.MAL_lla-malayalam_R</key>
     <array>
-      <string>lla-malayalam</string>
       <string>ll_lla-malayalam</string>
+      <string>lla-malayalam</string>
     </array>
     <key>public.kern1.MAL_lllChillu-malayalam_R</key>
     <array>
@@ -2359,31 +2359,31 @@
     </array>
     <key>public.kern1.MAL_nna-malayalam.half_R</key>
     <array>
-      <string>nna-malayalam.half</string>
       <string>na-malayalam.half</string>
+      <string>nna-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_nya-malayalam_R</key>
     <array>
-      <string>nya-malayalam</string>
-      <string>ta-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
+      <string>eMatra-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>j_nya-malayalam</string>
       <string>k_ka-malayalam</string>
       <string>k_ta-malayalam</string>
-      <string>j_nya-malayalam</string>
-      <string>ny_nya-malayalam</string>
-      <string>t_ta-malayalam</string>
       <string>n_ta-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>t_ta-malayalam</string>
+      <string>ta-malayalam</string>
     </array>
     <key>public.kern1.MAL_o-malayalam_R</key>
     <array>
-      <string>o-malayalam</string>
-      <string>nga-malayalam</string>
       <string>da-malayalam</string>
       <string>g_da-malayalam</string>
       <string>n_da-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>o-malayalam</string>
     </array>
     <key>public.kern1.MAL_one-malayalam_R</key>
     <array>
@@ -2404,12 +2404,12 @@
     </array>
     <key>public.kern1.MAL_onehalf-malayalam_R</key>
     <array>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
       <string>llChillu-malayalam</string>
+      <string>nChillu-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rrChillu-malayalam</string>
+      <string>threequarters-malayalam</string>
     </array>
     <key>public.kern1.MAL_onehundredsixtieth-malayalam_R</key>
     <array>
@@ -2425,21 +2425,21 @@
     </array>
     <key>public.kern1.MAL_oo-malayalam_R</key>
     <array>
-      <string>oo-malayalam</string>
       <string>aaMatra-malayalam</string>
       <string>oMatra-malayalam</string>
+      <string>oo-malayalam</string>
       <string>ooMatra-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_la-malayalam_R</key>
     <array>
-      <string>p_la-malayalam</string>
       <string>b_dha-malayalam</string>
       <string>m_p_la-malayalam</string>
+      <string>p_la-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_pa-malayalam_R</key>
     <array>
-      <string>p_pa-malayalam</string>
       <string>l_pa-malayalam</string>
+      <string>p_pa-malayalam</string>
     </array>
     <key>public.kern1.MAL_p_ta-malayalam_R</key>
     <array>
@@ -2503,8 +2503,8 @@
     </array>
     <key>public.kern1.MAL_rra-malayalam.half_R</key>
     <array>
-      <string>rra-malayalam.half</string>
       <string>ha-malayalam.half</string>
+      <string>rra-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_rra_llVocalicMatra-malayalam_R</key>
     <array>
@@ -2528,13 +2528,13 @@
     </array>
     <key>public.kern1.MAL_sh_sha-malayalam_R</key>
     <array>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
     </array>
     <key>public.kern1.MAL_six-malayalam_R</key>
     <array>
-      <string>six-malayalam</string>
       <string>onehundred-malayalam</string>
+      <string>six-malayalam</string>
     </array>
     <key>public.kern1.MAL_ss_tta-malayalam_R</key>
     <array>
@@ -2546,26 +2546,26 @@
     </array>
     <key>public.kern1.MAL_tha-malayalam.half_R</key>
     <array>
-      <string>tha-malayalam.half</string>
-      <string>pha-malayalam.half</string>
       <string>ma-malayalam.half</string>
+      <string>pha-malayalam.half</string>
+      <string>tha-malayalam.half</string>
     </array>
     <key>public.kern1.MAL_tha-malayalam_R</key>
     <array>
-      <string>tha-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ma-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>threesixteenths-malayalam</string>
       <string>g_ma-malayalam</string>
-      <string>t_ma-malayalam</string>
-      <string>t_tha-malayalam</string>
+      <string>h_ma-malayalam</string>
+      <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
       <string>n_ma-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_ma-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>pha-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>h_ma-malayalam</string>
+      <string>t_ma-malayalam</string>
+      <string>t_tha-malayalam</string>
+      <string>tha-malayalam</string>
+      <string>threeeights-malayalam</string>
+      <string>threesixteenths-malayalam</string>
     </array>
     <key>public.kern1.MAL_tt_tta-malayalam_R</key>
     <array>
@@ -2609,8 +2609,8 @@
     </array>
     <key>public.kern1.MAL_two-malayalam_R</key>
     <array>
-      <string>two-malayalam</string>
       <string>three-malayalam</string>
+      <string>two-malayalam</string>
     </array>
     <key>public.kern1.MAL_uMatra-malayalam_R</key>
     <array>
@@ -2643,14 +2643,25 @@
     </array>
     <key>public.kern1.Man-georgian</key>
     <array>
+      <string>Jil-georgian</string>
       <string>Khar-georgian</string>
       <string>Qar-georgian</string>
-      <string>Jil-georgian</string>
     </array>
     <key>public.kern1.O</key>
     <array>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Ereversed-cy</string>
+      <string>Fita-cy</string>
+      <string>Haabkhasian-cy</string>
+      <string>Iu-cy</string>
       <string>O</string>
+      <string>O-cy</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -2659,32 +2670,21 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
       <string>Ohungarumlaut</string>
       <string>Omacron</string>
+      <string>Oopen</string>
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Ereversed-cy</string>
-      <string>Iu-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
+      <string>Qa-cy</string>
+      <string>Schwa</string>
       <string>Schwa-cy</string>
       <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
-      <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Oopen</string>
-      <string>Schwa</string>
     </array>
     <key>public.kern1.ODI_a-oriya-L</key>
     <array>
@@ -2695,48 +2695,48 @@
     <array>
       <string>a-oriya</string>
       <string>aa-oriya</string>
-      <string>e-oriya</string>
+      <string>aaMatra-oriya</string>
       <string>ai-oriya</string>
       <string>au-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>gha-oriya</string>
-      <string>nna-oriya</string>
-      <string>tha-oriya</string>
-      <string>dha-oriya</string>
-      <string>pa-oriya</string>
-      <string>ma-oriya</string>
-      <string>ya-oriya</string>
-      <string>sha-oriya</string>
-      <string>ssa-oriya</string>
-      <string>sa-oriya</string>
-      <string>aaMatra-oriya</string>
-      <string>iiMatra-oriya</string>
       <string>auLength-oriya</string>
-      <string>yya-oriya.blwf</string>
-      <string>k_ss_na-oriya</string>
-      <string>k_ss_ma-oriya</string>
-      <string>k_ssa-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>t_pa-oriya</string>
-      <string>t_ma-oriya</string>
       <string>dh_ya-oriya</string>
       <string>dh_yya-oriya</string>
+      <string>dha-oriya</string>
+      <string>e-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>gh_na-oriya</string>
+      <string>gha-oriya</string>
+      <string>iiMatra-oriya</string>
+      <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
+      <string>k_ssa-oriya</string>
+      <string>kha-oriya</string>
+      <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>ma-oriya</string>
+      <string>ng_gha-oriya</string>
+      <string>nna-oriya</string>
       <string>p_na-oriya</string>
       <string>p_pa-oriya</string>
       <string>p_sa-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_ma-oriya</string>
-      <string>ss_pa-oriya</string>
-      <string>ss_ma-oriya</string>
-      <string>s_tha-oriya</string>
+      <string>pa-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_t_ra-oriya</string>
+      <string>s_tha-oriya</string>
+      <string>sa-oriya</string>
+      <string>sha-oriya</string>
+      <string>ss_ma-oriya</string>
+      <string>ss_pa-oriya</string>
+      <string>ssa-oriya</string>
+      <string>t_ma-oriya</string>
+      <string>t_pa-oriya</string>
+      <string>tha-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya.blwf</string>
     </array>
     <key>public.kern1.ODI_anusvara-oriya_L</key>
     <array>
@@ -2748,9 +2748,9 @@
     </array>
     <key>public.kern1.ODI_bracketleft_L</key>
     <array>
-      <string>parenleft.loclODIA</string>
       <string>braceleft.loclODIA</string>
       <string>bracketleft.loclODIA</string>
+      <string>parenleft.loclODIA</string>
     </array>
     <key>public.kern1.ODI_ddha-oriya_L</key>
     <array>
@@ -2775,21 +2775,21 @@
     </array>
     <key>public.kern1.ODI_i-oriya_L</key>
     <array>
+      <string>bha-oriya</string>
+      <string>d_bha-oriya</string>
       <string>i-oriya</string>
       <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>la-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ra-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>u-oriya</string>
     </array>
     <key>public.kern1.ODI_j_jha-oriya_L</key>
     <array>
@@ -2810,66 +2810,66 @@
     </array>
     <key>public.kern1.ODI_ka-oriya_L</key>
     <array>
-      <string>ka-oriya</string>
-      <string>ca-oriya</string>
-      <string>cha-oriya</string>
-      <string>ja-oriya</string>
-      <string>dda-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>na-oriya</string>
-      <string>ba-oriya</string>
-      <string>lla-oriya</string>
-      <string>va-oriya</string>
-      <string>ha-oriya</string>
-      <string>rra-oriya</string>
-      <string>k_ka-oriya</string>
-      <string>k_tta-oriya</string>
-      <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ka-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_na-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_da-oriya</string>
-      <string>d_dha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>n_ta-oriya</string>
-      <string>n_tha-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_d_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_dh_bha-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>cha-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_da-oriya</string>
+      <string>d_dha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>h_ba-oriya</string>
+      <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>ja-oriya</string>
+      <string>k_ba-oriya</string>
+      <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_ta-oriya</string>
+      <string>k_tta-oriya</string>
+      <string>k_ttha-oriya</string>
+      <string>ka-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
-      <string>h_ba-oriya</string>
-      <string>h_la-oriya</string>
+      <string>lla-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_d_ba-oriya</string>
+      <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
+      <string>n_ta-oriya</string>
+      <string>n_tha-oriya</string>
+      <string>na-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_ka-oriya</string>
+      <string>t_na-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern1.ODI_lVocalic-oriya_L</key>
     <array>
@@ -2890,16 +2890,16 @@
     </array>
     <key>public.kern1.ODI_nga-oriya_L</key>
     <array>
-      <string>nga-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
+      <string>nga-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ba-oriya_L</key>
     <array>
-      <string>nn_ba-oriya</string>
       <string>dh_ba-oriya</string>
       <string>m_ba-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>sh_wa-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_dda-oriya_L</key>
@@ -2921,8 +2921,8 @@
     <array>
       <string>nn_tta-oriya</string>
       <string>p_tta-oriya</string>
-      <string>ss_tta-oriya</string>
       <string>s_tta-oriya</string>
+      <string>ss_tta-oriya</string>
     </array>
     <key>public.kern1.ODI_nn_ttha-oriya_L</key>
     <array>
@@ -2952,10 +2952,10 @@
     </array>
     <key>public.kern1.ODI_pha-oriya_L</key>
     <array>
-      <string>pha-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
       <string>m_pha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>pha-oriya</string>
     </array>
     <key>public.kern1.ODI_rrVocalic-oriya_L</key>
     <array>
@@ -2983,13 +2983,13 @@
     </array>
     <key>public.kern1.ODI_ss_pha-oriya_L</key>
     <array>
-      <string>ss_pha-oriya</string>
       <string>s_pha-oriya</string>
+      <string>ss_pha-oriya</string>
     </array>
     <key>public.kern1.ODI_tta-oriya_L</key>
     <array>
-      <string>tta-oriya</string>
       <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
     </array>
     <key>public.kern1.ODI_ttha-oriya_L</key>
     <array>
@@ -2997,8 +2997,8 @@
     </array>
     <key>public.kern1.ODI_uu-oriya_L</key>
     <array>
-      <string>uu-oriya</string>
       <string>rVocalic-oriya</string>
+      <string>uu-oriya</string>
     </array>
     <key>public.kern1.ODI_visarga-oriya_L</key>
     <array>
@@ -3018,9 +3018,9 @@
     </array>
     <key>public.kern1.P</key>
     <array>
-      <string>P</string>
       <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>P</string>
     </array>
     <key>public.kern1.R</key>
     <array>
@@ -3031,13 +3031,13 @@
     </array>
     <key>public.kern1.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern1.SNH_a-sinhala_R</key>
@@ -3048,17 +3048,17 @@
     <array>
       <string>aa-sinhala</string>
       <string>aaMatra-sinhala</string>
+      <string>aaMatra_virama-sinhala</string>
       <string>oMatra-sinhala</string>
       <string>ooMatra-sinhala</string>
       <string>threelith-sinhala</string>
-      <string>aaMatra_virama-sinhala</string>
     </array>
     <key>public.kern1.SNH_aaeMatra-sinhala_R</key>
     <array>
-      <string>aee-sinhala</string>
       <string>aaeMatra-sinhala</string>
-      <string>ruu-sinhala</string>
+      <string>aee-sinhala</string>
       <string>lluu-sinhala</string>
+      <string>ruu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ae-sinhala_R</key>
     <array>
@@ -3073,26 +3073,26 @@
     <key>public.kern1.SNH_c-sinhala_R</key>
     <array>
       <string>c-sinhala</string>
-      <string>tt-sinhala</string>
       <string>m-sinhala</string>
+      <string>tt-sinhala</string>
       <string>v-sinhala</string>
     </array>
     <key>public.kern1.SNH_c_ra-sinhala_R</key>
     <array>
       <string>c_ra-sinhala</string>
-      <string>tt_ra-sinhala</string>
       <string>m_ra-sinhala</string>
+      <string>tt_ra-sinhala</string>
       <string>v_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ca-sinhala_R</key>
     <array>
       <string>ca-sinhala</string>
-      <string>tta-sinhala</string>
-      <string>ma-sinhala</string>
-      <string>va-sinhala</string>
       <string>ca_reph-sinhala</string>
-      <string>tta_reph-sinhala</string>
+      <string>ma-sinhala</string>
       <string>ma_reph-sinhala</string>
+      <string>tta-sinhala</string>
+      <string>tta_reph-sinhala</string>
+      <string>va-sinhala</string>
       <string>va_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ch-sinhala_R</key>
@@ -3112,9 +3112,9 @@
     <key>public.kern1.SNH_cha-sinhala_R</key>
     <array>
       <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>cha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_chu-sinhala_R</key>
     <array>
@@ -3143,11 +3143,11 @@
     </array>
     <key>public.kern1.SNH_da-sinhala_R</key>
     <array>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
       <string>da-sinhala</string>
-      <string>nda-sinhala</string>
       <string>fivelith-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>nda-sinhala</string>
+      <string>nya-sinhala</string>
     </array>
     <key>public.kern1.SNH_ddhi-sinhala_R</key>
     <array>
@@ -3161,18 +3161,18 @@
     </array>
     <key>public.kern1.SNH_e-sinhala_R</key>
     <array>
-      <string>e-sinhala</string>
       <string>ai-sinhala</string>
-      <string>tha-sinhala</string>
-      <string>pha-sinhala</string>
+      <string>e-sinhala</string>
       <string>llu-sinhala</string>
-      <string>tha_reph-sinhala</string>
+      <string>pha-sinhala</string>
       <string>pha_reph-sinhala</string>
+      <string>tha-sinhala</string>
+      <string>tha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_eMatra-sinhala_R</key>
     <array>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
+      <string>eMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ee-sinhala_R</key>
     <array>
@@ -3190,11 +3190,11 @@
     </array>
     <key>public.kern1.SNH_fa-sinhala_R</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_fu-sinhala_R</key>
     <array>
@@ -3203,55 +3203,55 @@
     </array>
     <key>public.kern1.SNH_g-sinhala_R</key>
     <array>
-      <string>g-sinhala</string>
-      <string>nng-sinhala</string>
       <string>bh-sinhala</string>
+      <string>g-sinhala</string>
       <string>h-sinhala</string>
+      <string>nng-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_r-sinhala_R</key>
     <array>
-      <string>g_r-sinhala</string>
-      <string>nng_r-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>g_r-sinhala</string>
       <string>h_r-sinhala</string>
+      <string>nng_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ra-sinhala_R</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>nng_ra-sinhala</string>
       <string>bh_ra-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>h_ra-sinhala</string>
+      <string>nng_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_g_ri-sinhala_R</key>
     <array>
-      <string>g_ri-sinhala</string>
-      <string>nng_ri-sinhala</string>
       <string>bh_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
-      <string>g_rii-sinhala</string>
-      <string>nng_rii-sinhala</string>
       <string>bh_rii-sinhala</string>
+      <string>g_ri-sinhala</string>
+      <string>g_rii-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ga-sinhala_R</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>nnga-sinhala</string>
       <string>bha-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>ga_reph-sinhala</string>
-      <string>nnga_reph-sinhala</string>
       <string>bha_reph-sinhala</string>
+      <string>ga-sinhala</string>
+      <string>ga_reph-sinhala</string>
+      <string>ha-sinhala</string>
       <string>ha_reph-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh-sinhala_R</key>
     <array>
       <string>gh-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>s-sinhala</string>
       <string>k_ss-sinhala</string>
-      <string>ss_r-sinhala</string>
+      <string>s-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ss_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_gh_r-sinhala_R</key>
     <array>
@@ -3260,21 +3260,21 @@
     <key>public.kern1.SNH_gh_ra-sinhala_R</key>
     <array>
       <string>gh_ra-sinhala</string>
-      <string>s_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
-      <string>s_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
+      <string>s_ra-sinhala</string>
+      <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gha-sinhala_R</key>
     <array>
       <string>gha-sinhala</string>
-      <string>sa-sinhala</string>
+      <string>gha_reph-sinhala</string>
       <string>ghi-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>gha_reph-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ghii-sinhala_R</key>
     <array>
@@ -3283,42 +3283,42 @@
     <key>public.kern1.SNH_ghu-sinhala_R</key>
     <array>
       <string>ghu-sinhala</string>
+      <string>ghuu-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
       <string>pu-sinhala</string>
+      <string>puu-sinhala</string>
       <string>ssu-sinhala</string>
       <string>su-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>ghuu-sinhala</string>
-      <string>puu-sinhala</string>
       <string>suu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_gi-sinhala_R</key>
     <array>
-      <string>gi-sinhala</string>
-      <string>nngi-sinhala</string>
       <string>bhi-sinhala</string>
+      <string>gi-sinhala</string>
       <string>hi-sinhala</string>
+      <string>nngi-sinhala</string>
     </array>
     <key>public.kern1.SNH_gii-sinhala_R</key>
     <array>
-      <string>gii-sinhala</string>
-      <string>nngii-sinhala</string>
       <string>bhii-sinhala</string>
+      <string>gii-sinhala</string>
       <string>hii-sinhala</string>
+      <string>nngii-sinhala</string>
     </array>
     <key>public.kern1.SNH_gu-sinhala_R</key>
     <array>
+      <string>bhu-sinhala</string>
       <string>gu-sinhala</string>
       <string>nngu-sinhala</string>
-      <string>tu-sinhala</string>
-      <string>bhu-sinhala</string>
       <string>shu-sinhala</string>
+      <string>tu-sinhala</string>
     </array>
     <key>public.kern1.SNH_guu-sinhala_R</key>
     <array>
+      <string>bhuu-sinhala</string>
       <string>guu-sinhala</string>
       <string>nnguu-sinhala</string>
-      <string>bhuu-sinhala</string>
       <string>shuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_hu-sinhala_R</key>
@@ -3347,23 +3347,23 @@
     <key>public.kern1.SNH_j_ra-sinhala_R</key>
     <array>
       <string>j_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
       <string>j_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
       <string>j_rii-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
       <string>nyj_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ja-sinhala_R</key>
     <array>
-      <string>ja-sinhala</string>
-      <string>nyja-sinhala</string>
       <string>fourlith-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>nyjii-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>nyja-sinhala</string>
       <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
     </array>
     <key>public.kern1.SNH_jny_r-sinhala_R</key>
     <array>
@@ -3377,115 +3377,115 @@
     <key>public.kern1.SNH_ju-sinhala_R</key>
     <array>
       <string>ju-sinhala</string>
-      <string>nyju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>nyju-sinhala</string>
       <string>nyjuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_k-sinhala_R</key>
     <array>
       <string>k-sinhala</string>
-      <string>t-sinhala</string>
       <string>n-sinhala</string>
+      <string>t-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_r-sinhala_R</key>
     <array>
       <string>k_r-sinhala</string>
-      <string>t_r-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>t_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ra-sinhala_R</key>
     <array>
       <string>k_ra-sinhala</string>
-      <string>t_ra-sinhala</string>
       <string>n_ra-sinhala</string>
+      <string>t_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_k_ri-sinhala_R</key>
     <array>
       <string>k_ri-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>n_ri-sinhala</string>
       <string>k_rii-sinhala</string>
-      <string>t_rii-sinhala</string>
+      <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh-sinhala_R</key>
     <array>
-      <string>kh-sinhala</string>
-      <string>ng-sinhala</string>
-      <string>jh-sinhala</string>
-      <string>dd-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>dh-sinhala</string>
       <string>b-sinhala</string>
+      <string>dd-sinhala</string>
+      <string>dh-sinhala</string>
+      <string>jh-sinhala</string>
+      <string>kh-sinhala</string>
       <string>mb-sinhala</string>
+      <string>ng-sinhala</string>
+      <string>nndd-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_r-sinhala_R</key>
     <array>
-      <string>kh_r-sinhala</string>
-      <string>ng_r-sinhala</string>
-      <string>c_r-sinhala</string>
-      <string>jh_r-sinhala</string>
-      <string>tt_r-sinhala</string>
-      <string>dd_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
-      <string>dh_r-sinhala</string>
       <string>b_r-sinhala</string>
+      <string>c_r-sinhala</string>
+      <string>dd_r-sinhala</string>
+      <string>dh_r-sinhala</string>
+      <string>jh_r-sinhala</string>
+      <string>kh_r-sinhala</string>
       <string>m_r-sinhala</string>
       <string>mb_r-sinhala</string>
+      <string>ng_r-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>tt_r-sinhala</string>
       <string>v_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ra-sinhala_R</key>
     <array>
-      <string>kh_ra-sinhala</string>
-      <string>ng_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>dd_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>dh_ra-sinhala</string>
       <string>b_ra-sinhala</string>
+      <string>dd_ra-sinhala</string>
+      <string>dh_ra-sinhala</string>
+      <string>jh_ra-sinhala</string>
+      <string>kh_ra-sinhala</string>
       <string>mb_ra-sinhala</string>
+      <string>ng_ra-sinhala</string>
+      <string>nndd_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_kh_ri-sinhala_R</key>
     <array>
-      <string>kh_ri-sinhala</string>
-      <string>ng_ri-sinhala</string>
-      <string>c_ri-sinhala</string>
-      <string>jh_ri-sinhala</string>
-      <string>tt_ri-sinhala</string>
-      <string>dd_ri-sinhala</string>
-      <string>dh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
-      <string>v_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
-      <string>ng_rii-sinhala</string>
-      <string>c_rii-sinhala</string>
-      <string>jh_rii-sinhala</string>
-      <string>tt_rii-sinhala</string>
-      <string>dd_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
-      <string>dh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>c_ri-sinhala</string>
+      <string>c_rii-sinhala</string>
+      <string>dd_ri-sinhala</string>
+      <string>dd_rii-sinhala</string>
+      <string>dh_ri-sinhala</string>
+      <string>dh_rii-sinhala</string>
+      <string>jh_ri-sinhala</string>
+      <string>jh_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
+      <string>m_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
+      <string>ng_ri-sinhala</string>
+      <string>ng_rii-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>tt_ri-sinhala</string>
+      <string>tt_rii-sinhala</string>
+      <string>v_ri-sinhala</string>
       <string>v_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khi-sinhala_R</key>
     <array>
+      <string>bi-sinhala</string>
+      <string>bii-sinhala</string>
+      <string>ddi-sinhala</string>
+      <string>ddii-sinhala</string>
+      <string>dhi-sinhala</string>
+      <string>dhii-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
       <string>khi-sinhala</string>
       <string>ngi-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>ddi-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>dhi-sinhala</string>
-      <string>bi-sinhala</string>
       <string>ngii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>ddii-sinhala</string>
+      <string>nnddi-sinhala</string>
       <string>nnddii-sinhala</string>
-      <string>dhii-sinhala</string>
-      <string>bii-sinhala</string>
     </array>
     <key>public.kern1.SNH_khii-sinhala_R</key>
     <array>
@@ -3493,30 +3493,30 @@
     </array>
     <key>public.kern1.SNH_khu-sinhala_R</key>
     <array>
-      <string>khu-sinhala</string>
-      <string>ngu-sinhala</string>
-      <string>cu-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>ttu-sinhala</string>
-      <string>ddu-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>dhu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>mu-sinhala</string>
-      <string>mbu-sinhala</string>
-      <string>vu-sinhala</string>
-      <string>khuu-sinhala</string>
-      <string>nguu-sinhala</string>
-      <string>cuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>ttuu-sinhala</string>
-      <string>tthuu-sinhala</string>
-      <string>dduu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>dhuu-sinhala</string>
       <string>buu-sinhala</string>
-      <string>muu-sinhala</string>
+      <string>cu-sinhala</string>
+      <string>cuu-sinhala</string>
+      <string>ddu-sinhala</string>
+      <string>dduu-sinhala</string>
+      <string>dhu-sinhala</string>
+      <string>dhuu-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
+      <string>mbu-sinhala</string>
       <string>mbuu-sinhala</string>
+      <string>mu-sinhala</string>
+      <string>muu-sinhala</string>
+      <string>ngu-sinhala</string>
+      <string>nguu-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
+      <string>ttuu-sinhala</string>
+      <string>vu-sinhala</string>
       <string>vuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_ku-sinhala_R</key>
@@ -3538,24 +3538,24 @@
     </array>
     <key>public.kern1.SNH_lVocalic-sinhala_R</key>
     <array>
-      <string>lVocalic-sinhala</string>
       <string>ka-sinhala</string>
-      <string>ta-sinhala</string>
-      <string>na-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>ninelith-sinhala</string>
+      <string>ka_reph-sinhala</string>
       <string>ki-sinhala</string>
       <string>kii-sinhala</string>
-      <string>ka_reph-sinhala</string>
-      <string>ta_reph-sinhala</string>
+      <string>lVocalic-sinhala</string>
+      <string>na-sinhala</string>
       <string>na_reph-sinhala</string>
+      <string>ninelith-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern1.SNH_la-sinhala_R</key>
     <array>
       <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_ll-sinhala_R</key>
     <array>
@@ -3615,9 +3615,9 @@
     <key>public.kern1.SNH_nna-sinhala_R</key>
     <array>
       <string>nna-sinhala</string>
+      <string>nna_reph-sinhala</string>
       <string>nni-sinhala</string>
       <string>nnii-sinhala</string>
-      <string>nna_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nnu-sinhala_R</key>
     <array>
@@ -3631,10 +3631,10 @@
     </array>
     <key>public.kern1.SNH_ny-sinhala_R</key>
     <array>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
       <string>d-sinhala</string>
+      <string>jny-sinhala</string>
       <string>nd-sinhala</string>
+      <string>ny-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_r-sinhala_R</key>
     <array>
@@ -3642,12 +3642,12 @@
     </array>
     <key>public.kern1.SNH_ny_ra-sinhala_R</key>
     <array>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
       <string>d_ra-sinhala</string>
+      <string>jny_ra-sinhala</string>
       <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
       <string>nd_rii-sinhala</string>
+      <string>ny_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ny_ri-sinhala_R</key>
     <array>
@@ -3656,53 +3656,53 @@
     </array>
     <key>public.kern1.SNH_nya_reph-sinhala_R</key>
     <array>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
       <string>da_reph-sinhala</string>
+      <string>jnya_reph-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>nya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyi-sinhala_R</key>
     <array>
-      <string>nyi-sinhala</string>
       <string>jnyi-sinhala</string>
       <string>ndi-sinhala</string>
+      <string>nyi-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyii-sinhala_R</key>
     <array>
-      <string>nyii-sinhala</string>
       <string>jnyii-sinhala</string>
+      <string>nyii-sinhala</string>
     </array>
     <key>public.kern1.SNH_nyu-sinhala__R</key>
     <array>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
       <string>du-sinhala</string>
-      <string>ndu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
       <string>duu-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
+      <string>ndu-sinhala</string>
       <string>nduu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern1.SNH_o-sinhala_R</key>
     <array>
+      <string>ba-sinhala</string>
+      <string>ba_reph-sinhala</string>
+      <string>dda-sinhala</string>
+      <string>dda_reph-sinhala</string>
+      <string>dha-sinhala</string>
+      <string>dha_reph-sinhala</string>
+      <string>jha-sinhala</string>
+      <string>jha_reph-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
+      <string>nga-sinhala</string>
+      <string>nga_reph-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>kha-sinhala</string>
-      <string>nga-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>dda-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>dha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>kha_reph-sinhala</string>
-      <string>nga_reph-sinhala</string>
-      <string>jha_reph-sinhala</string>
-      <string>dda_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
-      <string>dha_reph-sinhala</string>
-      <string>ba_reph-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_p-sinhala_R</key>
     <array>
@@ -3715,38 +3715,38 @@
     <key>public.kern1.SNH_p_ra-sinhala_R</key>
     <array>
       <string>p_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
       <string>p_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
       <string>p_rii-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
       <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_pa-sinhala_R</key>
     <array>
-      <string>pa-sinhala</string>
-      <string>ssa-sinhala</string>
       <string>k_ssa-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>ssi-sinhala</string>
       <string>k_ssi-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>ssii-sinhala</string>
       <string>k_ssii-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern1.SNH_rVocalic-sinhala_R</key>
     <array>
       <string>rVocalic-sinhala</string>
-      <string>rrVocalic-sinhala</string>
       <string>rVocalicMatra-sinhala</string>
+      <string>rrVocalic-sinhala</string>
       <string>rrVocalicMatra-sinhala</string>
     </array>
     <key>public.kern1.SNH_ra-sinhala_R</key>
     <array>
-      <string>ra-sinhala</string>
       <string>eightlith-sinhala</string>
       <string>r-sinhala</string>
+      <string>ra-sinhala</string>
       <string>ri-sinhala</string>
       <string>rii-sinhala</string>
     </array>
@@ -3799,62 +3799,62 @@
     </array>
     <key>public.kern1.SNH_th-sinhala_R</key>
     <array>
-      <string>th-sinhala</string>
       <string>ph-sinhala</string>
+      <string>th-sinhala</string>
     </array>
     <key>public.kern1.SNH_th_r-sinhala_R</key>
     <array>
-      <string>th_r-sinhala</string>
       <string>ph_r-sinhala</string>
+      <string>th_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_thi-sinhala_R</key>
     <array>
-      <string>thi-sinhala</string>
       <string>phi-sinhala</string>
+      <string>thi-sinhala</string>
     </array>
     <key>public.kern1.SNH_thii-sinhala_R</key>
     <array>
-      <string>thii-sinhala</string>
       <string>phii-sinhala</string>
+      <string>thii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth-sinhala_R</key>
     <array>
-      <string>tth-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>tth-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_r-sinhala_R</key>
     <array>
-      <string>tth_r-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>tth_r-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ra-sinhala_R</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>ddh_ra-sinhala</string>
-      <string>th_ra-sinhala</string>
       <string>ph_ra-sinhala</string>
       <string>ph_ri-sinhala</string>
+      <string>th_ra-sinhala</string>
+      <string>tth_ra-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_ri-sinhala_R</key>
     <array>
-      <string>tth_ri-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>nndd_ri-sinhala</string>
       <string>th_ri-sinhala</string>
+      <string>tth_ri-sinhala</string>
     </array>
     <key>public.kern1.SNH_tth_rii-sinhala_R</key>
     <array>
-      <string>tth_rii-sinhala</string>
       <string>ddh_rii-sinhala</string>
-      <string>th_rii-sinhala</string>
       <string>ph_rii-sinhala</string>
+      <string>th_rii-sinhala</string>
+      <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern1.SNH_ttha-sinhala_R</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>ddha-sinhala</string>
-      <string>ttha_reph-sinhala</string>
       <string>ddha_reph-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>ttha_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthi-sinhala_R</key>
     <array>
@@ -3862,18 +3862,18 @@
     </array>
     <key>public.kern1.SNH_tthii-sinhala_R</key>
     <array>
-      <string>tthii-sinhala</string>
       <string>ddhii-sinhala</string>
+      <string>tthii-sinhala</string>
     </array>
     <key>public.kern1.SNH_tthu-sinhala_R</key>
     <array>
-      <string>tthu-sinhala</string>
       <string>ddhu-sinhala</string>
-      <string>thu-sinhala</string>
-      <string>phu-sinhala</string>
       <string>ddhuu-sinhala</string>
-      <string>thuu-sinhala</string>
+      <string>phu-sinhala</string>
       <string>phuu-sinhala</string>
+      <string>thu-sinhala</string>
+      <string>thuu-sinhala</string>
+      <string>tthu-sinhala</string>
     </array>
     <key>public.kern1.SNH_u-sinhala_R</key>
     <array>
@@ -3881,12 +3881,12 @@
     </array>
     <key>public.kern1.SNH_uu-sinhala_R</key>
     <array>
-      <string>uu-sinhala</string>
-      <string>llVocalic-sinhala</string>
       <string>au-sinhala</string>
-      <string>lVocalicMatra-sinhala</string>
-      <string>llVocalicMatra-sinhala</string>
       <string>auMatra-sinhala</string>
+      <string>lVocalicMatra-sinhala</string>
+      <string>llVocalic-sinhala</string>
+      <string>llVocalicMatra-sinhala</string>
+      <string>uu-sinhala</string>
     </array>
     <key>public.kern1.SNH_visargaya-sinhala_R</key>
     <array>
@@ -3917,9 +3917,9 @@
     <key>public.kern1.SNH_ya-sinhala_R</key>
     <array>
       <string>ya-sinhala</string>
+      <string>ya_reph-sinhala</string>
       <string>yi-sinhala</string>
       <string>yii-sinhala</string>
-      <string>ya_reph-sinhala</string>
     </array>
     <key>public.kern1.SNH_yi-sinhala.post_R</key>
     <array>
@@ -3958,9 +3958,9 @@
       <string>pau-telugu</string>
       <string>phau-telugu</string>
       <string>phau-telugu.alt</string>
+      <string>sau-telugu</string>
       <string>ssau-telugu</string>
       <string>ssau-telugu.alt</string>
-      <string>sau-telugu</string>
     </array>
     <key>public.kern1.TEL_ba-telugu.below_L</key>
     <array>
@@ -3994,68 +3994,68 @@
     </array>
     <key>public.kern1.TEL_oMatra-telugu_L</key>
     <array>
-      <string>oMatra-telugu</string>
-      <string>ooMatra-telugu</string>
-      <string>ko-telugu</string>
+      <string>bho-telugu</string>
+      <string>bhoo-telugu</string>
+      <string>bo-telugu</string>
+      <string>boo-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>ddho-telugu</string>
+      <string>ddhoo-telugu</string>
+      <string>ddo-telugu</string>
+      <string>ddoo-telugu</string>
+      <string>dho-telugu</string>
+      <string>dhoo-telugu</string>
+      <string>do-telugu</string>
+      <string>doo-telugu</string>
+      <string>go-telugu</string>
+      <string>goo-telugu</string>
+      <string>ho-telugu</string>
+      <string>hoo-telugu</string>
+      <string>jo-telugu</string>
+      <string>joo-telugu</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
-      <string>go-telugu</string>
-      <string>ngo-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>jo-telugu</string>
-      <string>nyo-telugu</string>
-      <string>tto-telugu</string>
-      <string>ttho-telugu</string>
-      <string>ddo-telugu</string>
-      <string>ddho-telugu</string>
-      <string>nno-telugu</string>
-      <string>to-telugu</string>
-      <string>tho-telugu</string>
-      <string>tho-telugu.alt</string>
-      <string>do-telugu</string>
-      <string>dho-telugu</string>
-      <string>no-telugu</string>
-      <string>bo-telugu</string>
-      <string>bho-telugu</string>
-      <string>ro-telugu</string>
-      <string>rro-telugu</string>
-      <string>lo-telugu</string>
-      <string>llo-telugu</string>
-      <string>lllo-telugu</string>
-      <string>vo-telugu</string>
-      <string>sho-telugu</string>
-      <string>ho-telugu</string>
-      <string>koo-telugu</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>goo-telugu</string>
+      <string>ko-telugu</string>
+      <string>koo-telugu</string>
+      <string>lllo-telugu</string>
+      <string>llloo-telugu</string>
+      <string>llo-telugu</string>
+      <string>lloo-telugu</string>
+      <string>lo-telugu</string>
+      <string>loo-telugu</string>
+      <string>ngo-telugu</string>
       <string>ngoo-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
-      <string>joo-telugu</string>
-      <string>nyoo-telugu</string>
-      <string>ttoo-telugu</string>
-      <string>tthoo-telugu</string>
-      <string>ddoo-telugu</string>
-      <string>ddhoo-telugu</string>
+      <string>nno-telugu</string>
       <string>nnoo-telugu</string>
-      <string>too-telugu</string>
+      <string>no-telugu</string>
+      <string>noo-telugu</string>
+      <string>nyo-telugu</string>
+      <string>nyoo-telugu</string>
+      <string>oMatra-telugu</string>
+      <string>ooMatra-telugu</string>
+      <string>ro-telugu</string>
+      <string>roo-telugu</string>
+      <string>rro-telugu</string>
+      <string>rroo-telugu</string>
+      <string>sho-telugu</string>
+      <string>shoo-telugu</string>
+      <string>tho-telugu</string>
+      <string>tho-telugu.alt</string>
       <string>thoo-telugu</string>
       <string>thoo-telugu.alt</string>
-      <string>doo-telugu</string>
-      <string>dhoo-telugu</string>
-      <string>noo-telugu</string>
-      <string>boo-telugu</string>
-      <string>bhoo-telugu</string>
-      <string>roo-telugu</string>
-      <string>rroo-telugu</string>
-      <string>loo-telugu</string>
-      <string>lloo-telugu</string>
-      <string>llloo-telugu</string>
+      <string>to-telugu</string>
+      <string>too-telugu</string>
+      <string>ttho-telugu</string>
+      <string>tthoo-telugu</string>
+      <string>tto-telugu</string>
+      <string>ttoo-telugu</string>
+      <string>vo-telugu</string>
       <string>voo-telugu</string>
-      <string>shoo-telugu</string>
-      <string>hoo-telugu</string>
     </array>
     <key>public.kern1.TEL_pa-telugu.below_L</key>
     <array>
@@ -4064,18 +4064,18 @@
     </array>
     <key>public.kern1.TEL_po-telugu_L</key>
     <array>
-      <string>po-telugu</string>
       <string>pho-telugu</string>
       <string>pho-telugu.alt</string>
-      <string>sso-telugu</string>
-      <string>sso-telugu.alt</string>
-      <string>so-telugu</string>
-      <string>poo-telugu</string>
       <string>phoo-telugu</string>
       <string>phoo-telugu.alt</string>
+      <string>po-telugu</string>
+      <string>poo-telugu</string>
+      <string>so-telugu</string>
+      <string>soo-telugu</string>
+      <string>sso-telugu</string>
+      <string>sso-telugu.alt</string>
       <string>ssoo-telugu</string>
       <string>ssoo-telugu.alt</string>
-      <string>soo-telugu</string>
     </array>
     <key>public.kern1.TEL_quoteleft_L</key>
     <array>
@@ -4092,139 +4092,139 @@
     </array>
     <key>public.kern1.TEL_rrVocalic-telugu_L</key>
     <array>
-      <string>rrVocalic-telugu</string>
-      <string>ha-telugu</string>
       <string>aaMatra-telugu</string>
-      <string>uuMatra-telugu</string>
-      <string>rrVocalicMatra-telugu</string>
-      <string>h-telugu</string>
-      <string>kaa-telugu</string>
-      <string>khaa-telugu</string>
-      <string>khaa-telugu.alt</string>
+      <string>baa-telugu</string>
+      <string>bau-telugu</string>
+      <string>bhaa-telugu</string>
+      <string>bhau-telugu</string>
+      <string>bhuu-telugu</string>
+      <string>buu-telugu</string>
+      <string>caa-telugu</string>
+      <string>cau-telugu</string>
+      <string>chaa-telugu</string>
+      <string>chau-telugu</string>
+      <string>chuu-telugu</string>
+      <string>cuu-telugu</string>
+      <string>daa-telugu</string>
+      <string>dau-telugu</string>
+      <string>ddaa-telugu</string>
+      <string>ddau-telugu</string>
+      <string>ddhaa-telugu</string>
+      <string>ddhau-telugu</string>
+      <string>ddhuu-telugu</string>
+      <string>dduu-telugu</string>
+      <string>dhaa-telugu</string>
+      <string>dhau-telugu</string>
+      <string>dhuu-telugu</string>
+      <string>duu-telugu</string>
       <string>gaa-telugu</string>
+      <string>gau-telugu</string>
       <string>ghaa-telugu</string>
       <string>ghaa-telugu.alt</string>
-      <string>ngaa-telugu</string>
-      <string>caa-telugu</string>
-      <string>chaa-telugu</string>
+      <string>ghau-telugu</string>
+      <string>ghau-telugu.alt</string>
+      <string>ghoo-telugu</string>
+      <string>ghoo-telugu.alt</string>
+      <string>ghuu-telugu</string>
+      <string>ghuu-telugu.alt</string>
+      <string>guu-telugu</string>
+      <string>h-telugu</string>
+      <string>ha-telugu</string>
+      <string>haa-telugu</string>
+      <string>hau-telugu</string>
+      <string>he-telugu</string>
+      <string>hee-telugu</string>
+      <string>hi-telugu</string>
+      <string>hii-telugu</string>
+      <string>huu-telugu</string>
       <string>jaa-telugu</string>
+      <string>jau-telugu</string>
       <string>jhaa-telugu</string>
       <string>jhaa-telugu.alt</string>
-      <string>nyaa-telugu</string>
-      <string>ttaa-telugu</string>
-      <string>tthaa-telugu</string>
-      <string>ddaa-telugu</string>
-      <string>ddhaa-telugu</string>
-      <string>nnaa-telugu</string>
-      <string>taa-telugu</string>
-      <string>thaa-telugu</string>
-      <string>thaa-telugu.alt</string>
-      <string>daa-telugu</string>
-      <string>dhaa-telugu</string>
+      <string>jhau-telugu</string>
+      <string>jhau-telugu.alt</string>
+      <string>jhoo-telugu</string>
+      <string>jhoo-telugu.alt</string>
+      <string>jhuu-telugu</string>
+      <string>jhuu-telugu.alt</string>
+      <string>juu-telugu</string>
+      <string>kaa-telugu</string>
+      <string>kau-telugu</string>
+      <string>khaa-telugu</string>
+      <string>khaa-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
+      <string>kuu-telugu</string>
+      <string>laa-telugu</string>
+      <string>lau-telugu</string>
+      <string>llaa-telugu</string>
+      <string>llau-telugu</string>
+      <string>lllaa-telugu</string>
+      <string>lllau-telugu</string>
+      <string>llluu-telugu</string>
+      <string>luu-telugu</string>
+      <string>maa-telugu</string>
+      <string>mau-telugu</string>
+      <string>moo-telugu</string>
+      <string>muu-telugu</string>
       <string>naa-telugu</string>
+      <string>nau-telugu</string>
+      <string>ngaa-telugu</string>
+      <string>ngau-telugu</string>
+      <string>nguu-telugu</string>
+      <string>nnaa-telugu</string>
+      <string>nnau-telugu</string>
+      <string>nnuu-telugu</string>
+      <string>nuu-telugu</string>
+      <string>nyaa-telugu</string>
+      <string>nyau-telugu</string>
+      <string>nyuu-telugu</string>
       <string>paa-telugu</string>
       <string>phaa-telugu</string>
       <string>phaa-telugu.alt</string>
-      <string>baa-telugu</string>
-      <string>bhaa-telugu</string>
-      <string>maa-telugu</string>
-      <string>yaa-telugu</string>
-      <string>raa-telugu</string>
-      <string>rraa-telugu</string>
-      <string>laa-telugu</string>
-      <string>llaa-telugu</string>
-      <string>lllaa-telugu</string>
-      <string>vaa-telugu</string>
-      <string>shaa-telugu</string>
-      <string>ssaa-telugu</string>
-      <string>ssaa-telugu.alt</string>
-      <string>saa-telugu</string>
-      <string>haa-telugu</string>
-      <string>hi-telugu</string>
-      <string>yii-telugu</string>
-      <string>hii-telugu</string>
-      <string>kuu-telugu</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
-      <string>guu-telugu</string>
-      <string>ghuu-telugu</string>
-      <string>ghuu-telugu.alt</string>
-      <string>nguu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>juu-telugu</string>
-      <string>jhuu-telugu</string>
-      <string>jhuu-telugu.alt</string>
-      <string>nyuu-telugu</string>
-      <string>ttuu-telugu</string>
-      <string>tthuu-telugu</string>
-      <string>dduu-telugu</string>
-      <string>ddhuu-telugu</string>
-      <string>nnuu-telugu</string>
-      <string>tuu-telugu</string>
-      <string>thuu-telugu</string>
-      <string>thuu-telugu.alt</string>
-      <string>duu-telugu</string>
-      <string>dhuu-telugu</string>
-      <string>nuu-telugu</string>
-      <string>puu-telugu</string>
       <string>phuu-telugu</string>
       <string>phuu-telugu.alt</string>
-      <string>buu-telugu</string>
-      <string>bhuu-telugu</string>
-      <string>muu-telugu</string>
-      <string>yuu-telugu</string>
-      <string>ruu-telugu</string>
+      <string>puu-telugu</string>
+      <string>raa-telugu</string>
+      <string>rau-telugu</string>
+      <string>rrVocalic-telugu</string>
+      <string>rrVocalicMatra-telugu</string>
+      <string>rraa-telugu</string>
+      <string>rrau-telugu</string>
       <string>rruu-telugu</string>
-      <string>luu-telugu</string>
-      <string>llluu-telugu</string>
-      <string>vuu-telugu</string>
+      <string>ruu-telugu</string>
+      <string>saa-telugu</string>
+      <string>shaa-telugu</string>
+      <string>shau-telugu</string>
+      <string>ssaa-telugu</string>
+      <string>ssaa-telugu.alt</string>
       <string>ssuu-telugu</string>
       <string>ssuu-telugu.alt</string>
       <string>suu-telugu</string>
-      <string>huu-telugu</string>
-      <string>he-telugu</string>
-      <string>hee-telugu</string>
-      <string>ghoo-telugu</string>
-      <string>ghoo-telugu.alt</string>
-      <string>jhoo-telugu</string>
-      <string>jhoo-telugu.alt</string>
-      <string>moo-telugu</string>
-      <string>yoo-telugu</string>
-      <string>kau-telugu</string>
-      <string>gau-telugu</string>
-      <string>ghau-telugu</string>
-      <string>ghau-telugu.alt</string>
-      <string>ngau-telugu</string>
-      <string>cau-telugu</string>
-      <string>chau-telugu</string>
-      <string>jau-telugu</string>
-      <string>jhau-telugu</string>
-      <string>jhau-telugu.alt</string>
-      <string>nyau-telugu</string>
-      <string>ttau-telugu</string>
-      <string>tthau-telugu</string>
-      <string>ddau-telugu</string>
-      <string>ddhau-telugu</string>
-      <string>nnau-telugu</string>
+      <string>taa-telugu</string>
       <string>tau-telugu</string>
+      <string>thaa-telugu</string>
+      <string>thaa-telugu.alt</string>
       <string>thau-telugu</string>
       <string>thau-telugu.alt</string>
-      <string>dau-telugu</string>
-      <string>dhau-telugu</string>
-      <string>nau-telugu</string>
-      <string>bau-telugu</string>
-      <string>bhau-telugu</string>
-      <string>mau-telugu</string>
-      <string>yau-telugu</string>
-      <string>rau-telugu</string>
-      <string>rrau-telugu</string>
-      <string>lau-telugu</string>
-      <string>llau-telugu</string>
-      <string>lllau-telugu</string>
+      <string>thuu-telugu</string>
+      <string>thuu-telugu.alt</string>
+      <string>ttaa-telugu</string>
+      <string>ttau-telugu</string>
+      <string>tthaa-telugu</string>
+      <string>tthau-telugu</string>
+      <string>tthuu-telugu</string>
+      <string>ttuu-telugu</string>
+      <string>tuu-telugu</string>
+      <string>uuMatra-telugu</string>
+      <string>vaa-telugu</string>
       <string>vau-telugu</string>
-      <string>shau-telugu</string>
-      <string>hau-telugu</string>
+      <string>vuu-telugu</string>
+      <string>yaa-telugu</string>
+      <string>yau-telugu</string>
+      <string>yii-telugu</string>
+      <string>yoo-telugu</string>
+      <string>yuu-telugu</string>
     </array>
     <key>public.kern1.TEL_sa-telugu.below_L</key>
     <array>
@@ -4236,21 +4236,21 @@
     </array>
     <key>public.kern1.TEL_ssa-telugu.alt_L</key>
     <array>
-      <string>ssa-telugu.alt</string>
       <string>ss-telugu.alt</string>
-      <string>ssi-telugu.alt</string>
-      <string>ssii-telugu.alt</string>
+      <string>ssa-telugu.alt</string>
       <string>sse-telugu.alt</string>
       <string>ssee-telugu.alt</string>
+      <string>ssi-telugu.alt</string>
+      <string>ssii-telugu.alt</string>
     </array>
     <key>public.kern1.TEL_ssa-telugu_L</key>
     <array>
-      <string>ssa-telugu</string>
       <string>ss-telugu</string>
-      <string>ssi-telugu</string>
-      <string>ssii-telugu</string>
+      <string>ssa-telugu</string>
       <string>sse-telugu</string>
       <string>ssee-telugu</string>
+      <string>ssi-telugu</string>
+      <string>ssii-telugu</string>
     </array>
     <key>public.kern1.TEL_va-telugu.below_L</key>
     <array>
@@ -4263,27 +4263,27 @@
     <key>public.kern1.TML_a-tamil_L</key>
     <array>
       <string>a-tamil</string>
-      <string>eight-tamil</string>
       <string>debit-tamil</string>
-      <string>nga_uMatra-tamil</string>
-      <string>nya_uMatra-tamil</string>
-      <string>nna_uMatra-tamil</string>
-      <string>ta_uMatra-tamil</string>
-      <string>na_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
-      <string>pa_uMatra-tamil</string>
-      <string>ya_uMatra-tamil</string>
-      <string>rra_uMatra-tamil</string>
+      <string>eight-tamil</string>
       <string>la_uMatra-tamil</string>
+      <string>na_uMatra-tamil</string>
+      <string>nga_uMatra-tamil</string>
+      <string>nna_uMatra-tamil</string>
+      <string>nnna_uMatra-tamil</string>
+      <string>nya_uMatra-tamil</string>
+      <string>pa_uMatra-tamil</string>
+      <string>rra_uMatra-tamil</string>
+      <string>ta_uMatra-tamil</string>
       <string>va_uMatra-tamil</string>
+      <string>ya_uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_aa-tamil_L</key>
     <array>
       <string>aa-tamil</string>
       <string>nga_uuMatra-tamil</string>
       <string>pa_uuMatra-tamil</string>
-      <string>ya_uuMatra-tamil</string>
       <string>va_uuMatra-tamil</string>
+      <string>ya_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ai-tamil_L</key>
     <array>
@@ -4312,23 +4312,23 @@
     </array>
     <key>public.kern1.TML_e-tamil_L</key>
     <array>
-      <string>e-tamil</string>
-      <string>ee-tamil</string>
       <string>au-tamil</string>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
-      <string>lla-tamil</string>
       <string>auMatra-tamil</string>
       <string>aulengthmark-tamil</string>
-      <string>seven-tamil</string>
-      <string>onehundred-tamil</string>
-      <string>nya_uuMatra-tamil</string>
-      <string>nna_uuMatra-tamil</string>
-      <string>ta_uuMatra-tamil</string>
-      <string>na_uuMatra-tamil</string>
-      <string>nnna_uuMatra-tamil</string>
-      <string>rra_uuMatra-tamil</string>
+      <string>e-tamil</string>
+      <string>ee-tamil</string>
       <string>la_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>na_uuMatra-tamil</string>
+      <string>nna-tamil</string>
+      <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uuMatra-tamil</string>
+      <string>nya_uuMatra-tamil</string>
+      <string>onehundred-tamil</string>
+      <string>rra_uuMatra-tamil</string>
+      <string>seven-tamil</string>
+      <string>ta_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_eeMatra-tamil_L</key>
     <array>
@@ -4344,8 +4344,8 @@
     </array>
     <key>public.kern1.TML_i-tamil_L</key>
     <array>
-      <string>i-tamil</string>
       <string>eMatra-tamil</string>
+      <string>i-tamil</string>
     </array>
     <key>public.kern1.TML_ii-tamil_L</key>
     <array>
@@ -4377,27 +4377,27 @@
     </array>
     <key>public.kern1.TML_ma-tamil_L</key>
     <array>
-      <string>ma-tamil</string>
       <string>llla-tamil</string>
-      <string>ma_uMatra-tamil</string>
       <string>llla_uMatra-tamil</string>
-      <string>ma_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma-tamil</string>
+      <string>ma_uMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ma_iiMatra-tamil_L</key>
     <array>
-      <string>ma_iiMatra-tamil</string>
       <string>llla_iiMatra-tamil</string>
+      <string>ma_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_na-tamil_L</key>
     <array>
-      <string>na-tamil</string>
       <string>five-tamil</string>
-      <string>sh_ra_iiMatra-tamil</string>
-      <string>ra_uMatra-tamil</string>
       <string>lla_uMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
+      <string>na-tamil</string>
+      <string>ra_uMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
+      <string>sh_ra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_nine.loclTAML_L</key>
     <array>
@@ -4410,8 +4410,8 @@
     <key>public.kern1.TML_o-tamil_L</key>
     <array>
       <string>o-tamil</string>
-      <string>oo-tamil</string>
       <string>om-tamil</string>
+      <string>oo-tamil</string>
     </array>
     <key>public.kern1.TML_one.loclTAML_L</key>
     <array>
@@ -4424,20 +4424,20 @@
     </array>
     <key>public.kern1.TML_ra-tamil_L</key>
     <array>
-      <string>ra-tamil</string>
       <string>aaMatra-tamil</string>
       <string>oMatra-tamil</string>
       <string>ooMatra-tamil</string>
+      <string>ra-tamil</string>
     </array>
     <key>public.kern1.TML_rra-tamil_L</key>
     <array>
-      <string>rra-tamil</string>
       <string>ha-tamil</string>
+      <string>rra-tamil</string>
     </array>
     <key>public.kern1.TML_rra_iiMatra-tamil_L</key>
     <array>
-      <string>rra_iiMatra-tamil</string>
       <string>ha_iiMatra-tamil</string>
+      <string>rra_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_seven.loclTAML_L</key>
     <array>
@@ -4453,19 +4453,19 @@
     </array>
     <key>public.kern1.TML_ssa-tamil_L</key>
     <array>
-      <string>ssa-tamil</string>
       <string>asabove-tamil</string>
       <string>k_ssa-tamil</string>
+      <string>ssa-tamil</string>
     </array>
     <key>public.kern1.TML_ssa_iiMatra-tamil_L</key>
     <array>
-      <string>ssa_iiMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
     </array>
     <key>public.kern1.TML_ta-tamil_L</key>
     <array>
-      <string>ta-tamil</string>
       <string>ka_uMatra-tamil</string>
+      <string>ta-tamil</string>
     </array>
     <key>public.kern1.TML_three.loclTAML_L</key>
     <array>
@@ -4473,9 +4473,9 @@
     </array>
     <key>public.kern1.TML_tta-tamil_L</key>
     <array>
-      <string>tta-tamil</string>
-      <string>three-tamil</string>
       <string>day-tamil</string>
+      <string>three-tamil</string>
+      <string>tta-tamil</string>
       <string>tta_iMatra-tamil</string>
     </array>
     <key>public.kern1.TML_tta_uMatra-tamil_L</key>
@@ -4492,16 +4492,16 @@
     </array>
     <key>public.kern1.TML_u-tamil_L</key>
     <array>
-      <string>u-tamil</string>
       <string>two-tamil</string>
+      <string>u-tamil</string>
     </array>
     <key>public.kern1.TML_uMatra-tamil_L</key>
     <array>
-      <string>uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>ha_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>uMatra-tamil</string>
     </array>
     <key>public.kern1.TML_uu-tamil_L</key>
     <array>
@@ -4509,11 +4509,11 @@
     </array>
     <key>public.kern1.TML_uuMatra-tamil_L</key>
     <array>
-      <string>uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
-      <string>sa_uuMatra-tamil</string>
       <string>ha_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>sa_uuMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>uuMatra-tamil</string>
     </array>
     <key>public.kern1.TML_zero.loclTAML_L</key>
     <array>
@@ -4550,11 +4550,11 @@
     </array>
     <key>public.kern1.Vin-georgian</key>
     <array>
-      <string>Vin-georgian</string>
-      <string>Par-georgian</string>
       <string>Can-georgian</string>
       <string>Hae-georgian</string>
       <string>He-georgian</string>
+      <string>Par-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern1.W</key>
     <array>
@@ -4562,19 +4562,21 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern1.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern1.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
@@ -4583,8 +4585,6 @@
       <string>Ygrave</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
     </array>
     <key>public.kern1.Yhook</key>
@@ -4601,8 +4601,10 @@
     <key>public.kern1.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -4615,6 +4617,7 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
       <string>agrave</string>
       <string>ahookabove</string>
@@ -4623,14 +4626,13 @@
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
     </array>
     <key>public.kern1.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -4644,6 +4646,7 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
       <string>agrave.sc</string>
@@ -4653,9 +4656,6 @@
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
@@ -4671,16 +4671,16 @@
     </array>
     <key>public.kern1.armn_lc_bar_xheight_bottomRound</key>
     <array>
-      <string>zhe-arm</string>
       <string>ca-arm</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern1.armn_lc_baselineBar</key>
     <array>
-      <string>gim-arm</string>
       <string>da-arm</string>
+      <string>ech_yiwn-arm</string>
+      <string>gim-arm</string>
       <string>ra-arm</string>
       <string>yiwn-arm</string>
-      <string>ech_yiwn-arm</string>
     </array>
     <key>public.kern1.armn_lc_ben</key>
     <array>
@@ -4698,15 +4698,15 @@
     </array>
     <key>public.kern1.armn_lc_descender_bar</key>
     <array>
-      <string>za-arm</string>
-      <string>liwn-arm</string>
       <string>ghad-arm</string>
-      <string>za-arm.nonspacing.long</string>
       <string>ghad-arm.nonspacing.long</string>
-      <string>za-arm.spacing.short</string>
-      <string>liwn-arm.spacing.short</string>
       <string>ghad-arm.spacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.spacing.short</string>
       <string>vew-arm.spacing.short</string>
+      <string>za-arm</string>
+      <string>za-arm.nonspacing.long</string>
+      <string>za-arm.spacing.short</string>
     </array>
     <key>public.kern1.armn_lc_descender_bar_ascender</key>
     <array>
@@ -4715,10 +4715,10 @@
     </array>
     <key>public.kern1.armn_lc_diagonal_descenders</key>
     <array>
-      <string>sha-arm</string>
       <string>jheh-arm</string>
-      <string>sha-arm.nonspacing.short</string>
       <string>jheh-arm.nonspacing.short</string>
+      <string>sha-arm</string>
+      <string>sha-arm.nonspacing.short</string>
     </array>
     <key>public.kern1.armn_lc_feh</key>
     <array>
@@ -4744,14 +4744,14 @@
     <key>public.kern1.armn_lc_roundTop_bottomStraight_xheight</key>
     <array>
       <string>et-arm</string>
-      <string>ini-arm</string>
-      <string>ho-arm</string>
-      <string>vo-arm</string>
-      <string>tiwn-arm</string>
-      <string>reh-arm</string>
-      <string>piwr-arm</string>
-      <string>men_ini-arm.liga</string>
       <string>et-arm.nonspacing.short</string>
+      <string>ho-arm</string>
+      <string>ini-arm</string>
+      <string>men_ini-arm.liga</string>
+      <string>piwr-arm</string>
+      <string>reh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vo-arm</string>
     </array>
     <key>public.kern1.armn_lc_round_xheight</key>
     <array>
@@ -4765,14 +4765,14 @@
     <key>public.kern1.armn_lc_straight_xheight</key>
     <array>
       <string>ayb-arm</string>
-      <string>xeh-arm</string>
-      <string>now-arm</string>
-      <string>seh-arm</string>
       <string>men_now-arm.liga</string>
-      <string>vew_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
+      <string>now-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
+      <string>seh-arm</string>
+      <string>vew_now-arm.liga</string>
+      <string>xeh-arm</string>
     </array>
     <key>public.kern1.armn_lc_to</key>
     <array>
@@ -4780,8 +4780,8 @@
     </array>
     <key>public.kern1.armn_lc_topStraight_bottomRound_descender</key>
     <array>
-      <string>yi-arm</string>
       <string>co-arm</string>
+      <string>yi-arm</string>
     </array>
     <key>public.kern1.armn_uc_Cha</key>
     <array>
@@ -4829,13 +4829,13 @@
     </array>
     <key>public.kern1.armn_uc_Za_Jheh</key>
     <array>
-      <string>Za-arm</string>
       <string>Jheh-arm</string>
+      <string>Za-arm</string>
     </array>
     <key>public.kern1.armn_uc_Za_Jheh.sc</key>
     <array>
-      <string>za-arm.sc</string>
       <string>jheh-arm.sc</string>
+      <string>za-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_bottomRound_topBar</key>
     <array>
@@ -4855,14 +4855,14 @@
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight</key>
     <array>
-      <string>Gim-arm</string>
       <string>Da-arm</string>
+      <string>Gim-arm</string>
       <string>Ra-arm</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topRound_bottomStraight.sc</key>
     <array>
-      <string>gim-arm.sc</string>
       <string>da-arm.sc</string>
+      <string>gim-arm.sc</string>
       <string>ra-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_middleBar_topStraight_bottomRound</key>
@@ -4875,13 +4875,13 @@
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar</key>
     <array>
-      <string>Vew-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Vew-arm</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar.sc</key>
     <array>
-      <string>vew-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
+      <string>vew-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_straight_baselineBar_long</key>
     <array>
@@ -4935,19 +4935,19 @@
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound</key>
     <array>
-      <string>Xeh-arm</string>
-      <string>Now-arm</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Now-arm</string>
       <string>Vew_Now-arm.liga</string>
+      <string>Xeh-arm</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomRound.sc</key>
     <array>
-      <string>xeh-arm.sc</string>
-      <string>now-arm.sc</string>
       <string>men_now-arm.liga.sc</string>
-      <string>vew_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>now-arm.sc</string>
+      <string>vew_now-arm.liga.sc</string>
+      <string>xeh-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topLower_bottomStraight</key>
     <array>
@@ -4997,8 +4997,8 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomDiagonal.sc</key>
     <array>
-      <string>ja-arm.sc</string>
       <string>cha-arm.sc</string>
+      <string>ja-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomRaised</key>
     <array>
@@ -5034,13 +5034,13 @@
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight</key>
     <array>
-      <string>Vo-arm</string>
       <string>Peh-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern1.armn_uc_topRound_bottomStraight.sc</key>
     <array>
-      <string>vo-arm.sc</string>
       <string>peh-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern1.armn_uc_topRound_middleBar_bottomRaised</key>
     <array>
@@ -5073,10 +5073,10 @@
     <key>public.kern1.b</key>
     <array>
       <string>b</string>
-      <string>thorn</string>
+      <string>bhook</string>
       <string>f_b</string>
       <string>f_f_b</string>
-      <string>bhook</string>
+      <string>thorn</string>
     </array>
     <key>public.kern1.b.sc</key>
     <array>
@@ -5085,13 +5085,13 @@
     <key>public.kern1.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>zen-georgian</string>
-      <string>san-georgian</string>
-      <string>xan-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
       <string>labial-georgian</string>
+      <string>san-georgian</string>
+      <string>turnedgan-georgian</string>
+      <string>xan-georgian</string>
+      <string>zen-georgian</string>
     </array>
     <key>public.kern1.bet-hb</key>
     <array>
@@ -5102,9 +5102,9 @@
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>nun-hb</string>
+      <string>nunhafukha-hb</string>
       <string>tav-hb</string>
       <string>tavdagesh-hb</string>
-      <string>nunhafukha-hb</string>
     </array>
     <key>public.kern1.bha-malayalam.half</key>
     <array>
@@ -5112,20 +5112,20 @@
     </array>
     <key>public.kern1.bracketleft</key>
     <array>
-      <string>parenleft</string>
       <string>braceleft</string>
-      <string>bracketleft</string>
       <string>braceleft.loclDEVA</string>
+      <string>bracketleft</string>
       <string>bracketleft.loclDEVA</string>
+      <string>parenleft</string>
       <string>parenleft.loclDEVA</string>
     </array>
     <key>public.kern1.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern1.c</key>
@@ -5136,13 +5136,13 @@
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
-      <string>es-cy</string>
       <string>e-cy</string>
+      <string>eopen</string>
+      <string>es-cy</string>
       <string>esdescender-cy</string>
-      <string>reversedze-cy</string>
       <string>esdescender-cy.loclBSH</string>
       <string>esdescender-cy.loclCHU</string>
-      <string>eopen</string>
+      <string>reversedze-cy</string>
     </array>
     <key>public.kern1.c.sc</key>
     <array>
@@ -5152,69 +5152,69 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>esdescender-cy.sc</string>
       <string>cheabkhasian-cy.sc</string>
       <string>chedescenderabkhasian-cy.sc</string>
-      <string>reversedze-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>eopen.sc</string>
+      <string>es-cy.sc</string>
       <string>esdescender-cy.loclBSH.sc</string>
       <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>reversedze-cy.sc</string>
     </array>
     <key>public.kern1.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern1.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern1.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern1.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern1.cyr_B</key>
     <array>
@@ -5232,25 +5232,25 @@
     </array>
     <key>public.kern1.cyr_G</key>
     <array>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ghestroke-cy</string>
       <string>Enghe-cy</string>
+      <string>Ge-cy</string>
       <string>Gedescender-cy</string>
       <string>Gestrokehook-cy</string>
+      <string>Ghestroke-cy</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
     </array>
     <key>public.kern1.cyr_K</key>
     <array>
-      <string>Zhe-cy</string>
       <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Zhedescender-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
       <string>Kabashkir-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Zhe-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_Shha</key>
@@ -5260,27 +5260,27 @@
     </array>
     <key>public.kern1.cyr_Soft</key>
     <array>
-      <string>Softsign-cy</string>
       <string>Hardsign-cy</string>
       <string>Lje-cy</string>
       <string>Nje-cy</string>
-      <string>Yat-cy</string>
       <string>Semisoftsign-cy</string>
+      <string>Softsign-cy</string>
+      <string>Yat-cy</string>
     </array>
     <key>public.kern1.cyr_Tse</key>
     <array>
-      <string>De-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Tse-cy</string>
-      <string>Shcha-cy</string>
-      <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Tetse-cy</string>
       <string>Chedescender-cy</string>
-      <string>Eltail-cy</string>
-      <string>Entail-cy</string>
-      <string>Emtail-cy</string>
+      <string>De-cy</string>
       <string>Eldescender-cy</string>
+      <string>Eltail-cy</string>
+      <string>Emtail-cy</string>
+      <string>Endescender-cy</string>
+      <string>Entail-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Shcha-cy</string>
+      <string>Tetse-cy</string>
+      <string>Tse-cy</string>
     </array>
     <key>public.kern1.cyr_V</key>
     <array>
@@ -5289,18 +5289,18 @@
     <key>public.kern1.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern1.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_b</key>
     <array>
@@ -5312,9 +5312,9 @@
     </array>
     <key>public.kern1.cyr_dje.sc</key>
     <array>
-      <string>tshe-cy.sc</string>
       <string>dje-cy.sc</string>
       <string>ghemiddlehook-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern1.cyr_f.sc</key>
     <array>
@@ -5322,25 +5322,25 @@
     </array>
     <key>public.kern1.cyr_g</key>
     <array>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ghestroke-cy</string>
       <string>enghe-cy</string>
+      <string>ge-cy</string>
       <string>gedescender-cy</string>
       <string>gestrokehook-cy</string>
+      <string>ghestroke-cy</string>
       <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
       <string>gje-cy.loclMKD</string>
     </array>
     <key>public.kern1.cyr_g.sc</key>
     <array>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ghestroke-cy.sc</string>
       <string>enghe-cy.sc</string>
+      <string>ge-cy.sc</string>
       <string>gedescender-cy.sc</string>
       <string>gestrokehook-cy.sc</string>
+      <string>ghestroke-cy.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
     </array>
     <key>public.kern1.cyr_gBGR</key>
     <array>
@@ -5356,34 +5356,34 @@
     </array>
     <key>public.kern1.cyr_k</key>
     <array>
-      <string>kgreenlandic</string>
-      <string>zhe-cy</string>
       <string>ka-cy</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kabashkir-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kastroke-cy</string>
+      <string>kaverticalstroke-cy</string>
+      <string>kgreenlandic</string>
       <string>kje-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>kastroke-cy</string>
-      <string>kabashkir-cy</string>
-      <string>zhebreve-cy</string>
-      <string>kahook-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern1.cyr_k.sc</key>
     <array>
-      <string>zhe-cy.sc</string>
       <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>kastroke-cy.sc</string>
       <string>kabashkir-cy.sc</string>
-      <string>zhebreve-cy.sc</string>
+      <string>kadescender-cy.sc</string>
       <string>kahook-cy.sc</string>
+      <string>kastroke-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
+      <string>kje-cy.sc</string>
+      <string>zhe-cy.sc</string>
+      <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern1.cyr_lBGR</key>
@@ -5392,24 +5392,24 @@
     </array>
     <key>public.kern1.cyr_soft</key>
     <array>
-      <string>softsign-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>lje-cy</string>
       <string>nje-cy</string>
-      <string>yat-cy</string>
       <string>semisoftsign-cy</string>
+      <string>softsign-cy</string>
       <string>softsign-cy.loclBGR</string>
-      <string>hardsign-cy.loclBGR</string>
+      <string>yat-cy</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_soft.sc</key>
     <array>
-      <string>softsign-cy.sc</string>
       <string>hardsign-cy.sc</string>
       <string>lje-cy.sc</string>
       <string>nje-cy.sc</string>
-      <string>yat-cy.sc</string>
       <string>semisoftsign-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>yat-cy.sc</string>
     </array>
     <key>public.kern1.cyr_t</key>
     <array>
@@ -5418,40 +5418,40 @@
     </array>
     <key>public.kern1.cyr_tse</key>
     <array>
-      <string>de-cy</string>
-      <string>iishorttail-cy</string>
-      <string>tse-cy</string>
-      <string>shcha-cy</string>
-      <string>endescender-cy</string>
-      <string>pedescender-cy</string>
-      <string>tetse-cy</string>
       <string>chedescender-cy</string>
-      <string>shhadescender-cy</string>
-      <string>eltail-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
+      <string>de-cy</string>
       <string>eldescender-cy</string>
-      <string>tse-cy.loclBGR</string>
+      <string>eltail-cy</string>
+      <string>emtail-cy</string>
+      <string>endescender-cy</string>
+      <string>entail-cy</string>
+      <string>iishorttail-cy</string>
+      <string>pedescender-cy</string>
+      <string>shcha-cy</string>
       <string>shcha-cy.loclBGR</string>
+      <string>shhadescender-cy</string>
+      <string>tetse-cy</string>
+      <string>tse-cy</string>
+      <string>tse-cy.loclBGR</string>
     </array>
     <key>public.kern1.cyr_tse.sc</key>
     <array>
-      <string>de-cy.sc</string>
-      <string>tse-cy.sc</string>
-      <string>shcha-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>pedescender-cy.sc</string>
-      <string>tetse-cy.sc</string>
       <string>chedescender-cy.sc</string>
+      <string>de-cy.sc</string>
       <string>eldescender-cy.sc</string>
       <string>eltail-cy.sc</string>
-      <string>entail-cy.sc</string>
       <string>emtail-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>entail-cy.sc</string>
+      <string>pedescender-cy.sc</string>
+      <string>shcha-cy.sc</string>
+      <string>tetse-cy.sc</string>
+      <string>tse-cy.sc</string>
     </array>
     <key>public.kern1.cyr_v</key>
     <array>
-      <string>ve-cy</string>
       <string>izhitsa-cy</string>
+      <string>ve-cy</string>
     </array>
     <key>public.kern1.cyr_v.sc</key>
     <array>
@@ -5463,12 +5463,12 @@
     </array>
     <key>public.kern1.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern1.d</key>
     <array>
@@ -5491,18 +5491,18 @@
     </array>
     <key>public.kern1.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern1.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern1.dhook</key>
     <array>
@@ -5511,7 +5511,12 @@
     <key>public.kern1.e</key>
     <array>
       <string>ae</string>
+      <string>ae.alt</string>
       <string>aeacute</string>
+      <string>aeacute.alt</string>
+      <string>aie-cy</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>e</string>
       <string>eacute</string>
       <string>ebreve</string>
@@ -5530,21 +5535,17 @@
       <string>emacron</string>
       <string>eogonek</string>
       <string>etilde</string>
-      <string>oe</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
       <string>ie-cy</string>
+      <string>iebreve-cy</string>
       <string>iegrave-cy</string>
       <string>io-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>aie-cy</string>
-      <string>iebreve-cy</string>
+      <string>oe</string>
     </array>
     <key>public.kern1.e.sc</key>
     <array>
       <string>ae.sc</string>
       <string>aeacute.sc</string>
+      <string>aie-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -5563,26 +5564,25 @@
       <string>emacron.sc</string>
       <string>eogonek.sc</string>
       <string>etilde.sc</string>
-      <string>oe.sc</string>
       <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
       <string>iegrave-cy.sc</string>
       <string>io-cy.sc</string>
-      <string>aie-cy.sc</string>
-      <string>iebreve-cy.sc</string>
+      <string>oe.sc</string>
     </array>
     <key>public.kern1.eSign-khmer</key>
     <array>
-      <string>eSign-khmer</string>
       <string>aeSign-khmer</string>
       <string>aiSign-khmer</string>
+      <string>eSign-khmer</string>
     </array>
     <key>public.kern1.eVowel-lao</key>
     <array>
-      <string>eVowel-lao</string>
       <string>aeVowel-lao</string>
-      <string>oVowel-lao</string>
-      <string>ayMaiMuanVowel-lao</string>
       <string>aiMaiMayVowel-lao</string>
+      <string>ayMaiMuanVowel-lao</string>
+      <string>eVowel-lao</string>
+      <string>oVowel-lao</string>
     </array>
     <key>public.kern1.en-georgian</key>
     <array>
@@ -5623,70 +5623,70 @@
     </array>
     <key>public.kern1.ethi_cce</key>
     <array>
-      <string>ce-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ce-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccee</key>
     <array>
-      <string>cee-ethiopic</string>
       <string>ccee-ethiopic</string>
+      <string>cee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cci</key>
     <array>
-      <string>ci-ethiopic</string>
       <string>cci-ethiopic</string>
+      <string>ci-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ccu</key>
     <array>
-      <string>cu-ethiopic</string>
       <string>ccu-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
       <string>ccha-ethiopic</string>
       <string>cchha-ethiopic</string>
+      <string>cha-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chaa</key>
     <array>
-      <string>chaa-ethiopic</string>
       <string>cchaa-ethiopic</string>
       <string>cchhaa-ethiopic</string>
+      <string>chaa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cche-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chee</key>
     <array>
-      <string>chee-ethiopic</string>
       <string>cchee-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>chee-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chi</key>
     <array>
-      <string>chi-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchhi-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>chi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
-      <string>ccho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>ccho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern1.ethi_chu</key>
     <array>
-      <string>chu-ethiopic</string>
-      <string>cchu-ethiopic</string>
       <string>cchhu-ethiopic</string>
+      <string>cchu-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_co</key>
     <array>
-      <string>co-ethiopic</string>
       <string>cco-ethiopic</string>
+      <string>co-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddaa</key>
     <array>
@@ -5705,20 +5705,20 @@
     </array>
     <key>public.kern1.ethi_ddi</key>
     <array>
-      <string>ddi-ethiopic</string>
       <string>ddhi-ethiopic</string>
+      <string>ddi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
-      <string>doa-ethiopic</string>
-      <string>ddoa-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
+      <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
       <string>ddhu-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern1.ethi_ePharyngeal</key>
     <array>
@@ -5826,13 +5826,13 @@
     </array>
     <key>public.kern1.ethi_qwa</key>
     <array>
-      <string>qwa-ethiopic</string>
       <string>qhwa-ethiopic</string>
+      <string>qwa-ethiopic</string>
     </array>
     <key>public.kern1.ethi_qwi</key>
     <array>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern1.ethi_sa</key>
     <array>
@@ -5909,14 +5909,14 @@
     </array>
     <key>public.kern1.ethi_xa</key>
     <array>
+      <string>na-ethiopic</string>
       <string>xa-ethiopic</string>
       <string>xe-ethiopic</string>
-      <string>na-ethiopic</string>
     </array>
     <key>public.kern1.ethi_xo</key>
     <array>
-      <string>xo-ethiopic</string>
       <string>no-ethiopic</string>
+      <string>xo-ethiopic</string>
     </array>
     <key>public.kern1.ethi_za</key>
     <array>
@@ -5956,9 +5956,9 @@
     <key>public.kern1.exclam</key>
     <array>
       <string>exclam</string>
+      <string>exclam.loclDEVA</string>
       <string>exclamdouble</string>
       <string>questionexclamation</string>
-      <string>exclam.loclDEVA</string>
     </array>
     <key>public.kern1.f</key>
     <array>
@@ -5979,12 +5979,12 @@
     </array>
     <key>public.kern1.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern1.g.sc</key>
     <array>
@@ -6010,8 +6010,8 @@
     </array>
     <key>public.kern1.ghan-georgian</key>
     <array>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern1.gimel-hb</key>
     <array>
@@ -6040,18 +6040,37 @@
     </array>
     <key>public.kern1.h.sc</key>
     <array>
+      <string>che-cy.sc</string>
+      <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
+      <string>dzhe-cy.sc</string>
+      <string>el-cy.sc</string>
+      <string>elhook-cy.sc</string>
+      <string>em-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>enlefthook-cy.sc</string>
       <string>h.sc</string>
       <string>hbar.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
+      <string>ia-cy.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
@@ -6060,48 +6079,29 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
       <string>ntilde.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>el-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>che-cy.sc</string>
-      <string>sha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>ia-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>enlefthook-cy.sc</string>
       <string>palochka-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>chedieresis-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>sha-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>elhook-cy.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern1.hae-georgian</key>
     <array>
-      <string>par-georgian</string>
       <string>hae-georgian</string>
+      <string>par-georgian</string>
     </array>
     <key>public.kern1.i</key>
     <array>
+      <string>f_f_i</string>
+      <string>f_i</string>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>igrave</string>
       <string>ihookabove</string>
       <string>iogonek</string>
-      <string>f_f_i</string>
-      <string>f_i</string>
-      <string>i-cy</string>
     </array>
     <key>public.kern1.i_right</key>
     <array>
@@ -6114,35 +6114,35 @@
     </array>
     <key>public.kern1.in-georgian</key>
     <array>
-      <string>tan-georgian</string>
       <string>in-georgian</string>
       <string>on-georgian</string>
       <string>rae-georgian</string>
+      <string>tan-georgian</string>
     </array>
     <key>public.kern1.j</key>
     <array>
-      <string>j</string>
-      <string>jdotless</string>
-      <string>jcircumflex</string>
       <string>f_f_j</string>
       <string>f_j</string>
-      <string>je-cy</string>
       <string>ij</string>
+      <string>j</string>
+      <string>jcircumflex</string>
+      <string>jdotless</string>
+      <string>je-cy</string>
     </array>
     <key>public.kern1.j.sc</key>
     <array>
+      <string>ij.sc</string>
       <string>j.sc</string>
       <string>jcircumflex.sc</string>
       <string>je-cy.sc</string>
-      <string>ij.sc</string>
     </array>
     <key>public.kern1.k</key>
     <array>
-      <string>k</string>
-      <string>kcommaaccent</string>
-      <string>k.alt</string>
       <string>f_f_k</string>
       <string>f_k</string>
+      <string>k</string>
+      <string>k.alt</string>
+      <string>kcommaaccent</string>
       <string>khook</string>
     </array>
     <key>public.kern1.k.sc</key>
@@ -6152,11 +6152,11 @@
     </array>
     <key>public.kern1.l</key>
     <array>
+      <string>f_f_l</string>
+      <string>f_l</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcommaaccent</string>
-      <string>f_f_l</string>
-      <string>f_l</string>
       <string>palochka-cy</string>
     </array>
     <key>public.kern1.l.sc</key>
@@ -6172,38 +6172,38 @@
     <array>
       <string>aleflamed-hb</string>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
     </array>
     <key>public.kern1.lower_straight</key>
     <array>
-      <string>idotless</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
+      <string>che-cy</string>
+      <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
+      <string>dzhe-cy</string>
       <string>el-cy</string>
+      <string>elhook-cy</string>
       <string>em-cy</string>
       <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>che-cy</string>
-      <string>sha-cy</string>
-      <string>dzhe-cy</string>
-      <string>yeru-cy</string>
-      <string>ia-cy</string>
-      <string>cheverticalstroke-cy</string>
       <string>enhook-cy</string>
-      <string>chekhakassian-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>chedieresis-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>elhook-cy</string>
       <string>enlefthook-cy</string>
+      <string>ia-cy</string>
+      <string>idieresis-cy</string>
+      <string>idotless</string>
+      <string>ii-cy</string>
       <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
+      <string>iigrave-cy</string>
       <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>imacron-cy</string>
+      <string>pe-cy</string>
+      <string>sha-cy</string>
       <string>sha-cy.loclBGR</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern1.man-georgian</key>
     <array>
@@ -6216,8 +6216,8 @@
     </array>
     <key>public.kern1.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern1.mem-hb</key>
     <array>
@@ -6226,6 +6226,11 @@
     </array>
     <key>public.kern1.n</key>
     <array>
+      <string>Tshe-cy</string>
+      <string>dje-cy</string>
+      <string>eng</string>
+      <string>f_f_h</string>
+      <string>f_h</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
@@ -6234,16 +6239,11 @@
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
       <string>ntilde</string>
-      <string>f_f_h</string>
-      <string>f_h</string>
-      <string>Tshe-cy</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>shha-cy</string>
       <string>pe-cy.loclBGR</string>
+      <string>shha-cy</string>
       <string>te-cy.loclBGR</string>
+      <string>tshe-cy</string>
     </array>
     <key>public.kern1.nar-georgian</key>
     <array>
@@ -6251,8 +6251,20 @@
     </array>
     <key>public.kern1.o</key>
     <array>
+      <string>be-cy.loclSRB</string>
+      <string>edieresis-cy</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
+      <string>ereversed-cy</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>iu-cy</string>
+      <string>iu-cy.loclBGR</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -6261,41 +6273,40 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohungarumlaut</string>
       <string>omacron</string>
+      <string>oopen</string>
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>o-cy</string>
-      <string>ef-cy</string>
-      <string>ereversed-cy</string>
-      <string>iu-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>be-cy.loclSRB</string>
-      <string>oopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern1.o.sc</key>
     <array>
       <string>b.sc</string>
+      <string>bhook.sc</string>
       <string>d.sc</string>
-      <string>eth.sc</string>
       <string>dcaron.sc</string>
       <string>dcroat.sc</string>
+      <string>dhook.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>eth.sc</string>
+      <string>fita-cy.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>iu-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -6303,33 +6314,22 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohungarumlaut.sc</string>
       <string>omacron.sc</string>
+      <string>oopen.sc</string>
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>bhook.sc</string>
-      <string>dhook.sc</string>
-      <string>oopen.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern1.ohorn.sc</key>
     <array>
@@ -6342,32 +6342,32 @@
     </array>
     <key>public.kern1.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
+      <string>p</string>
     </array>
     <key>public.kern1.p.sc</key>
     <array>
-      <string>p.sc</string>
       <string>er-cy.sc</string>
       <string>ertick-cy.sc</string>
+      <string>p.sc</string>
     </array>
     <key>public.kern1.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern1.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern1.q</key>
     <array>
@@ -6376,34 +6376,34 @@
     </array>
     <key>public.kern1.question</key>
     <array>
-      <string>question</string>
-      <string>exclamationquestion</string>
       <string>doublequestion</string>
+      <string>exclamationquestion</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
     </array>
     <key>public.kern1.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern1.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern1.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern1.quotesingle</key>
@@ -6414,10 +6414,10 @@
     <key>public.kern1.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
       <string>rcommaaccent</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern1.r.sc</key>
     <array>
@@ -6428,24 +6428,24 @@
     </array>
     <key>public.kern1.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern1.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern1.seven</key>
@@ -6454,37 +6454,37 @@
     </array>
     <key>public.kern1.shin-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>samekhdagesh-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern1.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern1.space</key>
     <array>
-      <string>space</string>
       <string>nbspace</string>
+      <string>space</string>
     </array>
     <key>public.kern1.t</key>
     <array>
+      <string>f_f_t</string>
+      <string>f_t</string>
+      <string>r_t</string>
       <string>t</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>f_f_t</string>
-      <string>f_t</string>
-      <string>r_t</string>
-      <string>t_t</string>
     </array>
     <key>public.kern1.t.sc</key>
     <array>
@@ -6498,10 +6498,10 @@
     </array>
     <key>public.kern1.thai-saraE</key>
     <array>
-      <string>saraE-thai</string>
       <string>saraAe-thai</string>
       <string>saraAiMaimalai-thai</string>
       <string>saraAiMaimuan-thai</string>
+      <string>saraE-thai</string>
       <string>saraO-thai</string>
     </array>
     <key>public.kern1.tsadi-hb</key>
@@ -6511,6 +6511,7 @@
     </array>
     <key>public.kern1.u</key>
     <array>
+      <string>micro</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -6524,15 +6525,14 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>micro</string>
     </array>
     <key>public.kern1.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern1.uhorn</key>
     <array>
@@ -6554,9 +6554,9 @@
     </array>
     <key>public.kern1.v</key>
     <array>
-      <string>v</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern1.v.sc</key>
     <array>
@@ -6568,8 +6568,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern1.w.sc</key>
     <array>
@@ -6577,27 +6577,32 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern1.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern1.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern1.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
@@ -6605,14 +6610,10 @@
       <string>ygrave</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
     </array>
     <key>public.kern1.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
@@ -6621,7 +6622,6 @@
       <string>ygrave.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
     </array>
     <key>public.kern1.yhook</key>
     <array>
@@ -6633,9 +6633,9 @@
     </array>
     <key>public.kern1.yod-hb</key>
     <array>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern1.z</key>
@@ -6662,14 +6662,16 @@
     </array>
     <key>public.kern1.zhar-georgian</key>
     <array>
-      <string>zhar-georgian</string>
       <string>qar-georgian</string>
+      <string>zhar-georgian</string>
     </array>
     <key>public.kern2.A</key>
     <array>
       <string>A</string>
+      <string>A-cy</string>
       <string>Aacute</string>
       <string>Abreve</string>
+      <string>Abreve-cy</string>
       <string>Abreveacute</string>
       <string>Abrevedotbelow</string>
       <string>Abrevegrave</string>
@@ -6683,6 +6685,7 @@
       <string>Acircumflexhookabove</string>
       <string>Acircumflextilde</string>
       <string>Adieresis</string>
+      <string>Adieresis-cy</string>
       <string>Adotbelow</string>
       <string>Agrave</string>
       <string>Ahookabove</string>
@@ -6691,9 +6694,6 @@
       <string>Aring</string>
       <string>Aringacute</string>
       <string>Atilde</string>
-      <string>A-cy</string>
-      <string>Abreve-cy</string>
-      <string>Adieresis-cy</string>
       <string>De-cy.loclBGR</string>
       <string>El-cy.loclBGR</string>
     </array>
@@ -6743,14 +6743,14 @@
     </array>
     <key>public.kern2.DEV_aaMatra-deva_R</key>
     <array>
-      <string>ooeMatra-deva</string>
       <string>aaMatra-deva</string>
-      <string>iMatra-deva</string>
-      <string>oCandraMatra-deva</string>
-      <string>oShortMatra-deva</string>
-      <string>oMatra-deva</string>
       <string>auMatra-deva</string>
       <string>awMatra-deva</string>
+      <string>iMatra-deva</string>
+      <string>oCandraMatra-deva</string>
+      <string>oMatra-deva</string>
+      <string>oShortMatra-deva</string>
+      <string>ooeMatra-deva</string>
     </array>
     <key>public.kern2.DEV_bba-deva_R</key>
     <array>
@@ -6758,23 +6758,23 @@
     </array>
     <key>public.kern2.DEV_ca-deva_R</key>
     <array>
-      <string>ca-deva</string>
       <string>c-deva</string>
+      <string>ca-deva</string>
     </array>
     <key>public.kern2.DEV_cha-deva_R</key>
     <array>
-      <string>cha-deva</string>
       <string>ch-deva</string>
       <string>ch_ya-deva</string>
+      <string>cha-deva</string>
     </array>
     <key>public.kern2.DEV_dda-deva_R</key>
     <array>
-      <string>nga-deva</string>
+      <string>dd-deva</string>
+      <string>dd_ya-deva</string>
       <string>dda-deva</string>
       <string>dddha-deva</string>
       <string>ng-deva</string>
-      <string>dd-deva</string>
-      <string>dd_ya-deva</string>
+      <string>nga-deva</string>
     </array>
     <key>public.kern2.DEV_ddda-deva_R</key>
     <array>
@@ -6782,8 +6782,8 @@
     </array>
     <key>public.kern2.DEV_ddha-deva_R</key>
     <array>
-      <string>ddha-deva</string>
       <string>ddh-deva</string>
+      <string>ddha-deva</string>
     </array>
     <key>public.kern2.DEV_dha-deva_R</key>
     <array>
@@ -6791,9 +6791,9 @@
     </array>
     <key>public.kern2.DEV_ga-deva_R</key>
     <array>
+      <string>g-deva</string>
       <string>ga-deva</string>
       <string>ghha-deva</string>
-      <string>g-deva</string>
     </array>
     <key>public.kern2.DEV_gga-deva_R</key>
     <array>
@@ -6801,13 +6801,13 @@
     </array>
     <key>public.kern2.DEV_gha-deva_R</key>
     <array>
-      <string>gha-deva</string>
       <string>gh-deva</string>
+      <string>gha-deva</string>
     </array>
     <key>public.kern2.DEV_ha-deva_R</key>
     <array>
-      <string>ha-deva</string>
       <string>h-deva</string>
+      <string>ha-deva</string>
     </array>
     <key>public.kern2.DEV_i-deva_R</key>
     <array>
@@ -6817,10 +6817,10 @@
     </array>
     <key>public.kern2.DEV_ja-deva_R</key>
     <array>
+      <string>j-deva</string>
       <string>ja-deva</string>
       <string>za-deva</string>
       <string>zha-deva</string>
-      <string>j-deva</string>
     </array>
     <key>public.kern2.DEV_jja-deva_R</key>
     <array>
@@ -6828,9 +6828,9 @@
     </array>
     <key>public.kern2.DEV_ka-deva_R</key>
     <array>
-      <string>ka-deva</string>
-      <string>qa-deva</string>
       <string>k-deva</string>
+      <string>k-deva.alt10</string>
+      <string>k-deva.alt11</string>
       <string>k-deva.alt2</string>
       <string>k-deva.alt3</string>
       <string>k-deva.alt4</string>
@@ -6838,27 +6838,27 @@
       <string>k-deva.alt6</string>
       <string>k-deva.alt7</string>
       <string>k-deva.alt8</string>
-      <string>k-deva.alt10</string>
-      <string>k-deva.alt11</string>
+      <string>ka-deva</string>
+      <string>qa-deva</string>
     </array>
     <key>public.kern2.DEV_kha-deva_R</key>
     <array>
-      <string>kha-deva</string>
-      <string>ra-deva</string>
-      <string>rra-deva</string>
-      <string>sa-deva</string>
-      <string>khha-deva</string>
       <string>kh-deva</string>
       <string>kh-deva.alt2</string>
       <string>kh-deva.alt3</string>
       <string>kh-deva.alt4</string>
+      <string>kha-deva</string>
+      <string>khha-deva</string>
+      <string>ra-deva</string>
+      <string>rra-deva</string>
+      <string>sa-deva</string>
     </array>
     <key>public.kern2.DEV_la-deva_R</key>
     <array>
       <string>lVocalic-deva</string>
-      <string>llVocalic-deva</string>
       <string>la-deva</string>
       <string>la-deva.loclMAR</string>
+      <string>llVocalic-deva</string>
     </array>
     <key>public.kern2.DEV_lla-deva_R</key>
     <array>
@@ -6889,9 +6889,9 @@
     </array>
     <key>public.kern2.DEV_pa-deva_R</key>
     <array>
+      <string>fa-deva</string>
       <string>pa-deva</string>
       <string>ssa-deva</string>
-      <string>fa-deva</string>
     </array>
     <key>public.kern2.DEV_pha-deva_R</key>
     <array>
@@ -6911,14 +6911,14 @@
     </array>
     <key>public.kern2.DEV_ttha-deva_R</key>
     <array>
-      <string>tta-deva</string>
-      <string>ttha-deva</string>
+      <string>d-deva</string>
       <string>da-deva</string>
       <string>rha-deva</string>
       <string>tt-deva</string>
+      <string>tta-deva</string>
       <string>tth-deva</string>
-      <string>d-deva</string>
       <string>tth_ya-deva</string>
+      <string>ttha-deva</string>
     </array>
     <key>public.kern2.DEV_va-deva_R</key>
     <array>
@@ -6928,50 +6928,50 @@
     <key>public.kern2.DEV_ya-deva_R</key>
     <array>
       <string>ya-deva</string>
-      <string>yya-deva</string>
       <string>yaheavy-deva</string>
+      <string>yya-deva</string>
     </array>
     <key>public.kern2.En-georgian</key>
     <array>
       <string>En-georgian</string>
-      <string>Vin-georgian</string>
       <string>Man-georgian</string>
+      <string>Vin-georgian</string>
     </array>
     <key>public.kern2.GRK_Alpha</key>
     <array>
       <string>Alpha</string>
+      <string>Alphadasia</string>
+      <string>Alphadasiaoxia</string>
+      <string>Alphadasiaoxiaprosgegrammeni</string>
+      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
+      <string>Alphadasiaperispomeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni</string>
+      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Alphadasiaprosgegrammeni</string>
+      <string>Alphadasiaprosgegrammeni.ad</string>
+      <string>Alphadasiavaria</string>
+      <string>Alphadasiavariaprosgegrammeni</string>
+      <string>Alphadasiavariaprosgegrammeni.ad</string>
+      <string>Alphamacron</string>
+      <string>Alphaoxia</string>
+      <string>Alphaprosgegrammeni</string>
+      <string>Alphaprosgegrammeni.ad</string>
+      <string>Alphapsili</string>
+      <string>Alphapsilioxia</string>
+      <string>Alphapsilioxiaprosgegrammeni</string>
+      <string>Alphapsilioxiaprosgegrammeni.ad</string>
+      <string>Alphapsiliperispomeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni</string>
+      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
+      <string>Alphapsiliprosgegrammeni</string>
+      <string>Alphapsiliprosgegrammeni.ad</string>
+      <string>Alphapsilivaria</string>
+      <string>Alphapsilivariaprosgegrammeni</string>
+      <string>Alphapsilivariaprosgegrammeni.ad</string>
+      <string>Alphavaria</string>
+      <string>Alphavrachy</string>
       <string>Delta</string>
       <string>Lambda</string>
-      <string>Alphapsili</string>
-      <string>Alphadasia</string>
-      <string>Alphapsilivaria</string>
-      <string>Alphadasiavaria</string>
-      <string>Alphapsilioxia</string>
-      <string>Alphadasiaoxia</string>
-      <string>Alphapsiliperispomeni</string>
-      <string>Alphadasiaperispomeni</string>
-      <string>Alphavaria</string>
-      <string>Alphaoxia</string>
-      <string>Alphavrachy</string>
-      <string>Alphamacron</string>
-      <string>Alphaprosgegrammeni</string>
-      <string>Alphapsiliprosgegrammeni</string>
-      <string>Alphadasiaprosgegrammeni</string>
-      <string>Alphapsilivariaprosgegrammeni</string>
-      <string>Alphadasiavariaprosgegrammeni</string>
-      <string>Alphapsilioxiaprosgegrammeni</string>
-      <string>Alphadasiaoxiaprosgegrammeni</string>
-      <string>Alphapsiliperispomeniprosgegrammeni</string>
-      <string>Alphadasiaperispomeniprosgegrammeni</string>
-      <string>Alphaprosgegrammeni.ad</string>
-      <string>Alphapsiliprosgegrammeni.ad</string>
-      <string>Alphadasiaprosgegrammeni.ad</string>
-      <string>Alphapsilivariaprosgegrammeni.ad</string>
-      <string>Alphadasiavariaprosgegrammeni.ad</string>
-      <string>Alphapsilioxiaprosgegrammeni.ad</string>
-      <string>Alphadasiaoxiaprosgegrammeni.ad</string>
-      <string>Alphapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Alphadasiaperispomeniprosgegrammeni.ad</string>
     </array>
     <key>public.kern2.GRK_Chi</key>
     <array>
@@ -6980,40 +6980,40 @@
     <key>public.kern2.GRK_Omega</key>
     <array>
       <string>Omega</string>
-      <string>Omegapsili</string>
       <string>Omegadasia</string>
-      <string>Omegapsilivaria</string>
-      <string>Omegadasiavaria</string>
-      <string>Omegapsilioxia</string>
       <string>Omegadasiaoxia</string>
-      <string>Omegapsiliperispomeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni</string>
+      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
       <string>Omegadasiaperispomeni</string>
-      <string>Omegavaria</string>
+      <string>Omegadasiaperispomeniprosgegrammeni</string>
+      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegadasiaprosgegrammeni</string>
+      <string>Omegadasiaprosgegrammeni.ad</string>
+      <string>Omegadasiavaria</string>
+      <string>Omegadasiavariaprosgegrammeni</string>
+      <string>Omegadasiavariaprosgegrammeni.ad</string>
       <string>Omegaoxia</string>
       <string>Omegaprosgegrammeni</string>
-      <string>Omegapsiliprosgegrammeni</string>
-      <string>Omegadasiaprosgegrammeni</string>
-      <string>Omegapsilivariaprosgegrammeni</string>
-      <string>Omegadasiavariaprosgegrammeni</string>
-      <string>Omegapsilioxiaprosgegrammeni</string>
-      <string>Omegadasiaoxiaprosgegrammeni</string>
-      <string>Omegapsiliperispomeniprosgegrammeni</string>
-      <string>Omegadasiaperispomeniprosgegrammeni</string>
       <string>Omegaprosgegrammeni.ad</string>
-      <string>Omegapsiliprosgegrammeni.ad</string>
-      <string>Omegadasiaprosgegrammeni.ad</string>
-      <string>Omegapsilivariaprosgegrammeni.ad</string>
-      <string>Omegadasiavariaprosgegrammeni.ad</string>
+      <string>Omegapsili</string>
+      <string>Omegapsilioxia</string>
+      <string>Omegapsilioxiaprosgegrammeni</string>
       <string>Omegapsilioxiaprosgegrammeni.ad</string>
-      <string>Omegadasiaoxiaprosgegrammeni.ad</string>
+      <string>Omegapsiliperispomeni</string>
+      <string>Omegapsiliperispomeniprosgegrammeni</string>
       <string>Omegapsiliperispomeniprosgegrammeni.ad</string>
-      <string>Omegadasiaperispomeniprosgegrammeni.ad</string>
+      <string>Omegapsiliprosgegrammeni</string>
+      <string>Omegapsiliprosgegrammeni.ad</string>
+      <string>Omegapsilivaria</string>
+      <string>Omegapsilivariaprosgegrammeni</string>
+      <string>Omegapsilivariaprosgegrammeni.ad</string>
+      <string>Omegavaria</string>
     </array>
     <key>public.kern2.GRK_Omicron</key>
     <array>
-      <string>Theta</string>
       <string>Omicron</string>
       <string>Phi</string>
+      <string>Theta</string>
     </array>
     <key>public.kern2.GRK_Psi</key>
     <array>
@@ -7030,15 +7030,15 @@
     <key>public.kern2.GRK_Upsilon</key>
     <array>
       <string>Upsilon</string>
-      <string>Upsilondieresis</string>
       <string>Upsilondasia</string>
-      <string>Upsilondasiavaria</string>
       <string>Upsilondasiaoxia</string>
       <string>Upsilondasiaperispomeni</string>
-      <string>Upsilonvaria</string>
-      <string>Upsilonoxia</string>
-      <string>Upsilonvrachy</string>
+      <string>Upsilondasiavaria</string>
+      <string>Upsilondieresis</string>
       <string>Upsilonmacron</string>
+      <string>Upsilonoxia</string>
+      <string>Upsilonvaria</string>
+      <string>Upsilonvrachy</string>
     </array>
     <key>public.kern2.GRK_Zeta</key>
     <array>
@@ -7047,10 +7047,10 @@
     <key>public.kern2.GRK_alpha.sc</key>
     <array>
       <string>alpha.sc</string>
-      <string>delta.sc</string>
-      <string>lambda.sc</string>
       <string>alphatonos.sc</string>
       <string>alphatonos.sc.ss06</string>
+      <string>delta.sc</string>
+      <string>lambda.sc</string>
     </array>
     <key>public.kern2.GRK_chi</key>
     <array>
@@ -7063,153 +7063,153 @@
     <key>public.kern2.GRK_epsilon</key>
     <array>
       <string>epsilon</string>
-      <string>epsilontonos</string>
-      <string>epsilonpsili</string>
       <string>epsilondasia</string>
-      <string>epsilonpsilivaria</string>
-      <string>epsilondasiavaria</string>
-      <string>epsilonpsilioxia</string>
-      <string>epsilondasiaoxia</string>
-      <string>epsilonvaria</string>
-      <string>epsilonoxia</string>
-      <string>epsilonpsili.sc</string>
       <string>epsilondasia.sc</string>
-      <string>epsilonpsilivaria.sc</string>
-      <string>epsilondasiavaria.sc</string>
-      <string>epsilonpsilioxia.sc</string>
-      <string>epsilondasiaoxia.sc</string>
-      <string>epsilonvaria.sc</string>
-      <string>epsilonoxia.sc</string>
-      <string>epsilonpsili.sc.ss06</string>
       <string>epsilondasia.sc.ss06</string>
-      <string>epsilonpsilivaria.sc.ss06</string>
-      <string>epsilondasiavaria.sc.ss06</string>
-      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilondasiaoxia</string>
+      <string>epsilondasiaoxia.sc</string>
       <string>epsilondasiaoxia.sc.ss06</string>
-      <string>epsilonvaria.sc.ss06</string>
+      <string>epsilondasiavaria</string>
+      <string>epsilondasiavaria.sc</string>
+      <string>epsilondasiavaria.sc.ss06</string>
+      <string>epsilonoxia</string>
+      <string>epsilonoxia.sc</string>
       <string>epsilonoxia.sc.ss06</string>
+      <string>epsilonpsili</string>
+      <string>epsilonpsili.sc</string>
+      <string>epsilonpsili.sc.ss06</string>
+      <string>epsilonpsilioxia</string>
+      <string>epsilonpsilioxia.sc</string>
+      <string>epsilonpsilioxia.sc.ss06</string>
+      <string>epsilonpsilivaria</string>
+      <string>epsilonpsilivaria.sc</string>
+      <string>epsilonpsilivaria.sc.ss06</string>
+      <string>epsilontonos</string>
+      <string>epsilonvaria</string>
+      <string>epsilonvaria.sc</string>
+      <string>epsilonvaria.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_epsilon.sc</key>
     <array>
       <string>beta.sc</string>
-      <string>gamma.sc</string>
       <string>epsilon.sc</string>
+      <string>epsilontonos.sc</string>
+      <string>epsilontonos.sc.ss06</string>
       <string>eta.sc</string>
+      <string>etatonos.sc</string>
+      <string>etatonos.sc.ss06</string>
+      <string>gamma.sc</string>
       <string>iota.sc</string>
+      <string>iotadieresis.sc</string>
+      <string>iotadieresis.sc.ss06</string>
+      <string>iotadieresistonos.sc</string>
+      <string>iotadieresistonos.sc.ss06</string>
+      <string>iotatonos.sc</string>
+      <string>iotatonos.sc.ss06</string>
+      <string>kaiSymbol.sc</string>
       <string>kappa.sc</string>
       <string>mu.sc</string>
       <string>nu.sc</string>
       <string>pi.sc</string>
       <string>rho.sc</string>
-      <string>iotatonos.sc</string>
-      <string>iotadieresis.sc</string>
-      <string>iotadieresistonos.sc</string>
-      <string>epsilontonos.sc</string>
-      <string>etatonos.sc</string>
-      <string>kaiSymbol.sc</string>
-      <string>iotatonos.sc.ss06</string>
-      <string>iotadieresis.sc.ss06</string>
-      <string>iotadieresistonos.sc.ss06</string>
-      <string>epsilontonos.sc.ss06</string>
-      <string>etatonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_eta</key>
     <array>
       <string>eta</string>
-      <string>etatonos</string>
-      <string>etapsili</string>
       <string>etadasia</string>
-      <string>etapsilivaria</string>
-      <string>etadasiavaria</string>
-      <string>etapsilioxia</string>
-      <string>etadasiaoxia</string>
-      <string>etapsiliperispomeni</string>
-      <string>etadasiaperispomeni</string>
-      <string>etavaria</string>
-      <string>etaoxia</string>
-      <string>etaperispomeni</string>
-      <string>etaypogegrammeni</string>
-      <string>etavariaypogegrammeni</string>
-      <string>etaoxiaypogegrammeni</string>
-      <string>etapsiliypogegrammeni</string>
-      <string>etadasiaypogegrammeni</string>
-      <string>etapsilivariaypogegrammeni</string>
-      <string>etadasiavariaypogegrammeni</string>
-      <string>etapsilioxiaypogegrammeni</string>
-      <string>etadasiaoxiaypogegrammeni</string>
-      <string>etapsiliperispomeniypogegrammeni</string>
-      <string>etadasiaperispomeniypogegrammeni</string>
-      <string>etaperispomeniypogegrammeni</string>
-      <string>etaypogegrammeni.sc.ad</string>
-      <string>etavariaypogegrammeni.sc.ad</string>
-      <string>etaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliypogegrammeni.sc.ad</string>
-      <string>etadasiaypogegrammeni.sc.ad</string>
-      <string>etapsilivariaypogegrammeni.sc.ad</string>
-      <string>etadasiavariaypogegrammeni.sc.ad</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>etaperispomeniypogegrammeni.sc.ad</string>
-      <string>etapsili.sc</string>
       <string>etadasia.sc</string>
-      <string>etapsilivaria.sc</string>
-      <string>etadasiavaria.sc</string>
-      <string>etapsilioxia.sc</string>
-      <string>etadasiaoxia.sc</string>
-      <string>etapsiliperispomeni.sc</string>
-      <string>etadasiaperispomeni.sc</string>
-      <string>etavaria.sc</string>
-      <string>etaoxia.sc</string>
-      <string>etaperispomeni.sc</string>
-      <string>etaypogegrammeni.sc</string>
-      <string>etavariaypogegrammeni.sc</string>
-      <string>etaoxiaypogegrammeni.sc</string>
-      <string>etapsiliypogegrammeni.sc</string>
-      <string>etadasiaypogegrammeni.sc</string>
-      <string>etapsilivariaypogegrammeni.sc</string>
-      <string>etadasiavariaypogegrammeni.sc</string>
-      <string>etapsilioxiaypogegrammeni.sc</string>
-      <string>etadasiaoxiaypogegrammeni.sc</string>
-      <string>etapsiliperispomeniypogegrammeni.sc</string>
-      <string>etadasiaperispomeniypogegrammeni.sc</string>
-      <string>etaperispomeniypogegrammeni.sc</string>
-      <string>etaypogegrammeni.sc.ad.ss06</string>
-      <string>etavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>etapsili.sc.ss06</string>
       <string>etadasia.sc.ss06</string>
-      <string>etapsilivaria.sc.ss06</string>
-      <string>etadasiavaria.sc.ss06</string>
-      <string>etapsilioxia.sc.ss06</string>
+      <string>etadasiaoxia</string>
+      <string>etadasiaoxia.sc</string>
       <string>etadasiaoxia.sc.ss06</string>
-      <string>etapsiliperispomeni.sc.ss06</string>
-      <string>etadasiaperispomeni.sc.ss06</string>
-      <string>etavaria.sc.ss06</string>
-      <string>etaoxia.sc.ss06</string>
-      <string>etaperispomeni.sc.ss06</string>
-      <string>etaypogegrammeni.sc.ss06</string>
-      <string>etavariaypogegrammeni.sc.ss06</string>
-      <string>etaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliypogegrammeni.sc.ss06</string>
-      <string>etadasiaypogegrammeni.sc.ss06</string>
-      <string>etapsilivariaypogegrammeni.sc.ss06</string>
-      <string>etadasiavariaypogegrammeni.sc.ss06</string>
-      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etadasiaoxiaypogegrammeni</string>
+      <string>etadasiaoxiaypogegrammeni.sc</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>etadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiaperispomeni</string>
+      <string>etadasiaperispomeni.sc</string>
+      <string>etadasiaperispomeni.sc.ss06</string>
+      <string>etadasiaperispomeniypogegrammeni</string>
+      <string>etadasiaperispomeniypogegrammeni.sc</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>etadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etadasiavaria</string>
+      <string>etadasiavaria.sc</string>
+      <string>etadasiavaria.sc.ss06</string>
+      <string>etadasiavariaypogegrammeni</string>
+      <string>etadasiavariaypogegrammeni.sc</string>
+      <string>etadasiavariaypogegrammeni.sc.ad</string>
+      <string>etadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiavariaypogegrammeni.sc.ss06</string>
+      <string>etadasiaypogegrammeni</string>
+      <string>etadasiaypogegrammeni.sc</string>
+      <string>etadasiaypogegrammeni.sc.ad</string>
+      <string>etadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>etadasiaypogegrammeni.sc.ss06</string>
+      <string>etaoxia</string>
+      <string>etaoxia.sc</string>
+      <string>etaoxia.sc.ss06</string>
+      <string>etaoxiaypogegrammeni</string>
+      <string>etaoxiaypogegrammeni.sc</string>
+      <string>etaoxiaypogegrammeni.sc.ad</string>
+      <string>etaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etaoxiaypogegrammeni.sc.ss06</string>
+      <string>etaperispomeni</string>
+      <string>etaperispomeni.sc</string>
+      <string>etaperispomeni.sc.ss06</string>
+      <string>etaperispomeniypogegrammeni</string>
+      <string>etaperispomeniypogegrammeni.sc</string>
+      <string>etaperispomeniypogegrammeni.sc.ad</string>
+      <string>etaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>etaperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsili</string>
+      <string>etapsili.sc</string>
+      <string>etapsili.sc.ss06</string>
+      <string>etapsilioxia</string>
+      <string>etapsilioxia.sc</string>
+      <string>etapsilioxia.sc.ss06</string>
+      <string>etapsilioxiaypogegrammeni</string>
+      <string>etapsilioxiaypogegrammeni.sc</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad</string>
+      <string>etapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>etapsiliperispomeni</string>
+      <string>etapsiliperispomeni.sc</string>
+      <string>etapsiliperispomeni.sc.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni</string>
+      <string>etapsiliperispomeniypogegrammeni.sc</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>etapsilivaria</string>
+      <string>etapsilivaria.sc</string>
+      <string>etapsilivaria.sc.ss06</string>
+      <string>etapsilivariaypogegrammeni</string>
+      <string>etapsilivariaypogegrammeni.sc</string>
+      <string>etapsilivariaypogegrammeni.sc.ad</string>
+      <string>etapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>etapsilivariaypogegrammeni.sc.ss06</string>
+      <string>etapsiliypogegrammeni</string>
+      <string>etapsiliypogegrammeni.sc</string>
+      <string>etapsiliypogegrammeni.sc.ad</string>
+      <string>etapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>etapsiliypogegrammeni.sc.ss06</string>
+      <string>etatonos</string>
+      <string>etavaria</string>
+      <string>etavaria.sc</string>
+      <string>etavaria.sc.ss06</string>
+      <string>etavariaypogegrammeni</string>
+      <string>etavariaypogegrammeni.sc</string>
+      <string>etavariaypogegrammeni.sc.ad</string>
+      <string>etavariaypogegrammeni.sc.ad.ss06</string>
+      <string>etavariaypogegrammeni.sc.ss06</string>
+      <string>etaypogegrammeni</string>
+      <string>etaypogegrammeni.sc</string>
+      <string>etaypogegrammeni.sc.ad</string>
+      <string>etaypogegrammeni.sc.ad.ss06</string>
+      <string>etaypogegrammeni.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_gamma</key>
     <array>
@@ -7219,57 +7219,57 @@
     <key>public.kern2.GRK_iota</key>
     <array>
       <string>iota</string>
-      <string>iotatonos</string>
+      <string>iotadasia</string>
+      <string>iotadasia.sc</string>
+      <string>iotadasia.sc.ss06</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiaoxia.sc</string>
+      <string>iotadasiaoxia.sc.ss06</string>
+      <string>iotadasiaperispomeni</string>
+      <string>iotadasiaperispomeni.sc</string>
+      <string>iotadasiaperispomeni.sc.ss06</string>
+      <string>iotadasiavaria</string>
+      <string>iotadasiavaria.sc</string>
+      <string>iotadasiavaria.sc.ss06</string>
+      <string>iotadialytikaoxia</string>
+      <string>iotadialytikaoxia.sc</string>
+      <string>iotadialytikaoxia.sc.ss06</string>
+      <string>iotadialytikaperispomeni</string>
+      <string>iotadialytikaperispomeni.sc</string>
+      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotadialytikavaria</string>
+      <string>iotadialytikavaria.sc</string>
+      <string>iotadialytikavaria.sc.ss06</string>
       <string>iotadieresis</string>
       <string>iotadieresistonos</string>
-      <string>iotapsili</string>
-      <string>iotadasia</string>
-      <string>iotapsilivaria</string>
-      <string>iotadasiavaria</string>
-      <string>iotapsilioxia</string>
-      <string>iotadasiaoxia</string>
-      <string>iotapsiliperispomeni</string>
-      <string>iotadasiaperispomeni</string>
-      <string>iotavaria</string>
-      <string>iotaoxia</string>
-      <string>iotaperispomeni</string>
-      <string>iotavrachy</string>
       <string>iotamacron</string>
-      <string>iotadialytikavaria</string>
-      <string>iotadialytikaoxia</string>
-      <string>iotadialytikaperispomeni</string>
-      <string>iotapsili.sc</string>
-      <string>iotadasia.sc</string>
-      <string>iotapsilivaria.sc</string>
-      <string>iotadasiavaria.sc</string>
-      <string>iotapsilioxia.sc</string>
-      <string>iotadasiaoxia.sc</string>
-      <string>iotapsiliperispomeni.sc</string>
-      <string>iotadasiaperispomeni.sc</string>
-      <string>iotavaria.sc</string>
-      <string>iotaoxia.sc</string>
-      <string>iotaperispomeni.sc</string>
-      <string>iotavrachy.sc</string>
       <string>iotamacron.sc</string>
-      <string>iotadialytikavaria.sc</string>
-      <string>iotadialytikaoxia.sc</string>
-      <string>iotadialytikaperispomeni.sc</string>
-      <string>iotapsili.sc.ss06</string>
-      <string>iotadasia.sc.ss06</string>
-      <string>iotapsilivaria.sc.ss06</string>
-      <string>iotadasiavaria.sc.ss06</string>
-      <string>iotapsilioxia.sc.ss06</string>
-      <string>iotadasiaoxia.sc.ss06</string>
-      <string>iotapsiliperispomeni.sc.ss06</string>
-      <string>iotadasiaperispomeni.sc.ss06</string>
-      <string>iotavaria.sc.ss06</string>
-      <string>iotaoxia.sc.ss06</string>
-      <string>iotaperispomeni.sc.ss06</string>
-      <string>iotavrachy.sc.ss06</string>
       <string>iotamacron.sc.ss06</string>
-      <string>iotadialytikavaria.sc.ss06</string>
-      <string>iotadialytikaoxia.sc.ss06</string>
-      <string>iotadialytikaperispomeni.sc.ss06</string>
+      <string>iotaoxia</string>
+      <string>iotaoxia.sc</string>
+      <string>iotaoxia.sc.ss06</string>
+      <string>iotaperispomeni</string>
+      <string>iotaperispomeni.sc</string>
+      <string>iotaperispomeni.sc.ss06</string>
+      <string>iotapsili</string>
+      <string>iotapsili.sc</string>
+      <string>iotapsili.sc.ss06</string>
+      <string>iotapsilioxia</string>
+      <string>iotapsilioxia.sc</string>
+      <string>iotapsilioxia.sc.ss06</string>
+      <string>iotapsiliperispomeni</string>
+      <string>iotapsiliperispomeni.sc</string>
+      <string>iotapsiliperispomeni.sc.ss06</string>
+      <string>iotapsilivaria</string>
+      <string>iotapsilivaria.sc</string>
+      <string>iotapsilivaria.sc.ss06</string>
+      <string>iotatonos</string>
+      <string>iotavaria</string>
+      <string>iotavaria.sc</string>
+      <string>iotavaria.sc.ss06</string>
+      <string>iotavrachy</string>
+      <string>iotavrachy.sc</string>
+      <string>iotavrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_lambda</key>
     <array>
@@ -7277,156 +7277,156 @@
     </array>
     <key>public.kern2.GRK_mu</key>
     <array>
+      <string>kaiSymbol</string>
       <string>kappa</string>
       <string>mu</string>
       <string>rho</string>
-      <string>kaiSymbol</string>
-      <string>rhopsili</string>
       <string>rhodasia</string>
-      <string>rhopsili.sc</string>
       <string>rhodasia.sc</string>
-      <string>rhopsili.sc.ss06</string>
       <string>rhodasia.sc.ss06</string>
+      <string>rhopsili</string>
+      <string>rhopsili.sc</string>
+      <string>rhopsili.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_omicron</key>
     <array>
       <string>alpha</string>
-      <string>delta</string>
-      <string>omicron</string>
-      <string>sigmafinal</string>
-      <string>sigma</string>
-      <string>phi</string>
-      <string>omega</string>
-      <string>omicrontonos</string>
-      <string>omegatonos</string>
       <string>alphatonos</string>
-      <string>omicronpsili</string>
-      <string>omicrondasia</string>
-      <string>omicronpsilivaria</string>
-      <string>omicrondasiavaria</string>
-      <string>omicronpsilioxia</string>
-      <string>omicrondasiaoxia</string>
-      <string>omicronvaria</string>
-      <string>omicronoxia</string>
-      <string>omegapsili</string>
+      <string>delta</string>
+      <string>omega</string>
       <string>omegadasia</string>
-      <string>omegapsilivaria</string>
-      <string>omegadasiavaria</string>
-      <string>omegapsilioxia</string>
-      <string>omegadasiaoxia</string>
-      <string>omegapsiliperispomeni</string>
-      <string>omegadasiaperispomeni</string>
-      <string>omegavaria</string>
-      <string>omegaoxia</string>
-      <string>omegaperispomeni</string>
-      <string>omegaypogegrammeni</string>
-      <string>omegavariaypogegrammeni</string>
-      <string>omegaoxiaypogegrammeni</string>
-      <string>omegapsiliypogegrammeni</string>
-      <string>omegadasiaypogegrammeni</string>
-      <string>omegapsilivariaypogegrammeni</string>
-      <string>omegadasiavariaypogegrammeni</string>
-      <string>omegapsilioxiaypogegrammeni</string>
-      <string>omegadasiaoxiaypogegrammeni</string>
-      <string>omegapsiliperispomeniypogegrammeni</string>
-      <string>omegadasiaperispomeniypogegrammeni</string>
-      <string>omegaperispomeniypogegrammeni</string>
-      <string>omegaypogegrammeni.sc.ad</string>
-      <string>omegavariaypogegrammeni.sc.ad</string>
-      <string>omegaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliypogegrammeni.sc.ad</string>
-      <string>omegadasiaypogegrammeni.sc.ad</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad</string>
-      <string>omicronpsili.sc</string>
-      <string>omicrondasia.sc</string>
-      <string>omicronpsilivaria.sc</string>
-      <string>omicrondasiavaria.sc</string>
-      <string>omicronpsilioxia.sc</string>
-      <string>omicrondasiaoxia.sc</string>
-      <string>omicronvaria.sc</string>
-      <string>omicronoxia.sc</string>
-      <string>omegapsili.sc</string>
       <string>omegadasia.sc</string>
-      <string>omegapsilivaria.sc</string>
-      <string>omegadasiavaria.sc</string>
-      <string>omegapsilioxia.sc</string>
-      <string>omegadasiaoxia.sc</string>
-      <string>omegapsiliperispomeni.sc</string>
-      <string>omegadasiaperispomeni.sc</string>
-      <string>omegavaria.sc</string>
-      <string>omegaoxia.sc</string>
-      <string>omegaperispomeni.sc</string>
-      <string>omegaypogegrammeni.sc</string>
-      <string>omegavariaypogegrammeni.sc</string>
-      <string>omegaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliypogegrammeni.sc</string>
-      <string>omegadasiaypogegrammeni.sc</string>
-      <string>omegapsilivariaypogegrammeni.sc</string>
-      <string>omegadasiavariaypogegrammeni.sc</string>
-      <string>omegapsilioxiaypogegrammeni.sc</string>
-      <string>omegadasiaoxiaypogegrammeni.sc</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc</string>
-      <string>omegaperispomeniypogegrammeni.sc</string>
-      <string>omegaypogegrammeni.sc.ad.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
-      <string>omicronpsili.sc.ss06</string>
-      <string>omicrondasia.sc.ss06</string>
-      <string>omicronpsilivaria.sc.ss06</string>
-      <string>omicrondasiavaria.sc.ss06</string>
-      <string>omicronpsilioxia.sc.ss06</string>
-      <string>omicrondasiaoxia.sc.ss06</string>
-      <string>omicronvaria.sc.ss06</string>
-      <string>omicronoxia.sc.ss06</string>
-      <string>omegapsili.sc.ss06</string>
       <string>omegadasia.sc.ss06</string>
-      <string>omegapsilivaria.sc.ss06</string>
-      <string>omegadasiavaria.sc.ss06</string>
-      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegadasiaoxia</string>
+      <string>omegadasiaoxia.sc</string>
       <string>omegadasiaoxia.sc.ss06</string>
-      <string>omegapsiliperispomeni.sc.ss06</string>
-      <string>omegadasiaperispomeni.sc.ss06</string>
-      <string>omegavaria.sc.ss06</string>
-      <string>omegaoxia.sc.ss06</string>
-      <string>omegaperispomeni.sc.ss06</string>
-      <string>omegaypogegrammeni.sc.ss06</string>
-      <string>omegavariaypogegrammeni.sc.ss06</string>
-      <string>omegaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliypogegrammeni.sc.ss06</string>
-      <string>omegadasiaypogegrammeni.sc.ss06</string>
-      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
-      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
-      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaoxiaypogegrammeni</string>
+      <string>omegadasiaoxiaypogegrammeni.sc</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaoxiaypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaoxiaypogegrammeni.sc.ss06</string>
-      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiaperispomeni</string>
+      <string>omegadasiaperispomeni.sc</string>
+      <string>omegadasiaperispomeni.sc.ss06</string>
+      <string>omegadasiaperispomeniypogegrammeni</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegadasiaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegadasiaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegadasiavaria</string>
+      <string>omegadasiavaria.sc</string>
+      <string>omegadasiavaria.sc.ss06</string>
+      <string>omegadasiavariaypogegrammeni</string>
+      <string>omegadasiavariaypogegrammeni.sc</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad</string>
+      <string>omegadasiavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiavariaypogegrammeni.sc.ss06</string>
+      <string>omegadasiaypogegrammeni</string>
+      <string>omegadasiaypogegrammeni.sc</string>
+      <string>omegadasiaypogegrammeni.sc.ad</string>
+      <string>omegadasiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegadasiaypogegrammeni.sc.ss06</string>
+      <string>omegaoxia</string>
+      <string>omegaoxia.sc</string>
+      <string>omegaoxia.sc.ss06</string>
+      <string>omegaoxiaypogegrammeni</string>
+      <string>omegaoxiaypogegrammeni.sc</string>
+      <string>omegaoxiaypogegrammeni.sc.ad</string>
+      <string>omegaoxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaoxiaypogegrammeni.sc.ss06</string>
+      <string>omegaperispomeni</string>
+      <string>omegaperispomeni.sc</string>
+      <string>omegaperispomeni.sc.ss06</string>
+      <string>omegaperispomeniypogegrammeni</string>
+      <string>omegaperispomeniypogegrammeni.sc</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad</string>
+      <string>omegaperispomeniypogegrammeni.sc.ad.ss06</string>
       <string>omegaperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsili</string>
+      <string>omegapsili.sc</string>
+      <string>omegapsili.sc.ss06</string>
+      <string>omegapsilioxia</string>
+      <string>omegapsilioxia.sc</string>
+      <string>omegapsilioxia.sc.ss06</string>
+      <string>omegapsilioxiaypogegrammeni</string>
+      <string>omegapsilioxiaypogegrammeni.sc</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilioxiaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliperispomeni</string>
+      <string>omegapsiliperispomeni.sc</string>
+      <string>omegapsiliperispomeni.sc.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliperispomeniypogegrammeni.sc.ss06</string>
+      <string>omegapsilivaria</string>
+      <string>omegapsilivaria.sc</string>
+      <string>omegapsilivaria.sc.ss06</string>
+      <string>omegapsilivariaypogegrammeni</string>
+      <string>omegapsilivariaypogegrammeni.sc</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad</string>
+      <string>omegapsilivariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsilivariaypogegrammeni.sc.ss06</string>
+      <string>omegapsiliypogegrammeni</string>
+      <string>omegapsiliypogegrammeni.sc</string>
+      <string>omegapsiliypogegrammeni.sc.ad</string>
+      <string>omegapsiliypogegrammeni.sc.ad.ss06</string>
+      <string>omegapsiliypogegrammeni.sc.ss06</string>
+      <string>omegatonos</string>
+      <string>omegavaria</string>
+      <string>omegavaria.sc</string>
+      <string>omegavaria.sc.ss06</string>
+      <string>omegavariaypogegrammeni</string>
+      <string>omegavariaypogegrammeni.sc</string>
+      <string>omegavariaypogegrammeni.sc.ad</string>
+      <string>omegavariaypogegrammeni.sc.ad.ss06</string>
+      <string>omegavariaypogegrammeni.sc.ss06</string>
+      <string>omegaypogegrammeni</string>
+      <string>omegaypogegrammeni.sc</string>
+      <string>omegaypogegrammeni.sc.ad</string>
+      <string>omegaypogegrammeni.sc.ad.ss06</string>
+      <string>omegaypogegrammeni.sc.ss06</string>
+      <string>omicron</string>
+      <string>omicrondasia</string>
+      <string>omicrondasia.sc</string>
+      <string>omicrondasia.sc.ss06</string>
+      <string>omicrondasiaoxia</string>
+      <string>omicrondasiaoxia.sc</string>
+      <string>omicrondasiaoxia.sc.ss06</string>
+      <string>omicrondasiavaria</string>
+      <string>omicrondasiavaria.sc</string>
+      <string>omicrondasiavaria.sc.ss06</string>
+      <string>omicronoxia</string>
+      <string>omicronoxia.sc</string>
+      <string>omicronoxia.sc.ss06</string>
+      <string>omicronpsili</string>
+      <string>omicronpsili.sc</string>
+      <string>omicronpsili.sc.ss06</string>
+      <string>omicronpsilioxia</string>
+      <string>omicronpsilioxia.sc</string>
+      <string>omicronpsilioxia.sc.ss06</string>
+      <string>omicronpsilivaria</string>
+      <string>omicronpsilivaria.sc</string>
+      <string>omicronpsilivaria.sc.ss06</string>
+      <string>omicrontonos</string>
+      <string>omicronvaria</string>
+      <string>omicronvaria.sc</string>
+      <string>omicronvaria.sc.ss06</string>
+      <string>phi</string>
+      <string>sigma</string>
+      <string>sigmafinal</string>
     </array>
     <key>public.kern2.GRK_omicron.sc</key>
     <array>
-      <string>theta.sc</string>
-      <string>omicron.sc</string>
       <string>omega.sc</string>
-      <string>omicrontonos.sc</string>
       <string>omegatonos.sc</string>
-      <string>omicrontonos.sc.ss06</string>
       <string>omegatonos.sc.ss06</string>
+      <string>omicron.sc</string>
+      <string>omicrontonos.sc</string>
+      <string>omicrontonos.sc.ss06</string>
+      <string>theta.sc</string>
     </array>
     <key>public.kern2.GRK_phi.sc</key>
     <array>
@@ -7442,8 +7442,8 @@
     </array>
     <key>public.kern2.GRK_sigma.sc</key>
     <array>
-      <string>sigmafinal.sc</string>
       <string>sigma.sc</string>
+      <string>sigmafinal.sc</string>
     </array>
     <key>public.kern2.GRK_tau</key>
     <array>
@@ -7459,69 +7459,69 @@
     </array>
     <key>public.kern2.GRK_upsilon</key>
     <array>
-      <string>upsilon</string>
       <string>psi</string>
-      <string>upsilontonos</string>
+      <string>upsilon</string>
+      <string>upsilondasia</string>
+      <string>upsilondasia.sc</string>
+      <string>upsilondasia.sc.ss06</string>
+      <string>upsilondasiaoxia</string>
+      <string>upsilondasiaoxia.sc</string>
+      <string>upsilondasiaoxia.sc.ss06</string>
+      <string>upsilondasiaperispomeni</string>
+      <string>upsilondasiaperispomeni.sc</string>
+      <string>upsilondasiaperispomeni.sc.ss06</string>
+      <string>upsilondasiavaria</string>
+      <string>upsilondasiavaria.sc</string>
+      <string>upsilondasiavaria.sc.ss06</string>
+      <string>upsilondialytikaoxia</string>
+      <string>upsilondialytikaoxia.sc</string>
+      <string>upsilondialytikaoxia.sc.ss06</string>
+      <string>upsilondialytikaperispomeni</string>
+      <string>upsilondialytikaperispomeni.sc</string>
+      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilondialytikavaria</string>
+      <string>upsilondialytikavaria.sc</string>
+      <string>upsilondialytikavaria.sc.ss06</string>
       <string>upsilondieresis</string>
       <string>upsilondieresistonos</string>
-      <string>upsilonpsili</string>
-      <string>upsilondasia</string>
-      <string>upsilonpsilivaria</string>
-      <string>upsilondasiavaria</string>
-      <string>upsilonpsilioxia</string>
-      <string>upsilondasiaoxia</string>
-      <string>upsilonpsiliperispomeni</string>
-      <string>upsilondasiaperispomeni</string>
-      <string>upsilonvaria</string>
-      <string>upsilonoxia</string>
-      <string>upsilonperispomeni</string>
-      <string>upsilonvrachy</string>
       <string>upsilonmacron</string>
-      <string>upsilondialytikavaria</string>
-      <string>upsilondialytikaoxia</string>
-      <string>upsilondialytikaperispomeni</string>
-      <string>upsilonpsili.sc</string>
-      <string>upsilondasia.sc</string>
-      <string>upsilonpsilivaria.sc</string>
-      <string>upsilondasiavaria.sc</string>
-      <string>upsilonpsilioxia.sc</string>
-      <string>upsilondasiaoxia.sc</string>
-      <string>upsilonpsiliperispomeni.sc</string>
-      <string>upsilondasiaperispomeni.sc</string>
-      <string>upsilonvaria.sc</string>
-      <string>upsilonoxia.sc</string>
-      <string>upsilonperispomeni.sc</string>
-      <string>upsilonvrachy.sc</string>
       <string>upsilonmacron.sc</string>
-      <string>upsilondialytikavaria.sc</string>
-      <string>upsilondialytikaoxia.sc</string>
-      <string>upsilondialytikaperispomeni.sc</string>
-      <string>upsilonpsili.sc.ss06</string>
-      <string>upsilondasia.sc.ss06</string>
-      <string>upsilonpsilivaria.sc.ss06</string>
-      <string>upsilondasiavaria.sc.ss06</string>
-      <string>upsilonpsilioxia.sc.ss06</string>
-      <string>upsilondasiaoxia.sc.ss06</string>
-      <string>upsilonpsiliperispomeni.sc.ss06</string>
-      <string>upsilondasiaperispomeni.sc.ss06</string>
-      <string>upsilonvaria.sc.ss06</string>
-      <string>upsilonoxia.sc.ss06</string>
-      <string>upsilonperispomeni.sc.ss06</string>
-      <string>upsilonvrachy.sc.ss06</string>
       <string>upsilonmacron.sc.ss06</string>
-      <string>upsilondialytikavaria.sc.ss06</string>
-      <string>upsilondialytikaoxia.sc.ss06</string>
-      <string>upsilondialytikaperispomeni.sc.ss06</string>
+      <string>upsilonoxia</string>
+      <string>upsilonoxia.sc</string>
+      <string>upsilonoxia.sc.ss06</string>
+      <string>upsilonperispomeni</string>
+      <string>upsilonperispomeni.sc</string>
+      <string>upsilonperispomeni.sc.ss06</string>
+      <string>upsilonpsili</string>
+      <string>upsilonpsili.sc</string>
+      <string>upsilonpsili.sc.ss06</string>
+      <string>upsilonpsilioxia</string>
+      <string>upsilonpsilioxia.sc</string>
+      <string>upsilonpsilioxia.sc.ss06</string>
+      <string>upsilonpsiliperispomeni</string>
+      <string>upsilonpsiliperispomeni.sc</string>
+      <string>upsilonpsiliperispomeni.sc.ss06</string>
+      <string>upsilonpsilivaria</string>
+      <string>upsilonpsilivaria.sc</string>
+      <string>upsilonpsilivaria.sc.ss06</string>
+      <string>upsilontonos</string>
+      <string>upsilonvaria</string>
+      <string>upsilonvaria.sc</string>
+      <string>upsilonvaria.sc.ss06</string>
+      <string>upsilonvrachy</string>
+      <string>upsilonvrachy.sc</string>
+      <string>upsilonvrachy.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_upsilon.sc</key>
     <array>
       <string>upsilon.sc</string>
-      <string>upsilontonos.sc</string>
       <string>upsilondieresis.sc</string>
-      <string>upsilondieresistonos.sc</string>
-      <string>upsilontonos.sc.ss06</string>
       <string>upsilondieresis.sc.ss06</string>
+      <string>upsilondieresistonos.sc</string>
       <string>upsilondieresistonos.sc.ss06</string>
+      <string>upsilontonos.sc</string>
+      <string>upsilontonos.sc.ss06</string>
     </array>
     <key>public.kern2.GRK_xi</key>
     <array>
@@ -7543,27 +7543,27 @@
     <array>
       <string>a-gujarati</string>
       <string>aa-gujarati</string>
-      <string>e-gujarati</string>
       <string>ai-gujarati</string>
-      <string>eCandra-gujarati</string>
-      <string>oCandra-gujarati</string>
-      <string>o-gujarati</string>
       <string>au-gujarati</string>
+      <string>e-gujarati</string>
+      <string>eCandra-gujarati</string>
+      <string>o-gujarati</string>
+      <string>oCandra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ba-gujarati_L</key>
     <array>
-      <string>ba-gujarati</string>
-      <string>lla-gujarati</string>
-      <string>b_ra-gujarati</string>
-      <string>ll_ra-gujarati</string>
       <string>b_na-gujarati</string>
+      <string>b_ra-gujarati</string>
+      <string>ba-gujarati</string>
+      <string>ll_ra-gujarati</string>
       <string>ll_ya-gujarati</string>
+      <string>lla-gujarati</string>
     </array>
     <key>public.kern2.GUJ_bha-gujarati_L</key>
     <array>
-      <string>bha-gujarati</string>
       <string>bh-gujarati</string>
       <string>bh_ra-gujarati</string>
+      <string>bha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_c_ra-gujarati_L</key>
     <array>
@@ -7571,8 +7571,8 @@
     </array>
     <key>public.kern2.GUJ_ca-gujarati_L</key>
     <array>
-      <string>ca-gujarati</string>
       <string>c_cha-gujarati</string>
+      <string>ca-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ma-gujarati_L</key>
     <array>
@@ -7584,9 +7584,9 @@
     </array>
     <key>public.kern2.GUJ_d_ra-gujarati_L</key>
     <array>
-      <string>d_ra-gujarati</string>
       <string>d_ga-gujarati</string>
       <string>d_r_ya-gujarati</string>
+      <string>d_ra-gujarati</string>
       <string>da_rVocalicMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_d_ya-gujarati_L</key>
@@ -7595,30 +7595,30 @@
     </array>
     <key>public.kern2.GUJ_da-gujarati_L</key>
     <array>
-      <string>da-gujarati</string>
       <string>d_da-gujarati</string>
+      <string>da-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ddha-gujarati_L</key>
     <array>
-      <string>ddha-gujarati</string>
       <string>ddh-gujarati</string>
       <string>ddh_ra-gujarati</string>
       <string>ddh_ya-gujarati</string>
+      <string>ddha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dh_ra-gujarati_L</key>
     <array>
-      <string>dh_ra-gujarati</string>
       <string>dh_na-gujarati</string>
+      <string>dh_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_dha-gujarati_L</key>
     <array>
-      <string>dha-gujarati</string>
       <string>dh-gujarati</string>
+      <string>dha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_g_ra-gujarati_L</key>
     <array>
-      <string>g_ra-gujarati</string>
       <string>g_na-gujarati</string>
+      <string>g_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ga-gujarati_L</key>
     <array>
@@ -7630,17 +7630,17 @@
     </array>
     <key>public.kern2.GUJ_ha-gujarati_L</key>
     <array>
-      <string>ha-gujarati</string>
       <string>h-gujarati</string>
       <string>h_ra-gujarati</string>
+      <string>ha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_i-gujarati_L</key>
     <array>
-      <string>i-gujarati</string>
-      <string>ii-gujarati</string>
-      <string>cha-gujarati</string>
       <string>ch_va-gujarati</string>
       <string>ch_ya-gujarati</string>
+      <string>cha-gujarati</string>
+      <string>i-gujarati</string>
+      <string>ii-gujarati</string>
     </array>
     <key>public.kern2.GUJ_j_nya-gujarati_L</key>
     <array>
@@ -7648,10 +7648,10 @@
     </array>
     <key>public.kern2.GUJ_ja-gujarati_L</key>
     <array>
-      <string>ja-gujarati</string>
-      <string>j_ra-gujarati</string>
       <string>j_ja-gujarati</string>
+      <string>j_ra-gujarati</string>
       <string>j_ya-gujarati</string>
+      <string>ja-gujarati</string>
       <string>ja_aaMatra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ja_iiMatra-gujarati_L</key>
@@ -7668,9 +7668,9 @@
     </array>
     <key>public.kern2.GUJ_k_ssa-gujarati_L</key>
     <array>
+      <string>k_ss_ma-gujarati</string>
       <string>k_ss_ra-gujarati</string>
       <string>k_ssa-gujarati</string>
-      <string>k_ss_ma-gujarati</string>
     </array>
     <key>public.kern2.GUJ_kh_ra-gujarati_L</key>
     <array>
@@ -7678,8 +7678,8 @@
     </array>
     <key>public.kern2.GUJ_kha-gujarati_L</key>
     <array>
-      <string>kha-gujarati</string>
       <string>kh-gujarati</string>
+      <string>kha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_lVocalic-gujarati_L</key>
     <array>
@@ -7692,15 +7692,15 @@
     </array>
     <key>public.kern2.GUJ_la-gujarati_L</key>
     <array>
-      <string>la-gujarati</string>
-      <string>l_tta-gujarati</string>
       <string>l_dda-gujarati</string>
+      <string>l_tta-gujarati</string>
       <string>l_ya-gujarati</string>
+      <string>la-gujarati</string>
     </array>
     <key>public.kern2.GUJ_m_ra-gujarati_L</key>
     <array>
-      <string>m_ra-gujarati</string>
       <string>m_na-gujarati</string>
+      <string>m_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ma-gujarati_L</key>
     <array>
@@ -7716,9 +7716,9 @@
     </array>
     <key>public.kern2.GUJ_na-gujarati_L</key>
     <array>
-      <string>na-gujarati</string>
-      <string>n_tha-gujarati</string>
       <string>n_sa-gujarati</string>
+      <string>n_tha-gujarati</string>
+      <string>na-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ng_gha-gujarati_L</key>
     <array>
@@ -7726,13 +7726,13 @@
     </array>
     <key>public.kern2.GUJ_nga-gujarati_L</key>
     <array>
-      <string>nga-gujarati</string>
-      <string>dda-gujarati</string>
-      <string>ng-gujarati</string>
       <string>dd-gujarati</string>
       <string>dd_ra-gujarati</string>
-      <string>ng_ya-gujarati</string>
       <string>dd_ya-gujarati</string>
+      <string>dda-gujarati</string>
+      <string>ng-gujarati</string>
+      <string>ng_ya-gujarati</string>
+      <string>nga-gujarati</string>
     </array>
     <key>public.kern2.GUJ_nn_ra-gujarati_L</key>
     <array>
@@ -7748,9 +7748,9 @@
     </array>
     <key>public.kern2.GUJ_nya-gujarati_L</key>
     <array>
-      <string>nya-gujarati</string>
       <string>ny_ca-gujarati</string>
       <string>ny_ja-gujarati</string>
+      <string>nya-gujarati</string>
     </array>
     <key>public.kern2.GUJ_p_na-gujarati_L</key>
     <array>
@@ -7776,14 +7776,14 @@
     </array>
     <key>public.kern2.GUJ_pa-gujarati_L</key>
     <array>
-      <string>pa-gujarati</string>
-      <string>ssa-gujarati</string>
       <string>p-gujarati</string>
-      <string>ss-gujarati</string>
       <string>p_ka-gujarati</string>
       <string>p_pha-gujarati</string>
-      <string>ss_ka-gujarati</string>
+      <string>pa-gujarati</string>
+      <string>ss-gujarati</string>
       <string>ss_dda-gujarati</string>
+      <string>ss_ka-gujarati</string>
+      <string>ssa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ph_ra-gujarati_L</key>
     <array>
@@ -7791,9 +7791,9 @@
     </array>
     <key>public.kern2.GUJ_pha-gujarati_L</key>
     <array>
-      <string>pha-gujarati</string>
       <string>ph_na-gujarati</string>
       <string>ph_pha-gujarati</string>
+      <string>pha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_rVocalic-gujarati_L</key>
     <array>
@@ -7804,55 +7804,55 @@
     <key>public.kern2.GUJ_ra-gujarati_L</key>
     <array>
       <string>ra-gujarati</string>
-      <string>sa-gujarati</string>
+      <string>ra_uMatra-gujarati</string>
       <string>s-gujarati</string>
-      <string>s_ra-gujarati</string>
       <string>s_k_ra-gujarati</string>
-      <string>s_t_ra-gujarati</string>
-      <string>s_tha-gujarati</string>
+      <string>s_ma-gujarati</string>
       <string>s_na-gujarati</string>
       <string>s_pha-gujarati</string>
-      <string>s_ma-gujarati</string>
+      <string>s_ra-gujarati</string>
+      <string>s_t_ra-gujarati</string>
+      <string>s_tha-gujarati</string>
       <string>s_ya-gujarati</string>
-      <string>ra_uMatra-gujarati</string>
+      <string>sa-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sh_ra-gujarati_L</key>
     <array>
-      <string>sh_ra-gujarati</string>
       <string>sh_ca-gujarati</string>
       <string>sh_na-gujarati</string>
       <string>sh_r_ya-gujarati</string>
+      <string>sh_ra-gujarati</string>
       <string>sh_va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_sha-gujarati_L</key>
     <array>
-      <string>sha-gujarati</string>
       <string>sh-gujarati</string>
+      <string>sha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ss_ra-gujarati_L</key>
     <array>
-      <string>ss_ra-gujarati</string>
       <string>ss_na-gujarati</string>
+      <string>ss_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_t_ta-gujarati_L</key>
     <array>
-      <string>t_ta-gujarati</string>
-      <string>t_t_ya-gujarati</string>
       <string>t_t_ra-gujarati</string>
+      <string>t_t_ya-gujarati</string>
+      <string>t_ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_ta-gujarati_L</key>
     <array>
-      <string>ta-gujarati</string>
       <string>t-gujarati</string>
-      <string>t_ka-gujarati</string>
       <string>t_k_ra-gujarati</string>
-      <string>t_na-gujarati</string>
+      <string>t_ka-gujarati</string>
       <string>t_ma-gujarati</string>
+      <string>t_na-gujarati</string>
+      <string>ta-gujarati</string>
     </array>
     <key>public.kern2.GUJ_th_ra-gujarati_L</key>
     <array>
-      <string>th_ra-gujarati</string>
       <string>th_na-gujarati</string>
+      <string>th_ra-gujarati</string>
     </array>
     <key>public.kern2.GUJ_tha-gujarati_L</key>
     <array>
@@ -7860,9 +7860,9 @@
     </array>
     <key>public.kern2.GUJ_ttha-gujarati_L</key>
     <array>
-      <string>ttha-gujarati</string>
       <string>tth-gujarati</string>
       <string>tth_ra-gujarati</string>
+      <string>ttha-gujarati</string>
     </array>
     <key>public.kern2.GUJ_u-gujarati_L</key>
     <array>
@@ -7875,8 +7875,8 @@
     </array>
     <key>public.kern2.GUJ_va-gujarati_L</key>
     <array>
-      <string>va-gujarati</string>
       <string>v-gujarati</string>
+      <string>va-gujarati</string>
     </array>
     <key>public.kern2.GUJ_y_ra-gujarati_L</key>
     <array>
@@ -7911,9 +7911,9 @@
     </array>
     <key>public.kern2.GUR_period_L</key>
     <array>
-      <string>period.loclGURM</string>
       <string>colon.loclGURM</string>
       <string>ellipsis.loclGURM</string>
+      <string>period.loclGURM</string>
     </array>
     <key>public.kern2.GUR_quoteright_L</key>
     <array>
@@ -7938,11 +7938,11 @@
     </array>
     <key>public.kern2.In-georgian</key>
     <array>
-      <string>Tan-georgian</string>
-      <string>In-georgian</string>
-      <string>On-georgian</string>
       <string>HardSign-georgian</string>
+      <string>In-georgian</string>
       <string>Labial-georgian</string>
+      <string>On-georgian</string>
+      <string>Tan-georgian</string>
     </array>
     <key>public.kern2.J</key>
     <array>
@@ -7973,9 +7973,9 @@
     </array>
     <key>public.kern2.KND_ca-kannada.below_R</key>
     <array>
-      <string>ca-kannada.below</string>
       <string>ba-kannada.below</string>
       <string>bha-kannada.below</string>
+      <string>ca-kannada.below</string>
     </array>
     <key>public.kern2.KND_cha-kannada.below_R</key>
     <array>
@@ -7983,15 +7983,15 @@
     </array>
     <key>public.kern2.KND_cha-kannada_R</key>
     <array>
+      <string>ch-kannada</string>
       <string>cha-kannada</string>
       <string>chaa-kannada</string>
+      <string>chau-kannada</string>
+      <string>che-kannada</string>
       <string>chi-kannada</string>
+      <string>cho-kannada</string>
       <string>chu-kannada</string>
       <string>chuu-kannada</string>
-      <string>che-kannada</string>
-      <string>cho-kannada</string>
-      <string>chau-kannada</string>
-      <string>ch-kannada</string>
     </array>
     <key>public.kern2.KND_comma.loclKNDA_R</key>
     <array>
@@ -7999,59 +7999,59 @@
     </array>
     <key>public.kern2.KND_dda-kannada.below_R</key>
     <array>
+      <string>da-kannada.below</string>
       <string>dda-kannada.below</string>
       <string>ddha-kannada.below</string>
-      <string>tha-kannada.below</string>
-      <string>da-kannada.below</string>
       <string>dha-kannada.below</string>
+      <string>tha-kannada.below</string>
     </array>
     <key>public.kern2.KND_dda-kannada_R</key>
     <array>
-      <string>dda-kannada</string>
-      <string>ddha-kannada</string>
-      <string>tha-kannada</string>
+      <string>d-kannada</string>
       <string>da-kannada</string>
-      <string>dha-kannada</string>
-      <string>ddaa-kannada</string>
-      <string>ddi-kannada</string>
-      <string>ddu-kannada</string>
-      <string>dduu-kannada</string>
-      <string>dde-kannada</string>
-      <string>ddo-kannada</string>
-      <string>ddau-kannada</string>
+      <string>daa-kannada</string>
+      <string>dau-kannada</string>
       <string>dd-kannada</string>
+      <string>dda-kannada</string>
+      <string>ddaa-kannada</string>
+      <string>ddau-kannada</string>
+      <string>dde-kannada</string>
+      <string>ddh-kannada</string>
+      <string>ddha-kannada</string>
       <string>ddhaa-kannada</string>
+      <string>ddhau-kannada</string>
+      <string>ddhe-kannada</string>
       <string>ddhi-kannada</string>
+      <string>ddho-kannada</string>
       <string>ddhu-kannada</string>
       <string>ddhuu-kannada</string>
-      <string>ddhe-kannada</string>
-      <string>ddho-kannada</string>
-      <string>ddhau-kannada</string>
-      <string>ddh-kannada</string>
-      <string>thaa-kannada</string>
-      <string>thi-kannada</string>
-      <string>thu-kannada</string>
-      <string>thuu-kannada</string>
-      <string>the-kannada</string>
-      <string>tho-kannada</string>
-      <string>thau-kannada</string>
-      <string>th-kannada</string>
-      <string>daa-kannada</string>
-      <string>di-kannada</string>
-      <string>du-kannada</string>
-      <string>duu-kannada</string>
+      <string>ddi-kannada</string>
+      <string>ddo-kannada</string>
+      <string>ddu-kannada</string>
+      <string>dduu-kannada</string>
       <string>de-kannada</string>
-      <string>do-kannada</string>
-      <string>dau-kannada</string>
-      <string>d-kannada</string>
+      <string>dh-kannada</string>
+      <string>dha-kannada</string>
       <string>dhaa-kannada</string>
+      <string>dhau-kannada</string>
+      <string>dhe-kannada</string>
       <string>dhi-kannada</string>
+      <string>dho-kannada</string>
       <string>dhu-kannada</string>
       <string>dhuu-kannada</string>
-      <string>dhe-kannada</string>
-      <string>dho-kannada</string>
-      <string>dhau-kannada</string>
-      <string>dh-kannada</string>
+      <string>di-kannada</string>
+      <string>do-kannada</string>
+      <string>du-kannada</string>
+      <string>duu-kannada</string>
+      <string>th-kannada</string>
+      <string>tha-kannada</string>
+      <string>thaa-kannada</string>
+      <string>thau-kannada</string>
+      <string>the-kannada</string>
+      <string>thi-kannada</string>
+      <string>tho-kannada</string>
+      <string>thu-kannada</string>
+      <string>thuu-kannada</string>
     </array>
     <key>public.kern2.KND_e-kannada_R</key>
     <array>
@@ -8064,15 +8064,15 @@
     </array>
     <key>public.kern2.KND_ga-kannada_R</key>
     <array>
+      <string>g-kannada</string>
       <string>ga-kannada</string>
       <string>gaa-kannada</string>
+      <string>gau-kannada</string>
+      <string>ge-kannada</string>
       <string>gi-kannada</string>
+      <string>go-kannada</string>
       <string>gu-kannada</string>
       <string>guu-kannada</string>
-      <string>ge-kannada</string>
-      <string>go-kannada</string>
-      <string>gau-kannada</string>
-      <string>g-kannada</string>
     </array>
     <key>public.kern2.KND_gha-kannada.below_R</key>
     <array>
@@ -8081,58 +8081,58 @@
     </array>
     <key>public.kern2.KND_gha-kannada_R</key>
     <array>
+      <string>gh-kannada</string>
       <string>gha-kannada</string>
-      <string>pa-kannada</string>
-      <string>pha-kannada</string>
-      <string>ma-kannada</string>
-      <string>va-kannada</string>
-      <string>ssa-kannada</string>
-      <string>ssa-kannada.short</string>
       <string>ghaa-kannada</string>
+      <string>ghau-kannada</string>
+      <string>ghe-kannada</string>
       <string>ghi-kannada</string>
+      <string>gho-kannada</string>
       <string>ghu-kannada</string>
       <string>ghuu-kannada</string>
-      <string>ghe-kannada</string>
-      <string>gho-kannada</string>
-      <string>ghau-kannada</string>
-      <string>gh-kannada</string>
-      <string>paa-kannada</string>
-      <string>pu-kannada</string>
-      <string>puu-kannada</string>
-      <string>pe-kannada</string>
-      <string>po-kannada</string>
-      <string>pau-kannada</string>
-      <string>p-kannada</string>
-      <string>phaa-kannada</string>
-      <string>phu-kannada</string>
-      <string>phuu-kannada</string>
-      <string>phe-kannada</string>
-      <string>pho-kannada</string>
-      <string>phau-kannada</string>
-      <string>ph-kannada</string>
+      <string>m-kannada</string>
+      <string>ma-kannada</string>
       <string>maa-kannada</string>
-      <string>mu-kannada</string>
-      <string>muu-kannada</string>
+      <string>mau-kannada</string>
       <string>me-kannada</string>
       <string>mo-kannada</string>
-      <string>mau-kannada</string>
-      <string>m-kannada</string>
-      <string>vaa-kannada</string>
-      <string>vu-kannada</string>
-      <string>vuu-kannada</string>
-      <string>ve-kannada</string>
-      <string>vo-kannada</string>
-      <string>vau-kannada</string>
-      <string>v-kannada</string>
+      <string>mu-kannada</string>
+      <string>muu-kannada</string>
+      <string>p-kannada</string>
+      <string>pa-kannada</string>
+      <string>paa-kannada</string>
+      <string>pau-kannada</string>
+      <string>pe-kannada</string>
+      <string>ph-kannada</string>
+      <string>pha-kannada</string>
+      <string>phaa-kannada</string>
+      <string>phau-kannada</string>
+      <string>phe-kannada</string>
+      <string>pho-kannada</string>
+      <string>phu-kannada</string>
+      <string>phuu-kannada</string>
+      <string>po-kannada</string>
+      <string>pu-kannada</string>
+      <string>puu-kannada</string>
+      <string>ss-kannada</string>
+      <string>ss-kannada.short</string>
+      <string>ssa-kannada</string>
+      <string>ssa-kannada.short</string>
       <string>ssaa-kannada</string>
+      <string>ssau-kannada</string>
+      <string>sse-kannada</string>
+      <string>sse-kannada.short</string>
+      <string>sso-kannada</string>
       <string>ssu-kannada</string>
       <string>ssuu-kannada</string>
-      <string>sse-kannada</string>
-      <string>sso-kannada</string>
-      <string>ssau-kannada</string>
-      <string>ss-kannada</string>
-      <string>sse-kannada.short</string>
-      <string>ss-kannada.short</string>
+      <string>v-kannada</string>
+      <string>va-kannada</string>
+      <string>vaa-kannada</string>
+      <string>vau-kannada</string>
+      <string>ve-kannada</string>
+      <string>vo-kannada</string>
+      <string>vu-kannada</string>
+      <string>vuu-kannada</string>
     </array>
     <key>public.kern2.KND_ha-kannada.below_R</key>
     <array>
@@ -8140,14 +8140,14 @@
     </array>
     <key>public.kern2.KND_ha-kannada_R</key>
     <array>
+      <string>h-kannada</string>
       <string>ha-kannada</string>
       <string>haa-kannada</string>
-      <string>hu-kannada</string>
-      <string>huu-kannada</string>
+      <string>hau-kannada</string>
       <string>he-kannada</string>
       <string>ho-kannada</string>
-      <string>hau-kannada</string>
-      <string>h-kannada</string>
+      <string>hu-kannada</string>
+      <string>huu-kannada</string>
     </array>
     <key>public.kern2.KND_hi-kannada_R</key>
     <array>
@@ -8158,15 +8158,15 @@
       <string>i-kannada</string>
       <string>lVocalic-kannada</string>
       <string>llVocalic-kannada</string>
+      <string>ny-kannada</string>
       <string>nya-kannada</string>
       <string>nyaa-kannada</string>
+      <string>nyau-kannada</string>
+      <string>nye-kannada</string>
       <string>nyi-kannada</string>
+      <string>nyo-kannada</string>
       <string>nyu-kannada</string>
       <string>nyuu-kannada</string>
-      <string>nye-kannada</string>
-      <string>nyo-kannada</string>
-      <string>nyau-kannada</string>
-      <string>ny-kannada</string>
     </array>
     <key>public.kern2.KND_ii-kannada_R</key>
     <array>
@@ -8178,43 +8178,43 @@
     </array>
     <key>public.kern2.KND_jha-kannada_R</key>
     <array>
+      <string>jh-kannada</string>
       <string>jha-kannada</string>
-      <string>ttha-kannada</string>
-      <string>ra-kannada</string>
       <string>jhaa-kannada</string>
+      <string>jhau-kannada</string>
+      <string>jhe-kannada</string>
       <string>jhi-kannada</string>
+      <string>jho-kannada</string>
       <string>jhu-kannada</string>
       <string>jhuu-kannada</string>
-      <string>jhe-kannada</string>
-      <string>jho-kannada</string>
-      <string>jhau-kannada</string>
-      <string>jh-kannada</string>
-      <string>tthaa-kannada</string>
-      <string>tthi-kannada</string>
-      <string>tthu-kannada</string>
-      <string>tthuu-kannada</string>
-      <string>tthe-kannada</string>
-      <string>ttho-kannada</string>
-      <string>tthau-kannada</string>
-      <string>tth-kannada</string>
+      <string>r-kannada</string>
+      <string>ra-kannada</string>
       <string>raa-kannada</string>
+      <string>rau-kannada</string>
+      <string>re-kannada</string>
       <string>ri-kannada</string>
+      <string>ro-kannada</string>
       <string>ru-kannada</string>
       <string>ruu-kannada</string>
-      <string>re-kannada</string>
-      <string>ro-kannada</string>
-      <string>rau-kannada</string>
-      <string>r-kannada</string>
+      <string>tth-kannada</string>
+      <string>ttha-kannada</string>
+      <string>tthaa-kannada</string>
+      <string>tthau-kannada</string>
+      <string>tthe-kannada</string>
+      <string>tthi-kannada</string>
+      <string>ttho-kannada</string>
+      <string>tthu-kannada</string>
+      <string>tthuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssa-kannada_R</key>
     <array>
       <string>k_ssa-kannada</string>
       <string>k_ssaa-kannada</string>
-      <string>k_ssu-kannada</string>
-      <string>k_ssuu-kannada</string>
+      <string>k_ssau-kannada</string>
       <string>k_sse-kannada</string>
       <string>k_sso-kannada</string>
-      <string>k_ssau-kannada</string>
+      <string>k_ssu-kannada</string>
+      <string>k_ssuu-kannada</string>
     </array>
     <key>public.kern2.KND_k_ssi-kannada_R</key>
     <array>
@@ -8226,14 +8226,14 @@
     </array>
     <key>public.kern2.KND_ka-kannada_R</key>
     <array>
+      <string>k-kannada</string>
       <string>ka-kannada</string>
       <string>kaa-kannada</string>
-      <string>ku-kannada</string>
-      <string>kuu-kannada</string>
+      <string>kau-kannada</string>
       <string>ke-kannada</string>
       <string>ko-kannada</string>
-      <string>kau-kannada</string>
-      <string>k-kannada</string>
+      <string>ku-kannada</string>
+      <string>kuu-kannada</string>
     </array>
     <key>public.kern2.KND_kha-kannada.below_R</key>
     <array>
@@ -8241,15 +8241,15 @@
     </array>
     <key>public.kern2.KND_kha-kannada_R</key>
     <array>
+      <string>kh-kannada</string>
       <string>kha-kannada</string>
       <string>khaa-kannada</string>
+      <string>khau-kannada</string>
+      <string>khe-kannada</string>
       <string>khi-kannada</string>
+      <string>kho-kannada</string>
       <string>khu-kannada</string>
       <string>khuu-kannada</string>
-      <string>khe-kannada</string>
-      <string>kho-kannada</string>
-      <string>khau-kannada</string>
-      <string>kh-kannada</string>
     </array>
     <key>public.kern2.KND_ki-kannada_R</key>
     <array>
@@ -8261,15 +8261,15 @@
     </array>
     <key>public.kern2.KND_la-kannada_R</key>
     <array>
+      <string>l-kannada</string>
       <string>la-kannada</string>
       <string>laa-kannada</string>
+      <string>lau-kannada</string>
+      <string>le-kannada</string>
       <string>li-kannada</string>
+      <string>lo-kannada</string>
       <string>lu-kannada</string>
       <string>luu-kannada</string>
-      <string>le-kannada</string>
-      <string>lo-kannada</string>
-      <string>lau-kannada</string>
-      <string>l-kannada</string>
     </array>
     <key>public.kern2.KND_length-kannada_R</key>
     <array>
@@ -8281,15 +8281,15 @@
     </array>
     <key>public.kern2.KND_lla-kannada_R</key>
     <array>
+      <string>ll-kannada</string>
       <string>lla-kannada</string>
       <string>llaa-kannada</string>
+      <string>llau-kannada</string>
+      <string>lle-kannada</string>
       <string>lli-kannada</string>
+      <string>llo-kannada</string>
       <string>llu-kannada</string>
       <string>lluu-kannada</string>
-      <string>lle-kannada</string>
-      <string>llo-kannada</string>
-      <string>llau-kannada</string>
-      <string>ll-kannada</string>
     </array>
     <key>public.kern2.KND_ma-kannada.below_R</key>
     <array>
@@ -8301,27 +8301,27 @@
     </array>
     <key>public.kern2.KND_na-kannada_R</key>
     <array>
+      <string>n-kannada</string>
       <string>na-kannada</string>
-      <string>sa-kannada</string>
       <string>naa-kannada</string>
-      <string>nu-kannada</string>
-      <string>nuu-kannada</string>
+      <string>nau-kannada</string>
       <string>ne-kannada</string>
       <string>no-kannada</string>
-      <string>nau-kannada</string>
-      <string>n-kannada</string>
+      <string>nu-kannada</string>
+      <string>nuu-kannada</string>
+      <string>s-kannada</string>
+      <string>sa-kannada</string>
       <string>saa-kannada</string>
-      <string>su-kannada</string>
-      <string>suu-kannada</string>
+      <string>sau-kannada</string>
       <string>se-kannada</string>
       <string>so-kannada</string>
-      <string>sau-kannada</string>
-      <string>s-kannada</string>
+      <string>su-kannada</string>
+      <string>suu-kannada</string>
     </array>
     <key>public.kern2.KND_nga-kannada.below_R</key>
     <array>
-      <string>nga-kannada.below</string>
       <string>ja-kannada.below</string>
+      <string>nga-kannada.below</string>
     </array>
     <key>public.kern2.KND_ni-kannada_R</key>
     <array>
@@ -8340,11 +8340,11 @@
     </array>
     <key>public.kern2.KND_nnaa-kannada_R</key>
     <array>
+      <string>nn-kannada</string>
       <string>nnaa-kannada</string>
+      <string>nnau-kannada</string>
       <string>nne-kannada</string>
       <string>nno-kannada</string>
-      <string>nnau-kannada</string>
-      <string>nn-kannada</string>
     </array>
     <key>public.kern2.KND_nya-kannada.below_R</key>
     <array>
@@ -8352,54 +8352,54 @@
     </array>
     <key>public.kern2.KND_o-kannada_R</key>
     <array>
-      <string>o-kannada</string>
-      <string>oo-kannada</string>
       <string>au-kannada</string>
-      <string>nga-kannada</string>
-      <string>ca-kannada</string>
-      <string>ja-kannada</string>
-      <string>ba-kannada</string>
-      <string>bha-kannada</string>
-      <string>ngaa-kannada</string>
-      <string>ngi-kannada</string>
-      <string>ngu-kannada</string>
-      <string>nguu-kannada</string>
-      <string>nge-kannada</string>
-      <string>ngo-kannada</string>
-      <string>ngau-kannada</string>
-      <string>ng-kannada</string>
-      <string>caa-kannada</string>
-      <string>ci-kannada</string>
-      <string>cu-kannada</string>
-      <string>cuu-kannada</string>
-      <string>ce-kannada</string>
-      <string>co-kannada</string>
-      <string>cau-kannada</string>
-      <string>c-kannada</string>
-      <string>jaa-kannada</string>
-      <string>ji-kannada</string>
-      <string>ju-kannada</string>
-      <string>juu-kannada</string>
-      <string>je-kannada</string>
-      <string>jo-kannada</string>
-      <string>jau-kannada</string>
-      <string>j-kannada</string>
-      <string>baa-kannada</string>
-      <string>bi-kannada</string>
-      <string>bu-kannada</string>
-      <string>buu-kannada</string>
-      <string>be-kannada</string>
-      <string>bo-kannada</string>
-      <string>bau-kannada</string>
       <string>b-kannada</string>
+      <string>ba-kannada</string>
+      <string>baa-kannada</string>
+      <string>bau-kannada</string>
+      <string>be-kannada</string>
+      <string>bh-kannada</string>
+      <string>bha-kannada</string>
       <string>bhaa-kannada</string>
+      <string>bhau-kannada</string>
+      <string>bhe-kannada</string>
       <string>bhi-kannada</string>
+      <string>bho-kannada</string>
       <string>bhu-kannada</string>
       <string>bhuu-kannada</string>
-      <string>bhe-kannada</string>
-      <string>bho-kannada</string>
-      <string>bhau-kannada</string>
-      <string>bh-kannada</string>
+      <string>bi-kannada</string>
+      <string>bo-kannada</string>
+      <string>bu-kannada</string>
+      <string>buu-kannada</string>
+      <string>c-kannada</string>
+      <string>ca-kannada</string>
+      <string>caa-kannada</string>
+      <string>cau-kannada</string>
+      <string>ce-kannada</string>
+      <string>ci-kannada</string>
+      <string>co-kannada</string>
+      <string>cu-kannada</string>
+      <string>cuu-kannada</string>
+      <string>j-kannada</string>
+      <string>ja-kannada</string>
+      <string>jaa-kannada</string>
+      <string>jau-kannada</string>
+      <string>je-kannada</string>
+      <string>ji-kannada</string>
+      <string>jo-kannada</string>
+      <string>ju-kannada</string>
+      <string>juu-kannada</string>
+      <string>ng-kannada</string>
+      <string>nga-kannada</string>
+      <string>ngaa-kannada</string>
+      <string>ngau-kannada</string>
+      <string>nge-kannada</string>
+      <string>ngi-kannada</string>
+      <string>ngo-kannada</string>
+      <string>ngu-kannada</string>
+      <string>nguu-kannada</string>
+      <string>o-kannada</string>
+      <string>oo-kannada</string>
     </array>
     <key>public.kern2.KND_pa-kannada.below_R</key>
     <array>
@@ -8412,13 +8412,13 @@
     </array>
     <key>public.kern2.KND_period.loclKNDA_R</key>
     <array>
-      <string>period.loclKNDA</string>
       <string>ellipsis.loclKNDA</string>
+      <string>period.loclKNDA</string>
     </array>
     <key>public.kern2.KND_pi-kannada_R</key>
     <array>
-      <string>pi-kannada</string>
       <string>phi-kannada</string>
+      <string>pi-kannada</string>
       <string>ssi-kannada</string>
       <string>ssi-kannada.short</string>
     </array>
@@ -8438,9 +8438,9 @@
     </array>
     <key>public.kern2.KND_rVocalicMatra-kannada_R</key>
     <array>
+      <string>ailength-kannada</string>
       <string>rVocalicMatra-kannada</string>
       <string>rrVocalicMatra-kannada</string>
-      <string>ailength-kannada</string>
     </array>
     <key>public.kern2.KND_ra-kannada.below_R</key>
     <array>
@@ -8448,29 +8448,29 @@
     </array>
     <key>public.kern2.KND_rra-kannada.below_R</key>
     <array>
-      <string>rra-kannada.below</string>
       <string>fa-kannada.below</string>
+      <string>rra-kannada.below</string>
     </array>
     <key>public.kern2.KND_rra-kannada_R</key>
     <array>
-      <string>rra-kannada</string>
+      <string>lll-kannada</string>
       <string>llla-kannada</string>
-      <string>rraa-kannada</string>
-      <string>rri-kannada</string>
-      <string>rru-kannada</string>
-      <string>rruu-kannada</string>
-      <string>rre-kannada</string>
-      <string>rro-kannada</string>
-      <string>rrau-kannada</string>
-      <string>rr-kannada</string>
       <string>lllaa-kannada</string>
+      <string>lllau-kannada</string>
+      <string>llle-kannada</string>
       <string>llli-kannada</string>
+      <string>lllo-kannada</string>
       <string>lllu-kannada</string>
       <string>llluu-kannada</string>
-      <string>llle-kannada</string>
-      <string>lllo-kannada</string>
-      <string>lllau-kannada</string>
-      <string>lll-kannada</string>
+      <string>rr-kannada</string>
+      <string>rra-kannada</string>
+      <string>rraa-kannada</string>
+      <string>rrau-kannada</string>
+      <string>rre-kannada</string>
+      <string>rri-kannada</string>
+      <string>rro-kannada</string>
+      <string>rru-kannada</string>
+      <string>rruu-kannada</string>
     </array>
     <key>public.kern2.KND_sa-kannada.below_R</key>
     <array>
@@ -8486,14 +8486,14 @@
     </array>
     <key>public.kern2.KND_sha-kannada_R</key>
     <array>
+      <string>sh-kannada</string>
       <string>sha-kannada</string>
       <string>shaa-kannada</string>
-      <string>shu-kannada</string>
-      <string>shuu-kannada</string>
+      <string>shau-kannada</string>
       <string>she-kannada</string>
       <string>sho-kannada</string>
-      <string>shau-kannada</string>
-      <string>sh-kannada</string>
+      <string>shu-kannada</string>
+      <string>shuu-kannada</string>
     </array>
     <key>public.kern2.KND_shi-kannada_R</key>
     <array>
@@ -8509,15 +8509,15 @@
     </array>
     <key>public.kern2.KND_ta-kannada_R</key>
     <array>
+      <string>t-kannada</string>
       <string>ta-kannada</string>
       <string>taa-kannada</string>
+      <string>tau-kannada</string>
+      <string>te-kannada</string>
       <string>ti-kannada</string>
+      <string>to-kannada</string>
       <string>tu-kannada</string>
       <string>tuu-kannada</string>
-      <string>te-kannada</string>
-      <string>to-kannada</string>
-      <string>tau-kannada</string>
-      <string>t-kannada</string>
     </array>
     <key>public.kern2.KND_tta-kannada.below_R</key>
     <array>
@@ -8525,15 +8525,15 @@
     </array>
     <key>public.kern2.KND_tta-kannada_R</key>
     <array>
+      <string>tt-kannada</string>
       <string>tta-kannada</string>
       <string>ttaa-kannada</string>
+      <string>ttau-kannada</string>
+      <string>tte-kannada</string>
       <string>tti-kannada</string>
+      <string>tto-kannada</string>
       <string>ttu-kannada</string>
       <string>ttuu-kannada</string>
-      <string>tte-kannada</string>
-      <string>tto-kannada</string>
-      <string>ttau-kannada</string>
-      <string>tt-kannada</string>
     </array>
     <key>public.kern2.KND_ttha-kannada.below_R</key>
     <array>
@@ -8558,72 +8558,72 @@
     </array>
     <key>public.kern2.KND_ya-kannada_R</key>
     <array>
+      <string>y-kannada</string>
       <string>ya-kannada</string>
       <string>yaa-kannada</string>
+      <string>yau-kannada</string>
+      <string>ye-kannada</string>
       <string>yi-kannada</string>
+      <string>yo-kannada</string>
       <string>yu-kannada</string>
       <string>yuu-kannada</string>
-      <string>ye-kannada</string>
-      <string>yo-kannada</string>
-      <string>yau-kannada</string>
-      <string>y-kannada</string>
     </array>
     <key>public.kern2.Las-georgian</key>
     <array>
       <string>Don-georgian</string>
-      <string>Las-georgian</string>
       <string>Ghan-georgian</string>
+      <string>Las-georgian</string>
     </array>
     <key>public.kern2.MAL_a-malayalam_L</key>
     <array>
       <string>a-malayalam</string>
       <string>aa-malayalam</string>
-      <string>lVocalic-malayalam</string>
       <string>ai-malayalam</string>
-      <string>kha-malayalam</string>
-      <string>nga-malayalam</string>
-      <string>nya-malayalam</string>
-      <string>nna-malayalam</string>
-      <string>nnna-malayalam</string>
-      <string>ba-malayalam</string>
-      <string>bha-malayalam</string>
-      <string>rra-malayalam</string>
-      <string>va-malayalam</string>
-      <string>eMatra-malayalam</string>
       <string>aiMatra-malayalam</string>
-      <string>oMatra-malayalam</string>
       <string>auMatra-malayalam</string>
-      <string>threeeights-malayalam</string>
-      <string>llVocalic-malayalam</string>
-      <string>two-malayalam</string>
-      <string>eight-malayalam</string>
-      <string>onehalf-malayalam</string>
-      <string>threequarters-malayalam</string>
-      <string>nnChillu-malayalam</string>
-      <string>kha-malayalam.half</string>
-      <string>nga-malayalam.half</string>
-      <string>nya-malayalam.half</string>
-      <string>nna-malayalam.half</string>
+      <string>b_ba-malayalam</string>
+      <string>b_da-malayalam</string>
+      <string>b_dha-malayalam</string>
+      <string>b_la-malayalam</string>
+      <string>ba-malayalam</string>
       <string>ba-malayalam.half</string>
+      <string>bha-malayalam</string>
       <string>bha-malayalam.half</string>
-      <string>rra-malayalam.half</string>
-      <string>va-malayalam.half</string>
+      <string>eMatra-malayalam</string>
+      <string>eight-malayalam</string>
+      <string>kha-malayalam</string>
+      <string>kha-malayalam.half</string>
+      <string>lVocalic-malayalam</string>
+      <string>llVocalic-malayalam</string>
       <string>ng_k_la-malayalam</string>
-      <string>ny_ca-malayalam</string>
-      <string>ny_cha-malayalam</string>
-      <string>ny_ja-malayalam</string>
-      <string>ny_nya-malayalam</string>
+      <string>nga-malayalam</string>
+      <string>nga-malayalam.half</string>
+      <string>nnChillu-malayalam</string>
       <string>nn_dda-malayalam</string>
       <string>nn_ddha-malayalam</string>
       <string>nn_ma-malayalam</string>
       <string>nn_nna-malayalam</string>
       <string>nn_tta-malayalam</string>
-      <string>b_ba-malayalam</string>
-      <string>b_da-malayalam</string>
-      <string>b_dha-malayalam</string>
-      <string>b_la-malayalam</string>
+      <string>nna-malayalam</string>
+      <string>nna-malayalam.half</string>
+      <string>nnna-malayalam</string>
+      <string>ny_ca-malayalam</string>
+      <string>ny_cha-malayalam</string>
+      <string>ny_ja-malayalam</string>
+      <string>ny_nya-malayalam</string>
+      <string>nya-malayalam</string>
+      <string>nya-malayalam.half</string>
+      <string>oMatra-malayalam</string>
+      <string>onehalf-malayalam</string>
+      <string>rra-malayalam</string>
+      <string>rra-malayalam.half</string>
+      <string>threeeights-malayalam</string>
+      <string>threequarters-malayalam</string>
+      <string>two-malayalam</string>
       <string>v_la-malayalam</string>
       <string>v_va-malayalam</string>
+      <string>va-malayalam</string>
+      <string>va-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_asterisk.loclMALM_R</key>
     <array>
@@ -8652,11 +8652,11 @@
     </array>
     <key>public.kern2.MAL_ca-malayalam_L</key>
     <array>
-      <string>ca-malayalam</string>
-      <string>cha-malayalam</string>
-      <string>ca-malayalam.half</string>
-      <string>cha-malayalam.half</string>
       <string>c_ca-malayalam</string>
+      <string>ca-malayalam</string>
+      <string>ca-malayalam.half</string>
+      <string>cha-malayalam</string>
+      <string>cha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_comma.loclMALM_R</key>
     <array>
@@ -8664,13 +8664,13 @@
     </array>
     <key>public.kern2.MAL_da-malayalam_L</key>
     <array>
-      <string>ra-malayalam</string>
-      <string>onefortieth-malayalam</string>
-      <string>onefifth-malayalam</string>
       <string>four-malayalam</string>
-      <string>rrChillu-malayalam</string>
       <string>lChillu-malayalam</string>
+      <string>onefifth-malayalam</string>
+      <string>onefortieth-malayalam</string>
+      <string>ra-malayalam</string>
       <string>ra-malayalam.half</string>
+      <string>rrChillu-malayalam</string>
     </array>
     <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8679,58 +8679,58 @@
     </array>
     <key>public.kern2.MAL_dda-malayalam_L</key>
     <array>
-      <string>dda-malayalam</string>
-      <string>ddha-malayalam</string>
-      <string>na-malayalam</string>
-      <string>sa-malayalam</string>
-      <string>onetenth-malayalam</string>
-      <string>three-malayalam</string>
-      <string>six-malayalam</string>
-      <string>nine-malayalam</string>
-      <string>onehundred-malayalam</string>
-      <string>onethousand-malayalam</string>
       <string>datemark-malayalam</string>
-      <string>nChillu-malayalam</string>
-      <string>dda-malayalam.half</string>
-      <string>ddha-malayalam.half</string>
-      <string>na-malayalam.half</string>
-      <string>sa-malayalam.half</string>
       <string>dd_dda-malayalam</string>
       <string>dd_ddha-malayalam</string>
+      <string>dda-malayalam</string>
+      <string>dda-malayalam.half</string>
+      <string>ddha-malayalam</string>
+      <string>ddha-malayalam.half</string>
+      <string>m_p_la-malayalam</string>
+      <string>m_pa-malayalam</string>
+      <string>nChillu-malayalam</string>
       <string>n_da-malayalam</string>
       <string>n_dha-malayalam</string>
-      <string>n_na-malayalam</string>
       <string>n_ma-malayalam</string>
+      <string>n_na-malayalam</string>
       <string>n_rra-malayalam</string>
       <string>n_ta-malayalam</string>
       <string>n_tha-malayalam</string>
-      <string>m_pa-malayalam</string>
-      <string>m_p_la-malayalam</string>
+      <string>na-malayalam</string>
+      <string>na-malayalam.half</string>
+      <string>nine-malayalam</string>
+      <string>onehundred-malayalam</string>
+      <string>onetenth-malayalam</string>
+      <string>onethousand-malayalam</string>
+      <string>s_la-malayalam</string>
+      <string>s_rr_rra-malayalam</string>
       <string>s_sa-malayalam</string>
       <string>s_tha-malayalam</string>
-      <string>s_rr_rra-malayalam</string>
-      <string>s_la-malayalam</string>
+      <string>sa-malayalam</string>
+      <string>sa-malayalam.half</string>
+      <string>six-malayalam</string>
+      <string>three-malayalam</string>
     </array>
     <key>public.kern2.MAL_e-malayalam-L</key>
     <array>
       <string>e-malayalam</string>
       <string>ee-malayalam</string>
-      <string>pa-malayalam</string>
-      <string>pha-malayalam</string>
-      <string>ssa-malayalam</string>
-      <string>ha-malayalam</string>
-      <string>onesixteenth-malayalam</string>
-      <string>oneeighth-malayalam</string>
-      <string>pa-malayalam.half</string>
-      <string>pha-malayalam.half</string>
-      <string>ssa-malayalam.half</string>
-      <string>ha-malayalam.half</string>
-      <string>p_ta-malayalam</string>
-      <string>ph_la-malayalam</string>
-      <string>ss_tta-malayalam</string>
+      <string>h_la-malayalam</string>
       <string>h_ma-malayalam</string>
       <string>h_na-malayalam</string>
-      <string>h_la-malayalam</string>
+      <string>ha-malayalam</string>
+      <string>ha-malayalam.half</string>
+      <string>oneeighth-malayalam</string>
+      <string>onesixteenth-malayalam</string>
+      <string>p_ta-malayalam</string>
+      <string>pa-malayalam</string>
+      <string>pa-malayalam.half</string>
+      <string>ph_la-malayalam</string>
+      <string>pha-malayalam</string>
+      <string>pha-malayalam.half</string>
+      <string>ss_tta-malayalam</string>
+      <string>ssa-malayalam</string>
+      <string>ssa-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_eeMatra-malayalam_L</key>
     <array>
@@ -8747,22 +8747,22 @@
     </array>
     <key>public.kern2.MAL_ga-malayalam_L</key>
     <array>
-      <string>ga-malayalam</string>
       <string>dha-malayalam</string>
-      <string>sha-malayalam</string>
-      <string>onehundredsixtieth-malayalam</string>
-      <string>llChillu-malayalam</string>
-      <string>ga-malayalam.half</string>
       <string>dha-malayalam.half</string>
-      <string>sha-malayalam.half</string>
-      <string>g_ga-malayalam</string>
       <string>g_da-malayalam</string>
+      <string>g_ga-malayalam</string>
       <string>g_ma-malayalam</string>
       <string>g_na-malayalam</string>
+      <string>ga-malayalam</string>
+      <string>ga-malayalam.half</string>
+      <string>llChillu-malayalam</string>
+      <string>onehundredsixtieth-malayalam</string>
       <string>sh_ca-malayalam</string>
       <string>sh_cha-malayalam</string>
-      <string>sh_sha-malayalam</string>
       <string>sh_la-malayalam</string>
+      <string>sh_sha-malayalam</string>
+      <string>sha-malayalam</string>
+      <string>sha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_gha-malayalam_L</key>
     <array>
@@ -8778,10 +8778,10 @@
     </array>
     <key>public.kern2.MAL_ja-malayalam_L</key>
     <array>
-      <string>ja-malayalam</string>
-      <string>ja-malayalam.half</string>
       <string>j_ja-malayalam</string>
       <string>j_nya-malayalam</string>
+      <string>ja-malayalam</string>
+      <string>ja-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8790,33 +8790,33 @@
     </array>
     <key>public.kern2.MAL_jha-malayalam_L</key>
     <array>
-      <string>jha-malayalam</string>
-      <string>ta-malayalam</string>
+      <string>d_da-malayalam</string>
+      <string>d_dha-malayalam</string>
       <string>da-malayalam</string>
-      <string>jha-malayalam.half</string>
-      <string>ta-malayalam.half</string>
       <string>da-malayalam.half</string>
-      <string>t_na-malayalam</string>
+      <string>jha-malayalam</string>
+      <string>jha-malayalam.half</string>
       <string>t_bha-malayalam</string>
+      <string>t_la-malayalam</string>
       <string>t_ma-malayalam</string>
+      <string>t_na-malayalam</string>
       <string>t_sa-malayalam</string>
       <string>t_ta-malayalam</string>
       <string>t_tha-malayalam</string>
-      <string>t_la-malayalam</string>
-      <string>d_da-malayalam</string>
-      <string>d_dha-malayalam</string>
+      <string>ta-malayalam</string>
+      <string>ta-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ka-malayalam_L</key>
     <array>
-      <string>ka-malayalam</string>
       <string>kChillu-malayalam</string>
-      <string>ka-malayalam.half</string>
-      <string>k_ssa-malayalam.half</string>
       <string>k_ka-malayalam</string>
-      <string>k_ta-malayalam</string>
-      <string>k_tta-malayalam</string>
       <string>k_la-malayalam</string>
       <string>k_ssa-malayalam</string>
+      <string>k_ssa-malayalam.half</string>
+      <string>k_ta-malayalam</string>
+      <string>k_tta-malayalam</string>
+      <string>ka-malayalam</string>
+      <string>ka-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_l_la-malayalam_L</key>
     <array>
@@ -8828,9 +8828,9 @@
     </array>
     <key>public.kern2.MAL_lla-malayalam_L</key>
     <array>
+      <string>ll_lla-malayalam</string>
       <string>lla-malayalam</string>
       <string>lla-malayalam.half</string>
-      <string>ll_lla-malayalam</string>
     </array>
     <key>public.kern2.MAL_lllChillu-malayalam_L</key>
     <array>
@@ -8856,11 +8856,11 @@
     </array>
     <key>public.kern2.MAL_ma-malayalam_L</key>
     <array>
-      <string>ma-malayalam</string>
       <string>la-malayalam</string>
-      <string>ma-malayalam.half</string>
       <string>la-malayalam.half</string>
       <string>m_ma-malayalam</string>
+      <string>ma-malayalam</string>
+      <string>ma-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
     <array>
@@ -8873,10 +8873,10 @@
     </array>
     <key>public.kern2.MAL_o-malayalam_L</key>
     <array>
-      <string>o-malayalam</string>
-      <string>oo-malayalam</string>
       <string>au-malayalam</string>
       <string>ng_nga-malayalam</string>
+      <string>o-malayalam</string>
+      <string>oo-malayalam</string>
     </array>
     <key>public.kern2.MAL_one-malayalam_L</key>
     <array>
@@ -8909,8 +8909,8 @@
     </array>
     <key>public.kern2.MAL_period.loclMALM_R</key>
     <array>
-      <string>period.loclMALM</string>
       <string>ellipsis.loclMALM</string>
+      <string>period.loclMALM</string>
     </array>
     <key>public.kern2.MAL_question.loclMALM_R</key>
     <array>
@@ -8933,8 +8933,8 @@
     <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
     <array>
       <string>ra_lVocalicMatra-malayalam</string>
-      <string>rra_lVocalicMatra-malayalam</string>
       <string>ra_llVocalicMatra-malayalam</string>
+      <string>rra_lVocalicMatra-malayalam</string>
       <string>rra_llVocalicMatra-malayalam</string>
     </array>
     <key>public.kern2.MAL_rrVocalicMatra-malayalam_L</key>
@@ -8959,8 +8959,8 @@
     </array>
     <key>public.kern2.MAL_tha-malayalam_L</key>
     <array>
-      <string>tha-malayalam</string>
       <string>onetwentieth-malayalam</string>
+      <string>tha-malayalam</string>
       <string>tha-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_tt_tta-malayalam_L</key>
@@ -9001,10 +9001,10 @@
     </array>
     <key>public.kern2.MAL_ya-malayalam_L</key>
     <array>
-      <string>ya-malayalam</string>
       <string>yChillu-malayalam</string>
-      <string>ya-malayalam.half</string>
       <string>y_ya-malayalam</string>
+      <string>ya-malayalam</string>
+      <string>ya-malayalam.half</string>
     </array>
     <key>public.kern2.MAL_zero-malayalam_L</key>
     <array>
@@ -9012,10 +9012,10 @@
     </array>
     <key>public.kern2.Nar-georgian</key>
     <array>
+      <string>Elifi-georgian</string>
       <string>Nar-georgian</string>
       <string>San-georgian</string>
       <string>Xan-georgian</string>
-      <string>Elifi-georgian</string>
     </array>
     <key>public.kern2.O</key>
     <array>
@@ -9025,13 +9025,28 @@
       <string>Ccedilla</string>
       <string>Ccircumflex</string>
       <string>Cdotaccent</string>
+      <string>Cheabkhasian-cy</string>
+      <string>Chedescenderabkhasian-cy</string>
+      <string>E-cy</string>
+      <string>Edieresis-cy</string>
+      <string>Ef-cy.loclBGR</string>
+      <string>Es-cy</string>
+      <string>Esdescender-cy</string>
+      <string>Esdescender-cy.loclBSH</string>
+      <string>Esdescender-cy.loclCHU</string>
+      <string>Fita-cy</string>
       <string>G</string>
       <string>Gbreve</string>
       <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
       <string>Gdotaccent</string>
+      <string>Haabkhasian-cy</string>
       <string>O</string>
+      <string>O-cy</string>
+      <string>OE</string>
       <string>Oacute</string>
+      <string>Obarred-cy</string>
+      <string>Obarreddieresis-cy</string>
       <string>Obreve</string>
       <string>Ocircumflex</string>
       <string>Ocircumflexacute</string>
@@ -9040,6 +9055,7 @@
       <string>Ocircumflexhookabove</string>
       <string>Ocircumflextilde</string>
       <string>Odieresis</string>
+      <string>Odieresis-cy</string>
       <string>Odotbelow</string>
       <string>Ograve</string>
       <string>Ohookabove</string>
@@ -9054,25 +9070,9 @@
       <string>Oslash</string>
       <string>Oslashacute</string>
       <string>Otilde</string>
-      <string>OE</string>
       <string>Q</string>
-      <string>O-cy</string>
-      <string>Es-cy</string>
-      <string>E-cy</string>
-      <string>Fita-cy</string>
-      <string>Haabkhasian-cy</string>
-      <string>Esdescender-cy</string>
-      <string>Cheabkhasian-cy</string>
-      <string>Chedescenderabkhasian-cy</string>
-      <string>Schwadieresis-cy</string>
-      <string>Odieresis-cy</string>
-      <string>Obarred-cy</string>
-      <string>Obarreddieresis-cy</string>
-      <string>Edieresis-cy</string>
       <string>Qa-cy</string>
-      <string>Ef-cy.loclBGR</string>
-      <string>Esdescender-cy.loclBSH</string>
-      <string>Esdescender-cy.loclCHU</string>
+      <string>Schwadieresis-cy</string>
     </array>
     <key>public.kern2.ODI_a-oriya_R</key>
     <array>
@@ -9128,13 +9128,13 @@
     </array>
     <key>public.kern2.ODI_dha-oriya_R</key>
     <array>
-      <string>dha-oriya</string>
       <string>dh_ba-oriya</string>
+      <string>dha-oriya</string>
     </array>
     <key>public.kern2.ODI_e-oriya_R</key>
     <array>
-      <string>e-oriya</string>
       <string>ai-oriya</string>
+      <string>e-oriya</string>
     </array>
     <key>public.kern2.ODI_eMatra-oriya_R</key>
     <array>
@@ -9142,81 +9142,81 @@
     </array>
     <key>public.kern2.ODI_gha-oriya_R</key>
     <array>
-      <string>gha-oriya</string>
-      <string>la-oriya</string>
-      <string>lla-oriya</string>
       <string>gh_na-oriya</string>
-      <string>ng_gha-oriya</string>
-      <string>l_ka-oriya</string>
-      <string>l_ga-oriya</string>
+      <string>gha-oriya</string>
       <string>l_dda-oriya</string>
-      <string>l_pa-oriya</string>
-      <string>l_ma-oriya</string>
+      <string>l_ga-oriya</string>
+      <string>l_ka-oriya</string>
       <string>l_la-oriya</string>
+      <string>l_ma-oriya</string>
+      <string>l_pa-oriya</string>
+      <string>la-oriya</string>
+      <string>ll_bha-oriya</string>
       <string>ll_ka-oriya</string>
       <string>ll_pa-oriya</string>
       <string>ll_pha-oriya</string>
-      <string>ll_bha-oriya</string>
+      <string>lla-oriya</string>
+      <string>ng_gha-oriya</string>
     </array>
     <key>public.kern2.ODI_ha-oriya_R</key>
     <array>
-      <string>ha-oriya</string>
-      <string>h_nna-oriya</string>
-      <string>h_na-oriya</string>
       <string>h_ba-oriya</string>
       <string>h_la-oriya</string>
+      <string>h_na-oriya</string>
+      <string>h_nna-oriya</string>
+      <string>ha-oriya</string>
     </array>
     <key>public.kern2.ODI_i-oriya_R</key>
     <array>
-      <string>i-oriya</string>
-      <string>ii-oriya</string>
-      <string>u-oriya</string>
-      <string>uu-oriya</string>
-      <string>kha-oriya</string>
-      <string>ga-oriya</string>
-      <string>nga-oriya</string>
-      <string>ca-oriya</string>
-      <string>ja-oriya</string>
-      <string>tta-oriya</string>
-      <string>dda-oriya</string>
-      <string>ddha-oriya</string>
-      <string>ta-oriya</string>
-      <string>da-oriya</string>
-      <string>ba-oriya</string>
-      <string>bha-oriya</string>
-      <string>ra-oriya</string>
-      <string>va-oriya</string>
-      <string>rra-oriya</string>
-      <string>rha-oriya</string>
-      <string>g_da-oriya</string>
-      <string>g_dha-oriya</string>
-      <string>g_na-oriya</string>
-      <string>g_la-oriya</string>
-      <string>g_lla-oriya</string>
-      <string>ng_kha-oriya</string>
-      <string>ng_ga-oriya</string>
-      <string>ng_k_ssa-oriya</string>
-      <string>c_ca-oriya</string>
-      <string>c_cha-oriya</string>
-      <string>j_ja-oriya</string>
-      <string>j_jha-oriya</string>
-      <string>j_j_ba-oriya</string>
-      <string>tt_tta-oriya</string>
-      <string>dd_ga-oriya</string>
-      <string>dd_dda-oriya</string>
-      <string>t_ta-oriya</string>
-      <string>t_tha-oriya</string>
-      <string>t_t_ba-oriya</string>
-      <string>t_ba-oriya</string>
-      <string>d_ga-oriya</string>
-      <string>d_gha-oriya</string>
-      <string>d_ba-oriya</string>
-      <string>d_bha-oriya</string>
-      <string>d_ma-oriya</string>
-      <string>b_gha-oriya</string>
-      <string>b_ja-oriya</string>
       <string>b_da-oriya</string>
       <string>b_dha-oriya</string>
+      <string>b_gha-oriya</string>
+      <string>b_ja-oriya</string>
+      <string>ba-oriya</string>
+      <string>bha-oriya</string>
+      <string>c_ca-oriya</string>
+      <string>c_cha-oriya</string>
+      <string>ca-oriya</string>
+      <string>d_ba-oriya</string>
+      <string>d_bha-oriya</string>
+      <string>d_ga-oriya</string>
+      <string>d_gha-oriya</string>
+      <string>d_ma-oriya</string>
+      <string>da-oriya</string>
+      <string>dd_dda-oriya</string>
+      <string>dd_ga-oriya</string>
+      <string>dda-oriya</string>
+      <string>ddha-oriya</string>
+      <string>g_da-oriya</string>
+      <string>g_dha-oriya</string>
+      <string>g_la-oriya</string>
+      <string>g_lla-oriya</string>
+      <string>g_na-oriya</string>
+      <string>ga-oriya</string>
+      <string>i-oriya</string>
+      <string>ii-oriya</string>
+      <string>j_j_ba-oriya</string>
+      <string>j_ja-oriya</string>
+      <string>j_jha-oriya</string>
+      <string>ja-oriya</string>
+      <string>kha-oriya</string>
+      <string>ng_ga-oriya</string>
+      <string>ng_k_ssa-oriya</string>
+      <string>ng_kha-oriya</string>
+      <string>nga-oriya</string>
+      <string>ra-oriya</string>
+      <string>rha-oriya</string>
+      <string>rra-oriya</string>
+      <string>t_ba-oriya</string>
+      <string>t_t_ba-oriya</string>
+      <string>t_ta-oriya</string>
+      <string>t_tha-oriya</string>
+      <string>ta-oriya</string>
+      <string>tt_tta-oriya</string>
+      <string>tta-oriya</string>
+      <string>u-oriya</string>
+      <string>uu-oriya</string>
+      <string>va-oriya</string>
     </array>
     <key>public.kern2.ODI_iiMatra-oriya_R</key>
     <array>
@@ -9224,18 +9224,18 @@
     </array>
     <key>public.kern2.ODI_ka-oriya_R</key>
     <array>
-      <string>ka-oriya</string>
+      <string>k_ba-oriya</string>
       <string>k_ka-oriya</string>
+      <string>k_lla-oriya</string>
+      <string>k_sa-oriya</string>
+      <string>k_sha-oriya</string>
+      <string>k_ta-oriya</string>
       <string>k_tta-oriya</string>
       <string>k_ttha-oriya</string>
-      <string>k_ta-oriya</string>
-      <string>k_ba-oriya</string>
-      <string>k_lla-oriya</string>
-      <string>k_sha-oriya</string>
-      <string>k_sa-oriya</string>
-      <string>ng_ka-oriya</string>
-      <string>ng_k_ta-oriya</string>
+      <string>ka-oriya</string>
       <string>ng_k_t_ra-oriya</string>
+      <string>ng_k_ta-oriya</string>
+      <string>ng_ka-oriya</string>
       <string>t_ka-oriya</string>
     </array>
     <key>public.kern2.ODI_lVocalic-oriya_R</key>
@@ -9246,37 +9246,37 @@
     </array>
     <key>public.kern2.ODI_ma-oriya_R</key>
     <array>
-      <string>ma-oriya</string>
-      <string>t_ma-oriya</string>
-      <string>m_na-oriya</string>
-      <string>m_pa-oriya</string>
-      <string>m_pha-oriya</string>
       <string>m_ba-oriya</string>
       <string>m_bha-oriya</string>
       <string>m_ma-oriya</string>
+      <string>m_na-oriya</string>
+      <string>m_pa-oriya</string>
+      <string>m_pha-oriya</string>
+      <string>ma-oriya</string>
+      <string>t_ma-oriya</string>
     </array>
     <key>public.kern2.ODI_na-oriya_R</key>
     <array>
-      <string>na-oriya</string>
-      <string>t_na-oriya</string>
+      <string>n_ba-oriya</string>
+      <string>n_ma-oriya</string>
+      <string>n_na-oriya</string>
+      <string>n_sa-oriya</string>
+      <string>n_t_ba-oriya</string>
       <string>n_ta-oriya</string>
       <string>n_ta_ra-oriya</string>
       <string>n_tha-oriya</string>
-      <string>n_na-oriya</string>
-      <string>n_t_ba-oriya</string>
-      <string>n_ba-oriya</string>
-      <string>n_ma-oriya</string>
-      <string>n_sa-oriya</string>
+      <string>na-oriya</string>
+      <string>t_na-oriya</string>
     </array>
     <key>public.kern2.ODI_nna-oriya_R</key>
     <array>
-      <string>nna-oriya</string>
-      <string>nn_tta-oriya</string>
-      <string>nn_ttha-oriya</string>
+      <string>nn_ba-oriya</string>
       <string>nn_dda-oriya</string>
       <string>nn_ddha-oriya</string>
       <string>nn_nna-oriya</string>
-      <string>nn_ba-oriya</string>
+      <string>nn_tta-oriya</string>
+      <string>nn_ttha-oriya</string>
+      <string>nna-oriya</string>
     </array>
     <key>public.kern2.ODI_ny_ca-oriya_R</key>
     <array>
@@ -9286,14 +9286,14 @@
     </array>
     <key>public.kern2.ODI_nya-oriya_R</key>
     <array>
-      <string>nya-oriya</string>
       <string>j_nya-oriya</string>
       <string>ny_ja-oriya</string>
+      <string>nya-oriya</string>
     </array>
     <key>public.kern2.ODI_o-oriya_R</key>
     <array>
-      <string>o-oriya</string>
       <string>au-oriya</string>
+      <string>o-oriya</string>
     </array>
     <key>public.kern2.ODI_parenright_R</key>
     <array>
@@ -9301,8 +9301,8 @@
     </array>
     <key>public.kern2.ODI_period_R</key>
     <array>
-      <string>period.loclODIA</string>
       <string>ellipsis.loclODIA</string>
+      <string>period.loclODIA</string>
     </array>
     <key>public.kern2.ODI_question_R</key>
     <array>
@@ -9315,9 +9315,9 @@
     </array>
     <key>public.kern2.ODI_rVocalic-oriya_R</key>
     <array>
+      <string>jha-oriya</string>
       <string>rVocalic-oriya</string>
       <string>rrVocalic-oriya</string>
-      <string>jha-oriya</string>
     </array>
     <key>public.kern2.ODI_s_t_ra-oriya_R</key>
     <array>
@@ -9329,17 +9329,17 @@
     </array>
     <key>public.kern2.ODI_sa-oriya_R</key>
     <array>
-      <string>sa-oriya</string>
+      <string>s_ba-oriya</string>
       <string>s_ka-oriya</string>
       <string>s_kha-oriya</string>
-      <string>s_tta-oriya</string>
-      <string>s_ta-oriya</string>
+      <string>s_ma-oriya</string>
       <string>s_na-oriya</string>
       <string>s_pa-oriya</string>
       <string>s_pha-oriya</string>
-      <string>s_ba-oriya</string>
-      <string>s_ma-oriya</string>
       <string>s_sa-oriya</string>
+      <string>s_ta-oriya</string>
+      <string>s_tta-oriya</string>
+      <string>sa-oriya</string>
     </array>
     <key>public.kern2.ODI_t_s_na-oriya_R</key>
     <array>
@@ -9360,15 +9360,15 @@
     </array>
     <key>public.kern2.ODI_ya-oriya_R</key>
     <array>
-      <string>ya-oriya</string>
-      <string>yya-oriya</string>
-      <string>k_ss_na-oriya</string>
       <string>k_ss_ma-oriya</string>
+      <string>k_ss_na-oriya</string>
       <string>k_ssa-oriya</string>
-      <string>na_da-oriya</string>
-      <string>n_dha-oriya</string>
       <string>n_d_ba-oriya</string>
       <string>n_dh_bha-oriya</string>
+      <string>n_dha-oriya</string>
+      <string>na_da-oriya</string>
+      <string>ya-oriya</string>
+      <string>yya-oriya</string>
     </array>
     <key>public.kern2.ODI_yya-oriya.blwf_R</key>
     <array>
@@ -9384,13 +9384,13 @@
     </array>
     <key>public.kern2.S</key>
     <array>
+      <string>Dze-cy</string>
       <string>S</string>
       <string>Sacute</string>
       <string>Scaron</string>
       <string>Scedilla</string>
       <string>Scircumflex</string>
       <string>Scommaaccent</string>
-      <string>Dze-cy</string>
       <string>Sdotbelow</string>
     </array>
     <key>public.kern2.SNH_a-sinhala_L</key>
@@ -9416,15 +9416,15 @@
     <key>public.kern2.SNH_ai-sinhala_L</key>
     <array>
       <string>ai-sinhala</string>
-      <string>eMatra-sinhala</string>
       <string>aiMatra-sinhala</string>
-      <string>oMatra-sinhala</string>
-      <string>ooMatra-sinhala</string>
       <string>auMatra-sinhala</string>
-      <string>onelith-sinhala</string>
-      <string>twolith-sinhala</string>
-      <string>threelith-sinhala</string>
+      <string>eMatra-sinhala</string>
       <string>ninelith-sinhala</string>
+      <string>oMatra-sinhala</string>
+      <string>onelith-sinhala</string>
+      <string>ooMatra-sinhala</string>
+      <string>threelith-sinhala</string>
+      <string>twolith-sinhala</string>
     </array>
     <key>public.kern2.SNH_anusvaraya-sinhala_L</key>
     <array>
@@ -9432,18 +9432,18 @@
     </array>
     <key>public.kern2.SNH_bh_ra-sinhala_L</key>
     <array>
-      <string>bh_ra-sinhala</string>
       <string>bh_r-sinhala</string>
+      <string>bh_ra-sinhala</string>
       <string>bh_ri-sinhala</string>
       <string>bh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_bha-sinhala_L</key>
     <array>
-      <string>bha-sinhala</string>
       <string>bh-sinhala</string>
+      <string>bha-sinhala</string>
+      <string>bha_reph-sinhala</string>
       <string>bhi-sinhala</string>
       <string>bhii-sinhala</string>
-      <string>bha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_bhu-sinhala_L</key>
     <array>
@@ -9465,82 +9465,82 @@
     </array>
     <key>public.kern2.SNH_ca-sinhala_L</key>
     <array>
-      <string>ca-sinhala</string>
       <string>c-sinhala</string>
-      <string>ci-sinhala</string>
+      <string>ca-sinhala</string>
       <string>ca_reph-sinhala</string>
+      <string>ci-sinhala</string>
     </array>
     <key>public.kern2.SNH_ch_ra-sinhala_L</key>
     <array>
-      <string>ch_ra-sinhala</string>
-      <string>j_ra-sinhala</string>
-      <string>p_ra-sinhala</string>
-      <string>ph_ra-sinhala</string>
-      <string>ss_ra-sinhala</string>
-      <string>h_ra-sinhala</string>
       <string>ch_r-sinhala</string>
-      <string>j_r-sinhala</string>
-      <string>p_r-sinhala</string>
-      <string>ph_r-sinhala</string>
-      <string>ss_r-sinhala</string>
-      <string>h_r-sinhala</string>
+      <string>ch_ra-sinhala</string>
       <string>ch_ri-sinhala</string>
-      <string>j_ri-sinhala</string>
-      <string>p_ri-sinhala</string>
-      <string>ph_ri-sinhala</string>
-      <string>ss_ri-sinhala</string>
-      <string>h_ri-sinhala</string>
       <string>ch_rii-sinhala</string>
-      <string>j_rii-sinhala</string>
-      <string>p_rii-sinhala</string>
-      <string>ph_rii-sinhala</string>
-      <string>ss_rii-sinhala</string>
+      <string>h_r-sinhala</string>
+      <string>h_ra-sinhala</string>
+      <string>h_ri-sinhala</string>
       <string>h_rii-sinhala</string>
+      <string>j_r-sinhala</string>
+      <string>j_ra-sinhala</string>
+      <string>j_ri-sinhala</string>
+      <string>j_rii-sinhala</string>
+      <string>p_r-sinhala</string>
+      <string>p_ra-sinhala</string>
+      <string>p_ri-sinhala</string>
+      <string>p_rii-sinhala</string>
+      <string>ph_r-sinhala</string>
+      <string>ph_ra-sinhala</string>
+      <string>ph_ri-sinhala</string>
+      <string>ph_rii-sinhala</string>
+      <string>ss_r-sinhala</string>
+      <string>ss_ra-sinhala</string>
+      <string>ss_ri-sinhala</string>
+      <string>ss_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_cha-sinhala_L</key>
     <array>
-      <string>cha-sinhala</string>
-      <string>ja-sinhala</string>
-      <string>pa-sinhala</string>
-      <string>pha-sinhala</string>
-      <string>ssa-sinhala</string>
-      <string>ha-sinhala</string>
-      <string>fourlith-sinhala</string>
       <string>ch-sinhala</string>
-      <string>j-sinhala</string>
-      <string>p-sinhala</string>
-      <string>ph-sinhala</string>
-      <string>ss-sinhala</string>
-      <string>h-sinhala</string>
+      <string>cha-sinhala</string>
+      <string>cha_reph-sinhala</string>
       <string>chi-sinhala</string>
-      <string>ji-sinhala</string>
-      <string>pi-sinhala</string>
-      <string>phi-sinhala</string>
-      <string>ssi-sinhala</string>
-      <string>hi-sinhala</string>
       <string>chii-sinhala</string>
-      <string>jii-sinhala</string>
-      <string>pii-sinhala</string>
-      <string>phii-sinhala</string>
-      <string>ssii-sinhala</string>
+      <string>fourlith-sinhala</string>
+      <string>h-sinhala</string>
+      <string>ha-sinhala</string>
+      <string>ha_reph-sinhala</string>
+      <string>hi-sinhala</string>
       <string>hii-sinhala</string>
       <string>huu-sinhala</string>
-      <string>cha_reph-sinhala</string>
+      <string>j-sinhala</string>
+      <string>ja-sinhala</string>
       <string>ja_reph-sinhala</string>
+      <string>ji-sinhala</string>
+      <string>jii-sinhala</string>
+      <string>p-sinhala</string>
+      <string>pa-sinhala</string>
       <string>pa_reph-sinhala</string>
+      <string>ph-sinhala</string>
+      <string>pha-sinhala</string>
+      <string>phi-sinhala</string>
+      <string>phii-sinhala</string>
+      <string>pi-sinhala</string>
+      <string>pii-sinhala</string>
+      <string>ss-sinhala</string>
+      <string>ssa-sinhala</string>
       <string>ssa_reph-sinhala</string>
-      <string>ha_reph-sinhala</string>
+      <string>ssi-sinhala</string>
+      <string>ssii-sinhala</string>
     </array>
     <key>public.kern2.SNH_chu-sinhala_L</key>
     <array>
       <string>chu-sinhala</string>
-      <string>ju-sinhala</string>
-      <string>pu-sinhala</string>
-      <string>phu-sinhala</string>
-      <string>ssu-sinhala</string>
-      <string>hu-sinhala</string>
       <string>chuu-sinhala</string>
+      <string>hu-sinhala</string>
+      <string>ju-sinhala</string>
       <string>juu-sinhala</string>
+      <string>phu-sinhala</string>
+      <string>pu-sinhala</string>
+      <string>ssu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ci-sinhala_L</key>
     <array>
@@ -9558,8 +9558,8 @@
     </array>
     <key>public.kern2.SNH_d_ra-sinhala_L</key>
     <array>
-      <string>d_ra-sinhala</string>
       <string>d_r-sinhala</string>
+      <string>d_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_d_ri-sinhala_L</key>
     <array>
@@ -9571,9 +9571,9 @@
     </array>
     <key>public.kern2.SNH_da-sinhala_L</key>
     <array>
+      <string>d-sinhala</string>
       <string>da-sinhala</string>
       <string>fivelith-sinhala</string>
-      <string>d-sinhala</string>
     </array>
     <key>public.kern2.SNH_da_reph-sinhala_L</key>
     <array>
@@ -9603,15 +9603,15 @@
     </array>
     <key>public.kern2.SNH_ddh_ra-sinhala_L</key>
     <array>
-      <string>ddh_ra-sinhala</string>
       <string>ddh_r-sinhala</string>
+      <string>ddh_ra-sinhala</string>
       <string>ddh_ri-sinhala</string>
       <string>ddh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ddha-sinhala_L</key>
     <array>
-      <string>ddha-sinhala</string>
       <string>ddh-sinhala</string>
+      <string>ddha-sinhala</string>
       <string>ddhi-sinhala</string>
       <string>ddhii-sinhala</string>
     </array>
@@ -9683,18 +9683,18 @@
     </array>
     <key>public.kern2.SNH_f_ra-sinhala_L</key>
     <array>
-      <string>f_ra-sinhala</string>
       <string>f_r-sinhala</string>
+      <string>f_ra-sinhala</string>
       <string>f_ri-sinhala</string>
       <string>f_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_fa-sinhala_L</key>
     <array>
-      <string>fa-sinhala</string>
       <string>f-sinhala</string>
+      <string>fa-sinhala</string>
+      <string>fa_reph-sinhala</string>
       <string>fi-sinhala</string>
       <string>fii-sinhala</string>
-      <string>fa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_fu-sinhala_L</key>
     <array>
@@ -9703,44 +9703,44 @@
     </array>
     <key>public.kern2.SNH_g_ra-sinhala_L</key>
     <array>
-      <string>g_ra-sinhala</string>
-      <string>sh_ra-sinhala</string>
       <string>g_r-sinhala</string>
-      <string>sh_r-sinhala</string>
+      <string>g_ra-sinhala</string>
       <string>g_ri-sinhala</string>
-      <string>sh_ri-sinhala</string>
       <string>g_rii-sinhala</string>
+      <string>sh_r-sinhala</string>
+      <string>sh_ra-sinhala</string>
+      <string>sh_ri-sinhala</string>
       <string>sh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ga-sinhala_L</key>
     <array>
-      <string>ga-sinhala</string>
-      <string>sha-sinhala</string>
       <string>g-sinhala</string>
-      <string>sh-sinhala</string>
+      <string>ga-sinhala</string>
       <string>gi-sinhala</string>
-      <string>shi-sinhala</string>
       <string>gii-sinhala</string>
-      <string>shii-sinhala</string>
       <string>gu-sinhala</string>
-      <string>shu-sinhala</string>
       <string>guu-sinhala</string>
-      <string>shuu-sinhala</string>
+      <string>sh-sinhala</string>
+      <string>sha-sinhala</string>
       <string>sha_reph-sinhala</string>
+      <string>shi-sinhala</string>
+      <string>shii-sinhala</string>
+      <string>shu-sinhala</string>
+      <string>shuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_gh_ra-sinhala_L</key>
     <array>
-      <string>gh_ra-sinhala</string>
       <string>gh_r-sinhala</string>
+      <string>gh_ra-sinhala</string>
       <string>gh_ri-sinhala</string>
       <string>gh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_gha-sinhala_L</key>
     <array>
-      <string>gha-sinhala</string>
       <string>gh-sinhala</string>
-      <string>ghi-sinhala</string>
+      <string>gha-sinhala</string>
       <string>gha_reph-sinhala</string>
+      <string>ghi-sinhala</string>
     </array>
     <key>public.kern2.SNH_ghii-sinhala_L</key>
     <array>
@@ -9757,154 +9757,154 @@
     </array>
     <key>public.kern2.SNH_ii-sinhala_L</key>
     <array>
+      <string>eightlith-sinhala</string>
       <string>ii-sinhala</string>
       <string>ra-sinhala</string>
-      <string>eightlith-sinhala</string>
+      <string>raae-sinhala</string>
+      <string>rae-sinhala</string>
       <string>ru-sinhala</string>
       <string>ruu-sinhala</string>
-      <string>rae-sinhala</string>
-      <string>raae-sinhala</string>
     </array>
     <key>public.kern2.SNH_ka-sinhala_L</key>
     <array>
-      <string>ka-sinhala</string>
-      <string>jha-sinhala</string>
-      <string>k_ssa-sinhala</string>
-      <string>k-sinhala</string>
       <string>jh-sinhala</string>
-      <string>k_ss-sinhala</string>
-      <string>ki-sinhala</string>
-      <string>jhi-sinhala</string>
-      <string>k_ssi-sinhala</string>
-      <string>kii-sinhala</string>
-      <string>jhii-sinhala</string>
-      <string>k_ssii-sinhala</string>
-      <string>ku-sinhala</string>
-      <string>jhu-sinhala</string>
-      <string>k_ssu-sinhala</string>
-      <string>kuu-sinhala</string>
-      <string>jhuu-sinhala</string>
-      <string>k_ssuu-sinhala</string>
-      <string>k_ra-sinhala</string>
-      <string>jh_ra-sinhala</string>
-      <string>k_r-sinhala</string>
       <string>jh_r-sinhala</string>
-      <string>k_ri-sinhala</string>
+      <string>jh_ra-sinhala</string>
       <string>jh_ri-sinhala</string>
-      <string>k_rii-sinhala</string>
       <string>jh_rii-sinhala</string>
-      <string>ka_reph-sinhala</string>
+      <string>jha-sinhala</string>
       <string>jha_reph-sinhala</string>
+      <string>jhi-sinhala</string>
+      <string>jhii-sinhala</string>
+      <string>jhu-sinhala</string>
+      <string>jhuu-sinhala</string>
+      <string>k-sinhala</string>
+      <string>k_r-sinhala</string>
+      <string>k_ra-sinhala</string>
+      <string>k_ri-sinhala</string>
+      <string>k_rii-sinhala</string>
+      <string>k_ss-sinhala</string>
+      <string>k_ssa-sinhala</string>
+      <string>k_ssi-sinhala</string>
+      <string>k_ssii-sinhala</string>
+      <string>k_ssu-sinhala</string>
+      <string>k_ssuu-sinhala</string>
+      <string>ka-sinhala</string>
+      <string>ka_reph-sinhala</string>
+      <string>ki-sinhala</string>
+      <string>kii-sinhala</string>
+      <string>ku-sinhala</string>
+      <string>kuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh-sinhala_L</key>
     <array>
-      <string>kha-sinhala</string>
-      <string>ba-sinhala</string>
-      <string>kh-sinhala</string>
       <string>b-sinhala</string>
-      <string>kha_reph-sinhala</string>
+      <string>ba-sinhala</string>
       <string>ba_reph-sinhala</string>
+      <string>kh-sinhala</string>
+      <string>kha-sinhala</string>
+      <string>kha_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_r-sinhala_L</key>
     <array>
+      <string>b_r-sinhala</string>
       <string>b_ra-sinhala</string>
       <string>kh_r-sinhala</string>
-      <string>b_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_kh_ri-sinhala_L</key>
     <array>
-      <string>kh_ri-sinhala</string>
       <string>b_ri-sinhala</string>
-      <string>kh_rii-sinhala</string>
       <string>b_rii-sinhala</string>
+      <string>kh_ri-sinhala</string>
+      <string>kh_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khi-sinhala_L</key>
     <array>
-      <string>khi-sinhala</string>
       <string>bi-sinhala</string>
-      <string>khii-sinhala</string>
       <string>bii-sinhala</string>
+      <string>khi-sinhala</string>
+      <string>khii-sinhala</string>
     </array>
     <key>public.kern2.SNH_khu-sinhala_L</key>
     <array>
-      <string>khu-sinhala</string>
       <string>bu-sinhala</string>
-      <string>khuu-sinhala</string>
       <string>buu-sinhala</string>
       <string>kh_ra-sinhala</string>
+      <string>khu-sinhala</string>
+      <string>khuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalic-sinhala_L</key>
     <array>
+      <string>jny-sinhala</string>
+      <string>jny_r-sinhala</string>
+      <string>jny_ra-sinhala</string>
+      <string>jny_ri-sinhala</string>
+      <string>jny_rii-sinhala</string>
+      <string>jnya-sinhala</string>
+      <string>jnya_reph-sinhala</string>
+      <string>jnyi-sinhala</string>
+      <string>jnyii-sinhala</string>
+      <string>jnyu-sinhala</string>
+      <string>jnyuu-sinhala</string>
       <string>lVocalic-sinhala</string>
       <string>llVocalic-sinhala</string>
-      <string>nnga-sinhala</string>
-      <string>nya-sinhala</string>
-      <string>jnya-sinhala</string>
-      <string>nyja-sinhala</string>
-      <string>nndda-sinhala</string>
-      <string>nda-sinhala</string>
-      <string>nng-sinhala</string>
-      <string>ny-sinhala</string>
-      <string>jny-sinhala</string>
-      <string>nyj-sinhala</string>
-      <string>nndd-sinhala</string>
-      <string>nd-sinhala</string>
-      <string>nngi-sinhala</string>
-      <string>nyi-sinhala</string>
-      <string>jnyi-sinhala</string>
-      <string>nyji-sinhala</string>
-      <string>nnddi-sinhala</string>
-      <string>ndi-sinhala</string>
-      <string>nngii-sinhala</string>
-      <string>nyii-sinhala</string>
-      <string>jnyii-sinhala</string>
-      <string>nyjii-sinhala</string>
-      <string>nnddii-sinhala</string>
-      <string>ndii-sinhala</string>
-      <string>nngu-sinhala</string>
-      <string>nyu-sinhala</string>
-      <string>jnyu-sinhala</string>
-      <string>nyju-sinhala</string>
-      <string>nnddu-sinhala</string>
-      <string>ndu-sinhala</string>
       <string>llu-sinhala</string>
-      <string>nnguu-sinhala</string>
-      <string>nyuu-sinhala</string>
-      <string>jnyuu-sinhala</string>
-      <string>nyjuu-sinhala</string>
-      <string>nndduu-sinhala</string>
-      <string>nduu-sinhala</string>
       <string>lluu-sinhala</string>
-      <string>nng_ra-sinhala</string>
-      <string>ny_ra-sinhala</string>
-      <string>jny_ra-sinhala</string>
-      <string>nyj_ra-sinhala</string>
-      <string>nndd_ra-sinhala</string>
-      <string>nd_ra-sinhala</string>
-      <string>nng_r-sinhala</string>
-      <string>ny_r-sinhala</string>
-      <string>jny_r-sinhala</string>
-      <string>nyj_r-sinhala</string>
-      <string>nndd_r-sinhala</string>
+      <string>nd-sinhala</string>
       <string>nd_r-sinhala</string>
-      <string>nng_ri-sinhala</string>
-      <string>ny_ri-sinhala</string>
-      <string>jny_ri-sinhala</string>
-      <string>nyj_ri-sinhala</string>
-      <string>nndd_ri-sinhala</string>
+      <string>nd_ra-sinhala</string>
       <string>nd_ri-sinhala</string>
-      <string>nng_rii-sinhala</string>
-      <string>ny_rii-sinhala</string>
-      <string>jny_rii-sinhala</string>
-      <string>nyj_rii-sinhala</string>
-      <string>nndd_rii-sinhala</string>
       <string>nd_rii-sinhala</string>
-      <string>nnga_reph-sinhala</string>
-      <string>nya_reph-sinhala</string>
-      <string>jnya_reph-sinhala</string>
-      <string>nyja_reph-sinhala</string>
-      <string>nndda_reph-sinhala</string>
+      <string>nda-sinhala</string>
       <string>nda_reph-sinhala</string>
+      <string>ndi-sinhala</string>
+      <string>ndii-sinhala</string>
+      <string>ndu-sinhala</string>
+      <string>nduu-sinhala</string>
+      <string>nndd-sinhala</string>
+      <string>nndd_r-sinhala</string>
+      <string>nndd_ra-sinhala</string>
+      <string>nndd_ri-sinhala</string>
+      <string>nndd_rii-sinhala</string>
+      <string>nndda-sinhala</string>
+      <string>nndda_reph-sinhala</string>
+      <string>nnddi-sinhala</string>
+      <string>nnddii-sinhala</string>
+      <string>nnddu-sinhala</string>
+      <string>nndduu-sinhala</string>
+      <string>nng-sinhala</string>
+      <string>nng_r-sinhala</string>
+      <string>nng_ra-sinhala</string>
+      <string>nng_ri-sinhala</string>
+      <string>nng_rii-sinhala</string>
+      <string>nnga-sinhala</string>
+      <string>nnga_reph-sinhala</string>
+      <string>nngi-sinhala</string>
+      <string>nngii-sinhala</string>
+      <string>nngu-sinhala</string>
+      <string>nnguu-sinhala</string>
+      <string>ny-sinhala</string>
+      <string>ny_r-sinhala</string>
+      <string>ny_ra-sinhala</string>
+      <string>ny_ri-sinhala</string>
+      <string>ny_rii-sinhala</string>
+      <string>nya-sinhala</string>
+      <string>nya_reph-sinhala</string>
+      <string>nyi-sinhala</string>
+      <string>nyii-sinhala</string>
+      <string>nyj-sinhala</string>
+      <string>nyj_r-sinhala</string>
+      <string>nyj_ra-sinhala</string>
+      <string>nyj_ri-sinhala</string>
+      <string>nyj_rii-sinhala</string>
+      <string>nyja-sinhala</string>
+      <string>nyja_reph-sinhala</string>
+      <string>nyji-sinhala</string>
+      <string>nyjii-sinhala</string>
+      <string>nyju-sinhala</string>
+      <string>nyjuu-sinhala</string>
+      <string>nyu-sinhala</string>
+      <string>nyuu-sinhala</string>
     </array>
     <key>public.kern2.SNH_lVocalicMatra-sinhala_L</key>
     <array>
@@ -9913,19 +9913,19 @@
     </array>
     <key>public.kern2.SNH_la-sinhala_L</key>
     <array>
-      <string>la-sinhala</string>
       <string>l-sinhala</string>
+      <string>la-sinhala</string>
+      <string>la_reph-sinhala</string>
       <string>li-sinhala</string>
       <string>lii-sinhala</string>
-      <string>la_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lla-sinhala_L</key>
     <array>
-      <string>lla-sinhala</string>
       <string>ll-sinhala</string>
+      <string>lla-sinhala</string>
+      <string>lla_reph-sinhala</string>
       <string>lli-sinhala</string>
       <string>llii-sinhala</string>
-      <string>lla_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_lu-sinhala_L</key>
     <array>
@@ -9949,8 +9949,8 @@
     <key>public.kern2.SNH_m_ri-sinhala_L</key>
     <array>
       <string>m_ri-sinhala</string>
-      <string>mb_ri-sinhala</string>
       <string>m_rii-sinhala</string>
+      <string>mb_ri-sinhala</string>
       <string>mb_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ma-sinhala_L</key>
@@ -9980,31 +9980,31 @@
     </array>
     <key>public.kern2.SNH_n_ra-sinhala_L</key>
     <array>
-      <string>n_ra-sinhala</string>
       <string>n_r-sinhala</string>
+      <string>n_ra-sinhala</string>
       <string>n_ri-sinhala</string>
       <string>n_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_na-sinhala_L</key>
     <array>
-      <string>na-sinhala</string>
       <string>n-sinhala</string>
+      <string>na-sinhala</string>
+      <string>na_reph-sinhala</string>
       <string>ni-sinhala</string>
       <string>nii-sinhala</string>
       <string>nu-sinhala</string>
       <string>nuu-sinhala</string>
-      <string>na_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng-sinhala_L</key>
     <array>
-      <string>nga-sinhala</string>
       <string>ng-sinhala</string>
+      <string>nga-sinhala</string>
       <string>nga_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_r-sinhala_L</key>
     <array>
-      <string>ng_ra-sinhala</string>
       <string>ng_r-sinhala</string>
+      <string>ng_ra-sinhala</string>
     </array>
     <key>public.kern2.SNH_ng_ri-sinhala_L</key>
     <array>
@@ -10023,12 +10023,12 @@
     </array>
     <key>public.kern2.SNH_nna-sinhala_L</key>
     <array>
-      <string>nna-sinhala</string>
       <string>nn-sinhala</string>
+      <string>nn_r-sinhala</string>
+      <string>nn_ra-sinhala</string>
+      <string>nna-sinhala</string>
       <string>nnu-sinhala</string>
       <string>nnuu-sinhala</string>
-      <string>nn_ra-sinhala</string>
-      <string>nn_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_nna_reph-sinhala_L</key>
     <array>
@@ -10036,19 +10036,19 @@
     </array>
     <key>public.kern2.SNH_nni-sinhala_L</key>
     <array>
-      <string>nni-sinhala</string>
-      <string>nnii-sinhala</string>
       <string>nn_ri-sinhala</string>
       <string>nn_rii-sinhala</string>
+      <string>nni-sinhala</string>
+      <string>nnii-sinhala</string>
     </array>
     <key>public.kern2.SNH_o-sinhala_L</key>
     <array>
+      <string>au-sinhala</string>
+      <string>mb-sinhala</string>
+      <string>mba-sinhala</string>
+      <string>mba_reph-sinhala</string>
       <string>o-sinhala</string>
       <string>oo-sinhala</string>
-      <string>au-sinhala</string>
-      <string>mba-sinhala</string>
-      <string>mb-sinhala</string>
-      <string>mba_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_pha_reph-sinhala_L</key>
     <array>
@@ -10087,18 +10087,18 @@
     </array>
     <key>public.kern2.SNH_s_ra-sinhala_L</key>
     <array>
-      <string>s_ra-sinhala</string>
       <string>s_r-sinhala</string>
+      <string>s_ra-sinhala</string>
       <string>s_ri-sinhala</string>
       <string>s_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_sa-sinhala_L</key>
     <array>
-      <string>sa-sinhala</string>
       <string>s-sinhala</string>
+      <string>sa-sinhala</string>
+      <string>sa_reph-sinhala</string>
       <string>si-sinhala</string>
       <string>sii-sinhala</string>
-      <string>sa_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_sixlith-sinhala_L</key>
     <array>
@@ -10111,22 +10111,22 @@
     </array>
     <key>public.kern2.SNH_ta-sinhala_L</key>
     <array>
-      <string>ta-sinhala</string>
       <string>t-sinhala</string>
+      <string>t_r-sinhala</string>
+      <string>t_ra-sinhala</string>
+      <string>t_ri-sinhala</string>
+      <string>t_rii-sinhala</string>
+      <string>ta-sinhala</string>
+      <string>ta_reph-sinhala</string>
       <string>ti-sinhala</string>
       <string>tii-sinhala</string>
       <string>tu-sinhala</string>
       <string>tuu-sinhala</string>
-      <string>t_ra-sinhala</string>
-      <string>t_r-sinhala</string>
-      <string>t_ri-sinhala</string>
-      <string>t_rii-sinhala</string>
-      <string>ta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_th_ra-sinhala_L</key>
     <array>
-      <string>th_ra-sinhala</string>
       <string>th_r-sinhala</string>
+      <string>th_ra-sinhala</string>
       <string>th_ri-sinhala</string>
       <string>th_rii-sinhala</string>
     </array>
@@ -10148,8 +10148,8 @@
     </array>
     <key>public.kern2.SNH_tt_r-sinhala_L</key>
     <array>
-      <string>tt_r-sinhala</string>
       <string>dh_r-sinhala</string>
+      <string>tt_r-sinhala</string>
     </array>
     <key>public.kern2.SNH_tt_ra-sinhala_L</key>
     <array>
@@ -10162,32 +10162,32 @@
     </array>
     <key>public.kern2.SNH_tta-sinhala_L</key>
     <array>
-      <string>tta-sinhala</string>
-      <string>tha-sinhala</string>
       <string>th-sinhala</string>
+      <string>tha-sinhala</string>
       <string>thi-sinhala</string>
       <string>thii-sinhala</string>
+      <string>tta-sinhala</string>
       <string>tta_reph-sinhala</string>
     </array>
     <key>public.kern2.SNH_tth_ra-sinhala_L</key>
     <array>
-      <string>tth_ra-sinhala</string>
       <string>tth_r-sinhala</string>
+      <string>tth_ra-sinhala</string>
       <string>tth_ri-sinhala</string>
       <string>tth_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha-sinhala_L</key>
     <array>
-      <string>ttha-sinhala</string>
       <string>dha-sinhala</string>
-      <string>ya-sinhala</string>
-      <string>tth-sinhala</string>
-      <string>y-sinhala</string>
-      <string>tthi-sinhala</string>
-      <string>yi-sinhala</string>
-      <string>tthii-sinhala</string>
-      <string>yii-sinhala</string>
       <string>dha_reph-sinhala</string>
+      <string>tth-sinhala</string>
+      <string>ttha-sinhala</string>
+      <string>tthi-sinhala</string>
+      <string>tthii-sinhala</string>
+      <string>y-sinhala</string>
+      <string>ya-sinhala</string>
+      <string>yi-sinhala</string>
+      <string>yii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttha_reph-sinhala_L</key>
     <array>
@@ -10206,8 +10206,8 @@
     </array>
     <key>public.kern2.SNH_ttu-sinhala_L</key>
     <array>
-      <string>ttu-sinhala</string>
       <string>tthuu-sinhala</string>
+      <string>ttu-sinhala</string>
     </array>
     <key>public.kern2.SNH_ttuu-sinhala_L</key>
     <array>
@@ -10256,15 +10256,15 @@
     </array>
     <key>public.kern2.SNH_y_ra-sinhala_L</key>
     <array>
-      <string>y_ra-sinhala</string>
       <string>y_r-sinhala</string>
+      <string>y_ra-sinhala</string>
       <string>y_ri-sinhala</string>
       <string>y_rii-sinhala</string>
     </array>
     <key>public.kern2.SNH_ya-sinhala.post_L</key>
     <array>
-      <string>ya-sinhala.post</string>
       <string>y-sinhala.post</string>
+      <string>ya-sinhala.post</string>
     </array>
     <key>public.kern2.SNH_ya_reph-sinhala_L</key>
     <array>
@@ -10286,18 +10286,18 @@
     </array>
     <key>public.kern2.T</key>
     <array>
+      <string>Dje-cy</string>
+      <string>Hardsign-cy</string>
+      <string>Kabashkir-cy</string>
       <string>T</string>
       <string>Tbar</string>
       <string>Tcaron</string>
       <string>Tcedilla</string>
       <string>Tcommaaccent</string>
       <string>Te-cy</string>
-      <string>Hardsign-cy</string>
-      <string>Tshe-cy</string>
-      <string>Dje-cy</string>
-      <string>Kabashkir-cy</string>
       <string>Tedescender-cy</string>
       <string>Tetse-cy</string>
+      <string>Tshe-cy</string>
     </array>
     <key>public.kern2.TEL_ba-telugu.below_R</key>
     <array>
@@ -10311,30 +10311,30 @@
     </array>
     <key>public.kern2.TEL_ca-telugu_R</key>
     <array>
-      <string>ca-telugu</string>
-      <string>cha-telugu</string>
       <string>c-telugu</string>
-      <string>ch-telugu</string>
+      <string>ca-telugu</string>
       <string>caa-telugu</string>
-      <string>chaa-telugu</string>
-      <string>ci-telugu</string>
-      <string>chi-telugu</string>
-      <string>cii-telugu</string>
-      <string>chii-telugu</string>
-      <string>cu-telugu</string>
-      <string>chu-telugu</string>
-      <string>cuu-telugu</string>
-      <string>chuu-telugu</string>
-      <string>ce-telugu</string>
-      <string>che-telugu</string>
-      <string>cee-telugu</string>
-      <string>chee-telugu</string>
-      <string>co-telugu</string>
-      <string>cho-telugu</string>
-      <string>coo-telugu</string>
-      <string>choo-telugu</string>
       <string>cau-telugu</string>
+      <string>ce-telugu</string>
+      <string>cee-telugu</string>
+      <string>ch-telugu</string>
+      <string>cha-telugu</string>
+      <string>chaa-telugu</string>
       <string>chau-telugu</string>
+      <string>che-telugu</string>
+      <string>chee-telugu</string>
+      <string>chi-telugu</string>
+      <string>chii-telugu</string>
+      <string>cho-telugu</string>
+      <string>choo-telugu</string>
+      <string>chu-telugu</string>
+      <string>chuu-telugu</string>
+      <string>ci-telugu</string>
+      <string>cii-telugu</string>
+      <string>co-telugu</string>
+      <string>coo-telugu</string>
+      <string>cu-telugu</string>
+      <string>cuu-telugu</string>
     </array>
     <key>public.kern2.TEL_colon_R</key>
     <array>
@@ -10355,30 +10355,30 @@
     </array>
     <key>public.kern2.TEL_kha-telugu_R</key>
     <array>
-      <string>kha-telugu</string>
-      <string>kha-telugu.alt</string>
       <string>kh-telugu</string>
       <string>kh-telugu.alt</string>
+      <string>kha-telugu</string>
+      <string>kha-telugu.alt</string>
       <string>khaa-telugu</string>
       <string>khaa-telugu.alt</string>
-      <string>khi-telugu</string>
-      <string>khi-telugu.alt</string>
-      <string>khii-telugu</string>
-      <string>khii-telugu.alt</string>
-      <string>khu-telugu</string>
-      <string>khu-telugu.alt</string>
-      <string>khuu-telugu</string>
-      <string>khuu-telugu.alt</string>
+      <string>khau-telugu</string>
+      <string>khau-telugu.alt</string>
       <string>khe-telugu</string>
       <string>khe-telugu.alt</string>
       <string>khee-telugu</string>
       <string>khee-telugu.alt</string>
+      <string>khi-telugu</string>
+      <string>khi-telugu.alt</string>
+      <string>khii-telugu</string>
+      <string>khii-telugu.alt</string>
       <string>kho-telugu</string>
       <string>kho-telugu.alt</string>
       <string>khoo-telugu</string>
       <string>khoo-telugu.alt</string>
-      <string>khau-telugu</string>
-      <string>khau-telugu.alt</string>
+      <string>khu-telugu</string>
+      <string>khu-telugu.alt</string>
+      <string>khuu-telugu</string>
+      <string>khuu-telugu.alt</string>
     </array>
     <key>public.kern2.TEL_lla-telugu.below_R</key>
     <array>
@@ -10400,8 +10400,8 @@
     </array>
     <key>public.kern2.TEL_period_R</key>
     <array>
-      <string>period.loclTELU</string>
       <string>ellipsis.loclTELU</string>
+      <string>period.loclTELU</string>
     </array>
     <key>public.kern2.TEL_question_R</key>
     <array>
@@ -10454,9 +10454,9 @@
     </array>
     <key>public.kern2.TML_eMatra-tamil_R</key>
     <array>
+      <string>auMatra-tamil</string>
       <string>eMatra-tamil</string>
       <string>oMatra-tamil</string>
-      <string>auMatra-tamil</string>
     </array>
     <key>public.kern2.TML_eeMatra-tamil_R</key>
     <array>
@@ -10470,8 +10470,8 @@
     <key>public.kern2.TML_five-tamil_R</key>
     <array>
       <string>five-tamil</string>
-      <string>year-tamil</string>
       <string>rupee-tamil</string>
+      <string>year-tamil</string>
     </array>
     <key>public.kern2.TML_five.loclTAML_R</key>
     <array>
@@ -10495,56 +10495,56 @@
     </array>
     <key>public.kern2.TML_ii-tamil_R</key>
     <array>
+      <string>aaMatra-tamil</string>
       <string>ii-tamil</string>
       <string>nga-tamil</string>
-      <string>ra-tamil</string>
-      <string>aaMatra-tamil</string>
-      <string>three-tamil</string>
       <string>nga_uMatra-tamil</string>
       <string>nga_uuMatra-tamil</string>
+      <string>ra-tamil</string>
+      <string>three-tamil</string>
     </array>
     <key>public.kern2.TML_ka-tamil_R</key>
     <array>
-      <string>ka-tamil</string>
       <string>ca-tamil</string>
-      <string>one-tamil</string>
-      <string>four-tamil</string>
-      <string>six-tamil</string>
-      <string>nine-tamil</string>
-      <string>onethousand-tamil</string>
-      <string>k_ssa-tamil</string>
-      <string>ka_iMatra-tamil</string>
       <string>ca_iMatra-tamil</string>
+      <string>ca_uMatra-tamil</string>
+      <string>four-tamil</string>
+      <string>k_ssa-tamil</string>
       <string>k_ssa_iMatra-tamil</string>
       <string>k_ssa_iiMatra-tamil</string>
-      <string>ca_uMatra-tamil</string>
       <string>k_ssa_uMatra-tamil</string>
-      <string>ka_uuMatra-tamil</string>
       <string>k_ssa_uuMatra-tamil</string>
+      <string>ka-tamil</string>
+      <string>ka_iMatra-tamil</string>
+      <string>ka_uuMatra-tamil</string>
+      <string>nine-tamil</string>
+      <string>one-tamil</string>
+      <string>onethousand-tamil</string>
+      <string>six-tamil</string>
     </array>
     <key>public.kern2.TML_la-tamil_R</key>
     <array>
-      <string>la-tamil</string>
-      <string>lla-tamil</string>
-      <string>va-tamil</string>
-      <string>ssa-tamil</string>
-      <string>sa-tamil</string>
       <string>aulengthmark-tamil</string>
       <string>day-tamil</string>
+      <string>la-tamil</string>
       <string>la_iMatra-tamil</string>
-      <string>ssa_iMatra-tamil</string>
-      <string>sa_iMatra-tamil</string>
       <string>la_iiMatra-tamil</string>
-      <string>ssa_iiMatra-tamil</string>
-      <string>sa_iiMatra-tamil</string>
       <string>la_uMatra-tamil</string>
-      <string>va_uMatra-tamil</string>
-      <string>ssa_uMatra-tamil</string>
-      <string>sa_uMatra-tamil</string>
       <string>la_uuMatra-tamil</string>
-      <string>va_uuMatra-tamil</string>
-      <string>ssa_uuMatra-tamil</string>
+      <string>lla-tamil</string>
+      <string>sa-tamil</string>
+      <string>sa_iMatra-tamil</string>
+      <string>sa_iiMatra-tamil</string>
+      <string>sa_uMatra-tamil</string>
       <string>sa_uuMatra-tamil</string>
+      <string>ssa-tamil</string>
+      <string>ssa_iMatra-tamil</string>
+      <string>ssa_iiMatra-tamil</string>
+      <string>ssa_uMatra-tamil</string>
+      <string>ssa_uuMatra-tamil</string>
+      <string>va-tamil</string>
+      <string>va_uMatra-tamil</string>
+      <string>va_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_llla-tamil_R</key>
     <array>
@@ -10554,10 +10554,10 @@
     </array>
     <key>public.kern2.TML_ma_uuMatra-tamil_R</key>
     <array>
-      <string>ma_uuMatra-tamil</string>
-      <string>ra_uuMatra-tamil</string>
       <string>lla_uuMatra-tamil</string>
       <string>llla_uuMatra-tamil</string>
+      <string>ma_uuMatra-tamil</string>
+      <string>ra_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_nine.loclTAML_R</key>
     <array>
@@ -10565,12 +10565,12 @@
     </array>
     <key>public.kern2.TML_nna-tamil_R</key>
     <array>
-      <string>nna-tamil</string>
-      <string>nnna-tamil</string>
       <string>aiMatra-tamil</string>
+      <string>nna-tamil</string>
       <string>nna_uMatra-tamil</string>
-      <string>nnna_uMatra-tamil</string>
       <string>nna_uuMatra-tamil</string>
+      <string>nnna-tamil</string>
+      <string>nnna_uMatra-tamil</string>
       <string>nnna_uuMatra-tamil</string>
     </array>
     <key>public.kern2.TML_one.loclTAML_R</key>
@@ -10579,8 +10579,8 @@
     </array>
     <key>public.kern2.TML_period.loclTAML_R</key>
     <array>
-      <string>period.loclTAML</string>
       <string>ellipsis.loclTAML</string>
+      <string>period.loclTAML</string>
     </array>
     <key>public.kern2.TML_question.loclTAML_R</key>
     <array>
@@ -10639,9 +10639,9 @@
     </array>
     <key>public.kern2.TML_ya-tamil_R</key>
     <array>
-      <string>ya-tamil</string>
       <string>sha-tamil</string>
       <string>ten-tamil</string>
+      <string>ya-tamil</string>
       <string>ya_uMatra-tamil</string>
       <string>ya_uuMatra-tamil</string>
     </array>
@@ -10677,8 +10677,8 @@
     </array>
     <key>public.kern2.V</key>
     <array>
-      <string>V</string>
       <string>Izhitsa-cy</string>
+      <string>V</string>
     </array>
     <key>public.kern2.W</key>
     <array>
@@ -10686,31 +10686,31 @@
       <string>Wacute</string>
       <string>Wcircumflex</string>
       <string>Wdieresis</string>
-      <string>Wgrave</string>
       <string>We-cy</string>
+      <string>Wgrave</string>
     </array>
     <key>public.kern2.X</key>
     <array>
-      <string>X</string>
       <string>Ha-cy</string>
       <string>Hadescender-cy</string>
       <string>Hahook-cy</string>
       <string>Hastroke-cy</string>
+      <string>X</string>
     </array>
     <key>public.kern2.Y</key>
     <array>
+      <string>Ustraight-cy</string>
+      <string>Ustraightstroke-cy</string>
       <string>Y</string>
       <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
       <string>Ydotbelow</string>
       <string>Ygrave</string>
+      <string>Yhook</string>
       <string>Yhookabove</string>
       <string>Ytilde</string>
-      <string>Ustraight-cy</string>
-      <string>Ustraightstroke-cy</string>
       <string>ustraight-cy.sc</string>
-      <string>Yhook</string>
     </array>
     <key>public.kern2.Z</key>
     <array>
@@ -10722,8 +10722,10 @@
     <key>public.kern2.a</key>
     <array>
       <string>a</string>
+      <string>a-cy</string>
       <string>aacute</string>
       <string>abreve</string>
+      <string>abreve-cy</string>
       <string>abreveacute</string>
       <string>abrevedotbelow</string>
       <string>abrevegrave</string>
@@ -10736,25 +10738,25 @@
       <string>acircumflexhookabove</string>
       <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adieresis-cy</string>
       <string>adotbelow</string>
+      <string>ae</string>
+      <string>aeacute</string>
       <string>agrave</string>
       <string>ahookabove</string>
+      <string>aie-cy</string>
       <string>amacron</string>
       <string>aogonek</string>
       <string>aring</string>
       <string>aringacute</string>
       <string>atilde</string>
-      <string>ae</string>
-      <string>aeacute</string>
-      <string>a-cy</string>
-      <string>abreve-cy</string>
-      <string>adieresis-cy</string>
-      <string>aie-cy</string>
     </array>
     <key>public.kern2.a.sc</key>
     <array>
+      <string>a-cy.sc</string>
       <string>a.sc</string>
       <string>aacute.sc</string>
+      <string>abreve-cy.sc</string>
       <string>abreve.sc</string>
       <string>abreveacute.sc</string>
       <string>abrevedotbelow.sc</string>
@@ -10768,31 +10770,29 @@
       <string>acircumflexgrave.sc</string>
       <string>acircumflexhookabove.sc</string>
       <string>acircumflextilde.sc</string>
+      <string>adieresis-cy.sc</string>
       <string>adieresis.sc</string>
       <string>adotbelow.sc</string>
+      <string>ae.sc</string>
+      <string>aeacute.sc</string>
       <string>agrave.sc</string>
       <string>ahookabove.sc</string>
+      <string>aie-cy.sc</string>
       <string>amacron.sc</string>
       <string>aogonek.sc</string>
       <string>aring.sc</string>
       <string>aringacute.sc</string>
       <string>atilde.sc</string>
-      <string>ae.sc</string>
-      <string>aeacute.sc</string>
-      <string>a-cy.sc</string>
-      <string>abreve-cy.sc</string>
-      <string>adieresis-cy.sc</string>
-      <string>aie-cy.sc</string>
       <string>de-cy.loclBGR.sc</string>
       <string>el-cy.loclBGR.sc</string>
     </array>
     <key>public.kern2.alef-hb</key>
     <array>
-      <string>aleflamed-hb</string>
       <string>alef-hb</string>
+      <string>alefdagesh-hb</string>
+      <string>aleflamed-hb</string>
       <string>alefpatah-hb</string>
       <string>alefqamats-hb</string>
-      <string>alefdagesh-hb</string>
       <string>tsadi-hb</string>
       <string>tsadidagesh-hb</string>
     </array>
@@ -10834,13 +10834,13 @@
     </array>
     <key>public.kern2.armn_lc_round_xheight</key>
     <array>
-      <string>gim-arm</string>
-      <string>za-arm</string>
-      <string>zhe-arm</string>
       <string>co-arm</string>
+      <string>gim-arm</string>
       <string>oh-arm</string>
+      <string>za-arm</string>
       <string>za-arm.nonspacing.long</string>
       <string>za-arm.spacing.short</string>
+      <string>zhe-arm</string>
     </array>
     <key>public.kern2.armn_lc_round_xheight_topBar</key>
     <array>
@@ -10864,22 +10864,22 @@
     <array>
       <string>ben-arm</string>
       <string>et-arm</string>
-      <string>to-arm</string>
-      <string>liwn-arm</string>
-      <string>reh-arm</string>
-      <string>liwn-arm.nonspacing.long</string>
       <string>et-arm.nonspacing.short</string>
+      <string>liwn-arm</string>
+      <string>liwn-arm.nonspacing.long</string>
       <string>liwn-arm.spacing.short</string>
+      <string>reh-arm</string>
+      <string>to-arm</string>
     </array>
     <key>public.kern2.armn_lc_straight_xheight</key>
     <array>
       <string>da-arm</string>
       <string>ghad-arm</string>
-      <string>vo-arm</string>
-      <string>ra-arm</string>
-      <string>yiwn-arm</string>
       <string>ghad-arm.nonspacing.long</string>
       <string>ghad-arm.spacing.short</string>
+      <string>ra-arm</string>
+      <string>vo-arm</string>
+      <string>yiwn-arm</string>
     </array>
     <key>public.kern2.armn_lc_topRound_bottomStraight_ascender</key>
     <array>
@@ -10888,8 +10888,8 @@
     <key>public.kern2.armn_lc_topStraight_bottomRound_ascender</key>
     <array>
       <string>ech-arm</string>
-      <string>ken-arm</string>
       <string>ech_yiwn-arm</string>
+      <string>ken-arm</string>
       <string>now-arm.nonspacing.long</string>
       <string>now-arm.nonspacing.short</string>
     </array>
@@ -10897,19 +10897,19 @@
     <array>
       <string>ayb-arm</string>
       <string>men-arm</string>
-      <string>peh-arm</string>
-      <string>seh-arm</string>
-      <string>vew-arm</string>
-      <string>tiwn-arm</string>
-      <string>piwr-arm</string>
-      <string>men_now-arm.liga</string>
+      <string>men-arm.nonspacing.long</string>
       <string>men_ech-arm.liga</string>
       <string>men_ini-arm.liga</string>
-      <string>vew_now-arm.liga</string>
+      <string>men_now-arm.liga</string>
       <string>men_xeh-arm.liga</string>
-      <string>men-arm.nonspacing.long</string>
+      <string>peh-arm</string>
+      <string>piwr-arm</string>
+      <string>seh-arm</string>
+      <string>tiwn-arm</string>
+      <string>vew-arm</string>
       <string>vew-arm.nonspacing.long</string>
       <string>vew-arm.spacing.short</string>
+      <string>vew_now-arm.liga</string>
     </array>
     <key>public.kern2.armn_lc_yi</key>
     <array>
@@ -11076,13 +11076,13 @@
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound</key>
     <array>
-      <string>Yi-arm</string>
       <string>Oh-arm</string>
+      <string>Yi-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound.sc</key>
     <array>
-      <string>yi-arm.sc</string>
       <string>oh-arm.sc</string>
+      <string>yi-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomRound_bottomRaised</key>
     <array>
@@ -11096,19 +11096,19 @@
     <array>
       <string>Ben-arm</string>
       <string>Et-arm</string>
-      <string>To-arm</string>
-      <string>Vo-arm</string>
       <string>Ra-arm</string>
       <string>Reh-arm</string>
+      <string>To-arm</string>
+      <string>Vo-arm</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight.sc</key>
     <array>
       <string>ben-arm.sc</string>
       <string>et-arm.sc</string>
-      <string>to-arm.sc</string>
-      <string>vo-arm.sc</string>
       <string>ra-arm.sc</string>
       <string>reh-arm.sc</string>
+      <string>to-arm.sc</string>
+      <string>vo-arm.sc</string>
     </array>
     <key>public.kern2.armn_uc_topRound_bottomStraight_middleBar</key>
     <array>
@@ -11130,35 +11130,35 @@
     <array>
       <string>Ayb-arm</string>
       <string>Ech-arm</string>
-      <string>Men-arm</string>
-      <string>Seh-arm</string>
       <string>Ech_Vew-arm.liga</string>
+      <string>Men-arm</string>
       <string>Men_Ech-arm.liga</string>
       <string>Men_Ini-arm.liga</string>
-      <string>Men_Xeh-arm.liga</string>
       <string>Men_Now-arm.liga</string>
+      <string>Men_Xeh-arm.liga</string>
+      <string>Seh-arm</string>
     </array>
     <key>public.kern2.armn_uc_topStraight_bottomRound.sc</key>
     <array>
       <string>ayb-arm.sc</string>
       <string>ech-arm.sc</string>
-      <string>men-arm.sc</string>
-      <string>seh-arm.sc</string>
       <string>ech_vew-arm.liga.sc</string>
-      <string>men_now-arm.liga.sc</string>
+      <string>men-arm.sc</string>
       <string>men_ech-arm.liga.sc</string>
       <string>men_ini-arm.liga.sc</string>
+      <string>men_now-arm.liga.sc</string>
       <string>men_xeh-arm.liga.sc</string>
+      <string>seh-arm.sc</string>
     </array>
     <key>public.kern2.ban-georgian</key>
     <array>
       <string>ban-georgian</string>
-      <string>tan-georgian</string>
-      <string>jil-georgian</string>
       <string>fi-georgian</string>
-      <string>turnedgan-georgian</string>
       <string>hardsign-georgian</string>
+      <string>jil-georgian</string>
       <string>labial-georgian</string>
+      <string>tan-georgian</string>
+      <string>turnedgan-georgian</string>
     </array>
     <key>public.kern2.bet-hb</key>
     <array>
@@ -11173,93 +11173,93 @@
     </array>
     <key>public.kern2.boBae-lao</key>
     <array>
+      <string>boBae-lao</string>
+      <string>foFai-lao</string>
+      <string>hoHaan-lao</string>
+      <string>hoMo-lao</string>
+      <string>hoNo-lao</string>
+      <string>phoPhu-lao</string>
+      <string>poPa-lao</string>
+      <string>ssa-lao</string>
       <string>thoThong-lao</string>
       <string>thoThung-lao</string>
-      <string>boBae-lao</string>
-      <string>poPa-lao</string>
-      <string>phoPhu-lao</string>
-      <string>foFai-lao</string>
-      <string>ssa-lao</string>
-      <string>hoHaan-lao</string>
-      <string>hoNo-lao</string>
-      <string>hoMo-lao</string>
     </array>
     <key>public.kern2.bracketright</key>
     <array>
-      <string>parenright</string>
       <string>braceright</string>
-      <string>bracketright</string>
       <string>braceright.loclDEVA</string>
+      <string>bracketright</string>
       <string>bracketright.loclDEVA</string>
+      <string>parenright</string>
       <string>parenright.loclDEVA</string>
     </array>
     <key>public.kern2.bracketright.cap</key>
     <array>
-      <string>parenright.cap</string>
       <string>braceright.cap</string>
       <string>bracketright.cap</string>
+      <string>parenright.cap</string>
     </array>
     <key>public.kern2.circle</key>
     <array>
-      <string>one.sansSerifCircled</string>
-      <string>two.sansSerifCircled</string>
-      <string>three.sansSerifCircled</string>
-      <string>four.sansSerifCircled</string>
-      <string>five.sansSerifCircled</string>
-      <string>six.sansSerifCircled</string>
-      <string>seven.sansSerifCircled</string>
+      <string>G.circ</string>
+      <string>blackCircle</string>
+      <string>copyright.alt</string>
+      <string>eight.sansSerifBlackCircled</string>
       <string>eight.sansSerifCircled</string>
+      <string>five.sansSerifBlackCircled</string>
+      <string>five.sansSerifCircled</string>
+      <string>four.sansSerifBlackCircled</string>
+      <string>four.sansSerifCircled</string>
+      <string>nine.sansSerifBlackCircled</string>
       <string>nine.sansSerifCircled</string>
       <string>one.sansSerifBlackCircled</string>
-      <string>two.sansSerifBlackCircled</string>
-      <string>three.sansSerifBlackCircled</string>
-      <string>four.sansSerifBlackCircled</string>
-      <string>five.sansSerifBlackCircled</string>
-      <string>six.sansSerifBlackCircled</string>
-      <string>seven.sansSerifBlackCircled</string>
-      <string>eight.sansSerifBlackCircled</string>
-      <string>nine.sansSerifBlackCircled</string>
-      <string>blackCircle</string>
-      <string>whiteCircle</string>
-      <string>copyright.alt</string>
-      <string>registered.alt</string>
+      <string>one.sansSerifCircled</string>
       <string>published.alt</string>
-      <string>G.circ</string>
+      <string>registered.alt</string>
+      <string>seven.sansSerifBlackCircled</string>
+      <string>seven.sansSerifCircled</string>
+      <string>six.sansSerifBlackCircled</string>
+      <string>six.sansSerifCircled</string>
+      <string>three.sansSerifBlackCircled</string>
+      <string>three.sansSerifCircled</string>
+      <string>two.sansSerifBlackCircled</string>
+      <string>two.sansSerifCircled</string>
+      <string>whiteCircle</string>
     </array>
     <key>public.kern2.colon</key>
     <array>
       <string>colon</string>
-      <string>semicolon</string>
-      <string>questiongreek</string>
+      <string>colon.loclDEVA</string>
+      <string>colon.loclGEO</string>
       <string>period-arm</string>
       <string>period-arm.sc</string>
+      <string>questiongreek</string>
+      <string>semicolon</string>
       <string>semicolon.loclARM</string>
-      <string>colon.loclDEVA</string>
       <string>semicolon.loclDEVA</string>
-      <string>colon.loclGEO</string>
       <string>semicolon.loclGEO</string>
     </array>
     <key>public.kern2.copyright</key>
     <array>
       <string>copyright</string>
-      <string>registered</string>
       <string>published</string>
+      <string>registered</string>
     </array>
     <key>public.kern2.cyr-ze.sc</key>
     <array>
+      <string>dzeabkhasian-cy.sc</string>
       <string>ze-cy.sc</string>
+      <string>zedescender-cy.loclBSH.sc</string>
       <string>zedescender-cy.sc</string>
       <string>zedieresis-cy.sc</string>
-      <string>dzeabkhasian-cy.sc</string>
-      <string>zedescender-cy.loclBSH.sc</string>
     </array>
     <key>public.kern2.cyr_Che</key>
     <array>
       <string>Che-cy</string>
       <string>Chedescender-cy</string>
-      <string>Cheverticalstroke-cy</string>
-      <string>Chekhakassian-cy</string>
       <string>Chedieresis-cy</string>
+      <string>Chekhakassian-cy</string>
+      <string>Cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_D</key>
     <array>
@@ -11272,8 +11272,8 @@
     <key>public.kern2.cyr_E</key>
     <array>
       <string>Ereversed-cy</string>
-      <string>Schwa-cy</string>
       <string>Schwa</string>
+      <string>Schwa-cy</string>
     </array>
     <key>public.kern2.cyr_F</key>
     <array>
@@ -11282,55 +11282,55 @@
     <key>public.kern2.cyr_H</key>
     <array>
       <string>Be-cy</string>
-      <string>Ve-cy</string>
-      <string>Ge-cy</string>
-      <string>Gje-cy</string>
-      <string>Gheupturn-cy</string>
-      <string>Ie-cy</string>
-      <string>Iegrave-cy</string>
-      <string>Io-cy</string>
-      <string>Ii-cy</string>
-      <string>Iishort-cy</string>
-      <string>Iigrave-cy</string>
-      <string>Iishorttail-cy</string>
-      <string>Ka-cy</string>
-      <string>Kje-cy</string>
-      <string>Em-cy</string>
-      <string>En-cy</string>
-      <string>Pe-cy</string>
-      <string>Er-cy</string>
-      <string>Tse-cy</string>
-      <string>Sha-cy</string>
-      <string>Shcha-cy</string>
       <string>Dzhe-cy</string>
-      <string>Softsign-cy</string>
-      <string>Yeru-cy</string>
-      <string>Nje-cy</string>
-      <string>I-cy</string>
-      <string>Iu-cy</string>
-      <string>Ghestroke-cy</string>
-      <string>Ghemiddlehook-cy</string>
-      <string>Kadescender-cy</string>
-      <string>Kaverticalstroke-cy</string>
-      <string>Kastroke-cy</string>
+      <string>Em-cy</string>
+      <string>Emtail-cy</string>
+      <string>En-cy</string>
       <string>Endescender-cy</string>
-      <string>Pedescender-cy</string>
-      <string>Shha-cy</string>
-      <string>Shhadescender-cy</string>
-      <string>Palochka-cy</string>
-      <string>Kahook-cy</string>
       <string>Enhook-cy</string>
       <string>Entail-cy</string>
-      <string>Emtail-cy</string>
-      <string>Iebreve-cy</string>
-      <string>Imacron-cy</string>
-      <string>Idieresis-cy</string>
-      <string>Gedescender-cy</string>
-      <string>Yerudieresis-cy</string>
-      <string>Gestrokehook-cy</string>
-      <string>Semisoftsign-cy</string>
+      <string>Er-cy</string>
       <string>Ertick-cy</string>
+      <string>Ge-cy</string>
+      <string>Gedescender-cy</string>
+      <string>Gestrokehook-cy</string>
+      <string>Ghemiddlehook-cy</string>
+      <string>Ghestroke-cy</string>
       <string>Ghestroke-cy.loclBSH</string>
+      <string>Gheupturn-cy</string>
+      <string>Gje-cy</string>
+      <string>I-cy</string>
+      <string>Idieresis-cy</string>
+      <string>Ie-cy</string>
+      <string>Iebreve-cy</string>
+      <string>Iegrave-cy</string>
+      <string>Ii-cy</string>
+      <string>Iigrave-cy</string>
+      <string>Iishort-cy</string>
+      <string>Iishorttail-cy</string>
+      <string>Imacron-cy</string>
+      <string>Io-cy</string>
+      <string>Iu-cy</string>
+      <string>Ka-cy</string>
+      <string>Kadescender-cy</string>
+      <string>Kahook-cy</string>
+      <string>Kastroke-cy</string>
+      <string>Kaverticalstroke-cy</string>
+      <string>Kje-cy</string>
+      <string>Nje-cy</string>
+      <string>Palochka-cy</string>
+      <string>Pe-cy</string>
+      <string>Pedescender-cy</string>
+      <string>Semisoftsign-cy</string>
+      <string>Sha-cy</string>
+      <string>Shcha-cy</string>
+      <string>Shha-cy</string>
+      <string>Shhadescender-cy</string>
+      <string>Softsign-cy</string>
+      <string>Tse-cy</string>
+      <string>Ve-cy</string>
+      <string>Yeru-cy</string>
+      <string>Yerudieresis-cy</string>
     </array>
     <key>public.kern2.cyr_H_hook</key>
     <array>
@@ -11343,32 +11343,32 @@
     <key>public.kern2.cyr_L</key>
     <array>
       <string>El-cy</string>
-      <string>Lje-cy</string>
-      <string>Eltail-cy</string>
-      <string>Elhook-cy</string>
       <string>Eldescender-cy</string>
+      <string>Elhook-cy</string>
+      <string>Eltail-cy</string>
+      <string>Lje-cy</string>
     </array>
     <key>public.kern2.cyr_Y</key>
     <array>
       <string>U-cy</string>
-      <string>Ushort-cy</string>
-      <string>Umacron-cy</string>
       <string>Udieresis-cy</string>
       <string>Uhungarumlaut-cy</string>
+      <string>Umacron-cy</string>
+      <string>Ushort-cy</string>
     </array>
     <key>public.kern2.cyr_Z</key>
     <array>
+      <string>Dzeabkhasian-cy</string>
       <string>Ze-cy</string>
       <string>Zedescender-cy</string>
-      <string>Zedieresis-cy</string>
-      <string>Dzeabkhasian-cy</string>
       <string>Zedescender-cy.loclBSH</string>
+      <string>Zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_Zhe</key>
     <array>
       <string>Zhe-cy</string>
-      <string>Zhedescender-cy</string>
       <string>Zhebreve-cy</string>
+      <string>Zhedescender-cy</string>
       <string>Zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_b</key>
@@ -11380,17 +11380,17 @@
     <array>
       <string>che-cy</string>
       <string>chedescender-cy</string>
-      <string>cheverticalstroke-cy</string>
-      <string>chekhakassian-cy</string>
       <string>chedieresis-cy</string>
+      <string>chekhakassian-cy</string>
+      <string>cheverticalstroke-cy</string>
     </array>
     <key>public.kern2.cyr_che.sc</key>
     <array>
       <string>che-cy.sc</string>
       <string>chedescender-cy.sc</string>
-      <string>cheverticalstroke-cy.sc</string>
-      <string>chekhakassian-cy.sc</string>
       <string>chedieresis-cy.sc</string>
+      <string>chekhakassian-cy.sc</string>
+      <string>cheverticalstroke-cy.sc</string>
     </array>
     <key>public.kern2.cyr_d.sc</key>
     <array>
@@ -11427,18 +11427,18 @@
     <key>public.kern2.cyr_l</key>
     <array>
       <string>el-cy</string>
-      <string>lje-cy</string>
-      <string>eltail-cy</string>
-      <string>elhook-cy</string>
       <string>eldescender-cy</string>
+      <string>elhook-cy</string>
+      <string>eltail-cy</string>
+      <string>lje-cy</string>
     </array>
     <key>public.kern2.cyr_l.sc</key>
     <array>
       <string>el-cy.sc</string>
-      <string>lje-cy.sc</string>
       <string>eldescender-cy.sc</string>
-      <string>eltail-cy.sc</string>
       <string>elhook-cy.sc</string>
+      <string>eltail-cy.sc</string>
+      <string>lje-cy.sc</string>
     </array>
     <key>public.kern2.cyr_lBGR</key>
     <array>
@@ -11446,36 +11446,36 @@
     </array>
     <key>public.kern2.cyr_t</key>
     <array>
-      <string>te-cy</string>
       <string>hardsign-cy</string>
+      <string>hardsign-cy.loclBGR</string>
       <string>kabashkir-cy</string>
+      <string>te-cy</string>
       <string>tedescender-cy</string>
       <string>tetse-cy</string>
-      <string>hardsign-cy.loclBGR</string>
     </array>
     <key>public.kern2.cyr_z</key>
     <array>
-      <string>ze-cy</string>
-      <string>zedescender-cy</string>
-      <string>zedieresis-cy</string>
       <string>dzeabkhasian-cy</string>
+      <string>ze-cy</string>
       <string>ze-cy.loclBGR</string>
+      <string>zedescender-cy</string>
       <string>zedescender-cy.loclBSH</string>
+      <string>zedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe</key>
     <array>
-      <string>zhe-cy</string>
       <string>yusbig-cy</string>
-      <string>zhedescender-cy</string>
-      <string>zhebreve-cy</string>
-      <string>zhedieresis-cy</string>
+      <string>zhe-cy</string>
       <string>zhe-cy.loclBGR</string>
+      <string>zhebreve-cy</string>
+      <string>zhedescender-cy</string>
+      <string>zhedieresis-cy</string>
     </array>
     <key>public.kern2.cyr_zhe.sc</key>
     <array>
       <string>zhe-cy.sc</string>
-      <string>zhedescender-cy.sc</string>
       <string>zhebreve-cy.sc</string>
+      <string>zhedescender-cy.sc</string>
       <string>zhedieresis-cy.sc</string>
     </array>
     <key>public.kern2.dagger</key>
@@ -11490,50 +11490,50 @@
     </array>
     <key>public.kern2.dash</key>
     <array>
-      <string>hyphen</string>
-      <string>softhyphen</string>
-      <string>endash</string>
       <string>emdash</string>
+      <string>endash</string>
       <string>horizontalbar</string>
+      <string>hyphen</string>
       <string>hyphen-arm</string>
+      <string>softhyphen</string>
     </array>
     <key>public.kern2.dash.cap</key>
     <array>
-      <string>hyphen.cap</string>
-      <string>endash.cap</string>
       <string>emdash.cap</string>
+      <string>endash.cap</string>
+      <string>hyphen.cap</string>
     </array>
     <key>public.kern2.en-georgian</key>
     <array>
       <string>en-georgian</string>
-      <string>vin-georgian</string>
       <string>khar-georgian</string>
+      <string>vin-georgian</string>
     </array>
     <key>public.kern2.ethi_aGlottal</key>
     <array>
       <string>aGlottal-ethiopic</string>
-      <string>uGlottal-ethiopic</string>
-      <string>iGlottal-ethiopic</string>
       <string>eeGlottal-ethiopic</string>
+      <string>iGlottal-ethiopic</string>
       <string>oGlottal-ethiopic</string>
+      <string>uGlottal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_aPharyngeal</key>
     <array>
       <string>aPharyngeal-ethiopic</string>
-      <string>uPharyngeal-ethiopic</string>
       <string>tza-ethiopic</string>
       <string>tzu-ethiopic</string>
+      <string>uPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ba</key>
     <array>
       <string>ba-ethiopic</string>
-      <string>bu-ethiopic</string>
-      <string>bi-ethiopic</string>
       <string>bee-ethiopic</string>
+      <string>bi-ethiopic</string>
       <string>bo-ethiopic</string>
+      <string>bu-ethiopic</string>
       <string>bwaSebatbeit-ethiopic</string>
-      <string>bwi-ethiopic</string>
       <string>bwee-ethiopic</string>
+      <string>bwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_baa</key>
     <array>
@@ -11543,11 +11543,11 @@
     <key>public.kern2.ethi_bba</key>
     <array>
       <string>bba-ethiopic</string>
-      <string>bbu-ethiopic</string>
-      <string>bbi-ethiopic</string>
-      <string>bbee-ethiopic</string>
       <string>bbe-ethiopic</string>
+      <string>bbee-ethiopic</string>
+      <string>bbi-ethiopic</string>
       <string>bbo-ethiopic</string>
+      <string>bbu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_be</key>
     <array>
@@ -11557,51 +11557,51 @@
     <key>public.kern2.ethi_ca</key>
     <array>
       <string>ca-ethiopic</string>
-      <string>cu-ethiopic</string>
-      <string>ci-ethiopic</string>
       <string>cee-ethiopic</string>
+      <string>ci-ethiopic</string>
+      <string>cu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cca</key>
     <array>
       <string>cca-ethiopic</string>
-      <string>ccu-ethiopic</string>
-      <string>cci-ethiopic</string>
-      <string>ccee-ethiopic</string>
       <string>cce-ethiopic</string>
+      <string>ccee-ethiopic</string>
+      <string>cci-ethiopic</string>
+      <string>ccu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ccha</key>
     <array>
       <string>ccha-ethiopic</string>
-      <string>cchu-ethiopic</string>
-      <string>cchi-ethiopic</string>
       <string>cchee-ethiopic</string>
+      <string>cchi-ethiopic</string>
+      <string>cchu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cha</key>
     <array>
-      <string>cha-ethiopic</string>
-      <string>chu-ethiopic</string>
-      <string>chi-ethiopic</string>
-      <string>chee-ethiopic</string>
       <string>cchha-ethiopic</string>
-      <string>cchhu-ethiopic</string>
-      <string>cchhi-ethiopic</string>
       <string>cchhee-ethiopic</string>
+      <string>cchhi-ethiopic</string>
+      <string>cchhu-ethiopic</string>
+      <string>cha-ethiopic</string>
+      <string>chee-ethiopic</string>
+      <string>chi-ethiopic</string>
+      <string>chu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_chaa</key>
     <array>
+      <string>cchhaa-ethiopic</string>
       <string>chaa-ethiopic</string>
       <string>chwa-ethiopic</string>
-      <string>cchhaa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_che</key>
     <array>
-      <string>che-ethiopic</string>
       <string>cchhe-ethiopic</string>
+      <string>che-ethiopic</string>
     </array>
     <key>public.kern2.ethi_cho</key>
     <array>
-      <string>cho-ethiopic</string>
       <string>cchho-ethiopic</string>
+      <string>cho-ethiopic</string>
     </array>
     <key>public.kern2.ethi_da</key>
     <array>
@@ -11621,35 +11621,35 @@
     </array>
     <key>public.kern2.ethi_ddo</key>
     <array>
-      <string>ddo-ethiopic</string>
       <string>ddho-ethiopic</string>
+      <string>ddo-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ddu</key>
     <array>
-      <string>ddu-ethiopic</string>
-      <string>ddi-ethiopic</string>
       <string>ddaa-ethiopic</string>
-      <string>ddhu-ethiopic</string>
-      <string>ddhi-ethiopic</string>
       <string>ddhaa-ethiopic</string>
+      <string>ddhi-ethiopic</string>
+      <string>ddhu-ethiopic</string>
+      <string>ddi-ethiopic</string>
+      <string>ddu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_doa</key>
     <array>
-      <string>doa-ethiopic</string>
       <string>ddoa-ethiopic</string>
+      <string>doa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_du</key>
     <array>
-      <string>du-ethiopic</string>
-      <string>di-ethiopic</string>
       <string>daa-ethiopic</string>
+      <string>di-ethiopic</string>
+      <string>du-ethiopic</string>
     </array>
     <key>public.kern2.ethi_dzu</key>
     <array>
-      <string>dzu-ethiopic</string>
-      <string>dzi-ethiopic</string>
       <string>dzee-ethiopic</string>
+      <string>dzi-ethiopic</string>
       <string>dzo-ethiopic</string>
+      <string>dzu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ePharyngeal</key>
     <array>
@@ -11659,25 +11659,25 @@
     <key>public.kern2.ethi_fa</key>
     <array>
       <string>fa-ethiopic</string>
-      <string>fi-ethiopic</string>
       <string>fee-ethiopic</string>
+      <string>fi-ethiopic</string>
       <string>fwaSebatbeit-ethiopic</string>
       <string>fwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_fu</key>
     <array>
-      <string>fu-ethiopic</string>
       <string>faa-ethiopic</string>
+      <string>fu-ethiopic</string>
       <string>fwee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ga</key>
     <array>
       <string>ga-ethiopic</string>
-      <string>gu-ethiopic</string>
       <string>gi-ethiopic</string>
+      <string>gu-ethiopic</string>
       <string>gwa-ethiopic</string>
-      <string>gwi-ethiopic</string>
       <string>gwe-ethiopic</string>
+      <string>gwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gga</key>
     <array>
@@ -11687,65 +11687,65 @@
     <key>public.kern2.ethi_ggwa</key>
     <array>
       <string>ggwa-ethiopic</string>
-      <string>ggwi-ethiopic</string>
       <string>ggwe-ethiopic</string>
+      <string>ggwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_gya</key>
     <array>
       <string>gya-ethiopic</string>
-      <string>gyu-ethiopic</string>
-      <string>gyi-ethiopic</string>
       <string>gyee-ethiopic</string>
+      <string>gyi-ethiopic</string>
+      <string>gyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ha</key>
     <array>
       <string>ha-ethiopic</string>
-      <string>hu-ethiopic</string>
       <string>ho-ethiopic</string>
+      <string>hu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hha</key>
     <array>
       <string>hha-ethiopic</string>
-      <string>hhu-ethiopic</string>
-      <string>hhi-ethiopic</string>
-      <string>hhee-ethiopic</string>
       <string>hhe-ethiopic</string>
+      <string>hhee-ethiopic</string>
+      <string>hhi-ethiopic</string>
       <string>hho-ethiopic</string>
+      <string>hhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_hi</key>
     <array>
-      <string>hi-ethiopic</string>
       <string>haa-ethiopic</string>
       <string>hee-ethiopic</string>
+      <string>hi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_iPharyngeal</key>
     <array>
-      <string>iPharyngeal-ethiopic</string>
       <string>aaPharyngeal-ethiopic</string>
       <string>eePharyngeal-ethiopic</string>
+      <string>iPharyngeal-ethiopic</string>
     </array>
     <key>public.kern2.ethi_jee</key>
     <array>
-      <string>jee-ethiopic</string>
       <string>je-ethiopic</string>
+      <string>jee-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ju</key>
     <array>
-      <string>ju-ethiopic</string>
-      <string>ji-ethiopic</string>
       <string>jaa-ethiopic</string>
+      <string>ji-ethiopic</string>
+      <string>ju-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ka</key>
     <array>
       <string>ka-ethiopic</string>
-      <string>ku-ethiopic</string>
-      <string>ki-ethiopic</string>
-      <string>kee-ethiopic</string>
       <string>ke-ethiopic</string>
+      <string>kee-ethiopic</string>
+      <string>ki-ethiopic</string>
       <string>ko-ethiopic</string>
+      <string>ku-ethiopic</string>
       <string>kwa-ethiopic</string>
-      <string>kwi-ethiopic</string>
       <string>kwe-ethiopic</string>
+      <string>kwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kwaa</key>
     <array>
@@ -11755,20 +11755,20 @@
     <key>public.kern2.ethi_kxa</key>
     <array>
       <string>kxa-ethiopic</string>
-      <string>kxu-ethiopic</string>
-      <string>kxi-ethiopic</string>
-      <string>kxee-ethiopic</string>
       <string>kxe-ethiopic</string>
+      <string>kxee-ethiopic</string>
+      <string>kxi-ethiopic</string>
       <string>kxo-ethiopic</string>
+      <string>kxu-ethiopic</string>
       <string>kxwa-ethiopic</string>
-      <string>kxwi-ethiopic</string>
       <string>kxwe-ethiopic</string>
+      <string>kxwi-ethiopic</string>
       <string>xya-ethiopic</string>
-      <string>xyu-ethiopic</string>
-      <string>xyi-ethiopic</string>
-      <string>xyee-ethiopic</string>
       <string>xye-ethiopic</string>
+      <string>xyee-ethiopic</string>
+      <string>xyi-ethiopic</string>
       <string>xyo-ethiopic</string>
+      <string>xyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_kxwaa</key>
     <array>
@@ -11780,20 +11780,20 @@
     <key>public.kern2.ethi_kya</key>
     <array>
       <string>kya-ethiopic</string>
-      <string>kyu-ethiopic</string>
-      <string>kyi-ethiopic</string>
-      <string>kyee-ethiopic</string>
       <string>kye-ethiopic</string>
+      <string>kyee-ethiopic</string>
+      <string>kyi-ethiopic</string>
       <string>kyo-ethiopic</string>
+      <string>kyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_la</key>
     <array>
       <string>la-ethiopic</string>
-      <string>lu-ethiopic</string>
-      <string>li-ethiopic</string>
-      <string>lee-ethiopic</string>
       <string>le-ethiopic</string>
+      <string>lee-ethiopic</string>
+      <string>li-ethiopic</string>
       <string>lo-ethiopic</string>
+      <string>lu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_laa</key>
     <array>
@@ -11813,24 +11813,24 @@
     </array>
     <key>public.kern2.ethi_mi</key>
     <array>
-      <string>mi-ethiopic</string>
       <string>maa-ethiopic</string>
       <string>mee-ethiopic</string>
+      <string>mi-ethiopic</string>
       <string>mwa-ethiopic</string>
-      <string>mwi-ethiopic</string>
       <string>mwee-ethiopic</string>
+      <string>mwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_na</key>
     <array>
       <string>na-ethiopic</string>
-      <string>nu-ethiopic</string>
       <string>ni-ethiopic</string>
+      <string>nu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nya</key>
     <array>
       <string>nya-ethiopic</string>
-      <string>nyu-ethiopic</string>
       <string>nyi-ethiopic</string>
+      <string>nyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_nyaa</key>
     <array>
@@ -11845,9 +11845,9 @@
     <key>public.kern2.ethi_pa</key>
     <array>
       <string>pa-ethiopic</string>
-      <string>pu-ethiopic</string>
-      <string>pi-ethiopic</string>
       <string>pee-ethiopic</string>
+      <string>pi-ethiopic</string>
+      <string>pu-ethiopic</string>
       <string>pwaSebatbeit-ethiopic</string>
       <string>pwi-ethiopic</string>
     </array>
@@ -11859,39 +11859,39 @@
     <key>public.kern2.ethi_pha</key>
     <array>
       <string>pha-ethiopic</string>
-      <string>phu-ethiopic</string>
-      <string>phi-ethiopic</string>
-      <string>phee-ethiopic</string>
       <string>phe-ethiopic</string>
+      <string>phee-ethiopic</string>
+      <string>phi-ethiopic</string>
       <string>pho-ethiopic</string>
+      <string>phu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qa</key>
     <array>
       <string>qa-ethiopic</string>
-      <string>qu-ethiopic</string>
-      <string>qi-ethiopic</string>
-      <string>qee-ethiopic</string>
       <string>qe-ethiopic</string>
+      <string>qee-ethiopic</string>
+      <string>qi-ethiopic</string>
+      <string>qu-ethiopic</string>
       <string>qwa-ethiopic</string>
-      <string>qwi-ethiopic</string>
       <string>qwe-ethiopic</string>
+      <string>qwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qha</key>
     <array>
       <string>qha-ethiopic</string>
-      <string>qhu-ethiopic</string>
-      <string>qhi-ethiopic</string>
       <string>qhee-ethiopic</string>
+      <string>qhi-ethiopic</string>
+      <string>qhu-ethiopic</string>
       <string>qhwa-ethiopic</string>
-      <string>qhwi-ethiopic</string>
       <string>qhwe-ethiopic</string>
+      <string>qhwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_qya</key>
     <array>
       <string>qya-ethiopic</string>
-      <string>qyu-ethiopic</string>
-      <string>qyi-ethiopic</string>
       <string>qyee-ethiopic</string>
+      <string>qyi-ethiopic</string>
+      <string>qyu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ra</key>
     <array>
@@ -11905,22 +11905,22 @@
     </array>
     <key>public.kern2.ethi_ri</key>
     <array>
-      <string>ri-ethiopic</string>
       <string>raa-ethiopic</string>
+      <string>ri-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sa</key>
     <array>
       <string>sa-ethiopic</string>
-      <string>su-ethiopic</string>
-      <string>si-ethiopic</string>
-      <string>see-ethiopic</string>
       <string>se-ethiopic</string>
+      <string>see-ethiopic</string>
+      <string>si-ethiopic</string>
       <string>so-ethiopic</string>
-      <string>tthu-ethiopic</string>
-      <string>tthi-ethiopic</string>
-      <string>tthee-ethiopic</string>
+      <string>su-ethiopic</string>
       <string>tthe-ethiopic</string>
+      <string>tthee-ethiopic</string>
+      <string>tthi-ethiopic</string>
       <string>ttho-ethiopic</string>
+      <string>tthu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_saa</key>
     <array>
@@ -11931,11 +11931,11 @@
     <key>public.kern2.ethi_sha</key>
     <array>
       <string>sha-ethiopic</string>
-      <string>shu-ethiopic</string>
-      <string>shi-ethiopic</string>
-      <string>shee-ethiopic</string>
       <string>she-ethiopic</string>
+      <string>shee-ethiopic</string>
+      <string>shi-ethiopic</string>
       <string>sho-ethiopic</string>
+      <string>shu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_shaa</key>
     <array>
@@ -11945,11 +11945,11 @@
     <key>public.kern2.ethi_ssa</key>
     <array>
       <string>ssa-ethiopic</string>
-      <string>ssu-ethiopic</string>
-      <string>ssi-ethiopic</string>
-      <string>ssee-ethiopic</string>
       <string>sse-ethiopic</string>
+      <string>ssee-ethiopic</string>
+      <string>ssi-ethiopic</string>
       <string>sso-ethiopic</string>
+      <string>ssu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_sza</key>
     <array>
@@ -11958,53 +11958,53 @@
     </array>
     <key>public.kern2.ethi_szi</key>
     <array>
-      <string>szi-ethiopic</string>
       <string>szaa-ethiopic</string>
       <string>szee-ethiopic</string>
+      <string>szi-ethiopic</string>
       <string>szwa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ta</key>
     <array>
       <string>ta-ethiopic</string>
-      <string>tu-ethiopic</string>
-      <string>ti-ethiopic</string>
-      <string>tee-ethiopic</string>
       <string>te-ethiopic</string>
+      <string>tee-ethiopic</string>
+      <string>ti-ethiopic</string>
+      <string>tu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tha</key>
     <array>
       <string>tha-ethiopic</string>
-      <string>thu-ethiopic</string>
-      <string>thi-ethiopic</string>
       <string>thee-ethiopic</string>
+      <string>thi-ethiopic</string>
+      <string>thu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_toa</key>
     <array>
-      <string>toa-ethiopic</string>
       <string>coa-ethiopic</string>
+      <string>toa-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tsa</key>
     <array>
       <string>tsa-ethiopic</string>
-      <string>tsu-ethiopic</string>
-      <string>tsi-ethiopic</string>
-      <string>tsee-ethiopic</string>
       <string>tse-ethiopic</string>
+      <string>tsee-ethiopic</string>
+      <string>tsi-ethiopic</string>
       <string>tso-ethiopic</string>
+      <string>tsu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_tzi</key>
     <array>
-      <string>tzi-ethiopic</string>
       <string>tzaa-ethiopic</string>
       <string>tzee-ethiopic</string>
+      <string>tzi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_va</key>
     <array>
       <string>va-ethiopic</string>
-      <string>vu-ethiopic</string>
-      <string>vi-ethiopic</string>
       <string>vee-ethiopic</string>
+      <string>vi-ethiopic</string>
       <string>vo-ethiopic</string>
+      <string>vu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_vaa</key>
     <array>
@@ -12014,50 +12014,50 @@
     <key>public.kern2.ethi_wa</key>
     <array>
       <string>wa-ethiopic</string>
-      <string>wu-ethiopic</string>
       <string>we-ethiopic</string>
+      <string>wu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_wi</key>
     <array>
-      <string>wi-ethiopic</string>
       <string>waa-ethiopic</string>
       <string>wee-ethiopic</string>
+      <string>wi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_xa</key>
     <array>
       <string>xa-ethiopic</string>
-      <string>xu-ethiopic</string>
-      <string>xi-ethiopic</string>
       <string>xee-ethiopic</string>
+      <string>xi-ethiopic</string>
+      <string>xu-ethiopic</string>
       <string>xwa-ethiopic</string>
-      <string>xwi-ethiopic</string>
       <string>xwe-ethiopic</string>
+      <string>xwi-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ya</key>
     <array>
       <string>ya-ethiopic</string>
-      <string>yu-ethiopic</string>
-      <string>yi-ethiopic</string>
       <string>yee-ethiopic</string>
+      <string>yi-ethiopic</string>
       <string>yo-ethiopic</string>
+      <string>yu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_za</key>
     <array>
       <string>za-ethiopic</string>
-      <string>zu-ethiopic</string>
-      <string>zi-ethiopic</string>
       <string>zee-ethiopic</string>
+      <string>zi-ethiopic</string>
       <string>zo-ethiopic</string>
+      <string>zu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_ze</key>
     <array>
+      <string>dze-ethiopic</string>
       <string>ze-ethiopic</string>
       <string>zha-ethiopic</string>
-      <string>zhu-ethiopic</string>
-      <string>zhi-ethiopic</string>
       <string>zhee-ethiopic</string>
+      <string>zhi-ethiopic</string>
       <string>zho-ethiopic</string>
-      <string>dze-ethiopic</string>
+      <string>zhu-ethiopic</string>
     </array>
     <key>public.kern2.ethi_zhaa</key>
     <array>
@@ -12067,10 +12067,10 @@
     <key>public.kern2.ethi_zza</key>
     <array>
       <string>zza-ethiopic</string>
-      <string>zzu-ethiopic</string>
-      <string>zzi-ethiopic</string>
       <string>zzee-ethiopic</string>
+      <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
+      <string>zzu-ethiopic</string>
     </array>
     <key>public.kern2.f</key>
     <array>
@@ -12102,12 +12102,12 @@
     </array>
     <key>public.kern2.g</key>
     <array>
+      <string>de-cy.loclBGR</string>
       <string>g</string>
       <string>gbreve</string>
       <string>gcircumflex</string>
       <string>gcommaaccent</string>
       <string>gdotaccent</string>
-      <string>de-cy.loclBGR</string>
     </array>
     <key>public.kern2.gan-georgian</key>
     <array>
@@ -12121,14 +12121,14 @@
     </array>
     <key>public.kern2.gha-lao</key>
     <array>
-      <string>gha-lao</string>
       <string>dda-lao</string>
+      <string>gha-lao</string>
     </array>
     <key>public.kern2.ghan-georgian</key>
     <array>
       <string>don-georgian</string>
-      <string>las-georgian</string>
       <string>ghan-georgian</string>
+      <string>las-georgian</string>
     </array>
     <key>public.kern2.gimel-hb</key>
     <array>
@@ -12158,8 +12158,10 @@
     <key>public.kern2.h.sc</key>
     <array>
       <string>b.sc</string>
+      <string>be-cy.sc</string>
       <string>d.sc</string>
       <string>dcaron.sc</string>
+      <string>dzhe-cy.sc</string>
       <string>e.sc</string>
       <string>eacute.sc</string>
       <string>ebreve.sc</string>
@@ -12175,26 +12177,62 @@
       <string>edotbelow.sc</string>
       <string>egrave.sc</string>
       <string>ehookabove.sc</string>
+      <string>em-cy.sc</string>
       <string>emacron.sc</string>
+      <string>emtail-cy.sc</string>
+      <string>en-cy.sc</string>
+      <string>endescender-cy.sc</string>
+      <string>eng.sc</string>
+      <string>enghe-cy.sc</string>
+      <string>enhook-cy.sc</string>
+      <string>entail-cy.sc</string>
       <string>eogonek.sc</string>
+      <string>er-cy.sc</string>
+      <string>ertick-cy.sc</string>
       <string>etilde.sc</string>
       <string>f.sc</string>
+      <string>ge-cy.sc</string>
+      <string>gedescender-cy.sc</string>
+      <string>gestrokehook-cy.sc</string>
+      <string>ghemiddlehook-cy.sc</string>
+      <string>ghestroke-cy.loclBSH.sc</string>
+      <string>gheupturn-cy.sc</string>
+      <string>gje-cy.sc</string>
       <string>h.sc</string>
       <string>hcircumflex.sc</string>
+      <string>i-cy.sc</string>
       <string>i.sc</string>
       <string>iacute.sc</string>
       <string>ibreve.sc</string>
       <string>icircumflex.sc</string>
+      <string>idieresis-cy.sc</string>
       <string>idieresis.sc</string>
       <string>idotaccent.sc</string>
       <string>idotbelow.sc</string>
+      <string>ie-cy.sc</string>
+      <string>iebreve-cy.sc</string>
+      <string>iegrave-cy.sc</string>
       <string>igrave.sc</string>
       <string>ihookabove.sc</string>
+      <string>ii-cy.sc</string>
+      <string>iigrave-cy.sc</string>
+      <string>iishort-cy.sc</string>
+      <string>iishorttail-cy.sc</string>
+      <string>ij.sc</string>
+      <string>imacron-cy.sc</string>
       <string>imacron.sc</string>
+      <string>io-cy.sc</string>
       <string>iogonek.sc</string>
       <string>itilde.sc</string>
+      <string>iu-cy.sc</string>
       <string>k.sc</string>
+      <string>ka-cy.sc</string>
+      <string>kadescender-cy.sc</string>
+      <string>kahook-cy.sc</string>
+      <string>kaverticalstroke-cy.sc</string>
       <string>kcommaaccent.sc</string>
+      <string>khook.sc</string>
+      <string>kje-cy.sc</string>
       <string>l.sc</string>
       <string>lacute.sc</string>
       <string>lcaron.sc</string>
@@ -12205,80 +12243,42 @@
       <string>nacute.sc</string>
       <string>ncaron.sc</string>
       <string>ncommaaccent.sc</string>
-      <string>eng.sc</string>
+      <string>nje-cy.sc</string>
       <string>ntilde.sc</string>
       <string>p.sc</string>
-      <string>thorn.sc</string>
+      <string>palochka-cy.sc</string>
+      <string>pe-cy.sc</string>
+      <string>pedescender-cy.sc</string>
       <string>r.sc</string>
       <string>racute.sc</string>
       <string>rcaron.sc</string>
       <string>rcommaaccent.sc</string>
-      <string>be-cy.sc</string>
-      <string>ve-cy.sc</string>
-      <string>ge-cy.sc</string>
-      <string>gje-cy.sc</string>
-      <string>gheupturn-cy.sc</string>
-      <string>ie-cy.sc</string>
-      <string>iegrave-cy.sc</string>
-      <string>io-cy.sc</string>
-      <string>ii-cy.sc</string>
-      <string>iishort-cy.sc</string>
-      <string>iigrave-cy.sc</string>
-      <string>iishorttail-cy.sc</string>
-      <string>ka-cy.sc</string>
-      <string>kje-cy.sc</string>
-      <string>em-cy.sc</string>
-      <string>en-cy.sc</string>
-      <string>pe-cy.sc</string>
-      <string>er-cy.sc</string>
-      <string>tse-cy.sc</string>
       <string>sha-cy.sc</string>
       <string>shcha-cy.sc</string>
-      <string>dzhe-cy.sc</string>
-      <string>softsign-cy.sc</string>
-      <string>yeru-cy.sc</string>
-      <string>nje-cy.sc</string>
-      <string>i-cy.sc</string>
-      <string>yi-cy.sc</string>
-      <string>iu-cy.sc</string>
-      <string>ghemiddlehook-cy.sc</string>
-      <string>kadescender-cy.sc</string>
-      <string>kaverticalstroke-cy.sc</string>
-      <string>endescender-cy.sc</string>
-      <string>enghe-cy.sc</string>
-      <string>pedescender-cy.sc</string>
       <string>shha-cy.sc</string>
       <string>shhadescender-cy.sc</string>
-      <string>palochka-cy.sc</string>
-      <string>kahook-cy.sc</string>
-      <string>enhook-cy.sc</string>
-      <string>entail-cy.sc</string>
-      <string>emtail-cy.sc</string>
-      <string>iebreve-cy.sc</string>
-      <string>imacron-cy.sc</string>
-      <string>idieresis-cy.sc</string>
-      <string>gedescender-cy.sc</string>
+      <string>softsign-cy.sc</string>
+      <string>thorn.sc</string>
+      <string>tse-cy.sc</string>
+      <string>ve-cy.sc</string>
+      <string>yeru-cy.sc</string>
       <string>yerudieresis-cy.sc</string>
-      <string>gestrokehook-cy.sc</string>
-      <string>ertick-cy.sc</string>
-      <string>ghestroke-cy.loclBSH.sc</string>
-      <string>ij.sc</string>
-      <string>khook.sc</string>
+      <string>yi-cy.sc</string>
     </array>
     <key>public.kern2.het-hb</key>
     <array>
-      <string>he-hb</string>
-      <string>hedagesh-hb</string>
-      <string>het-hb</string>
       <string>finalkaf-hb</string>
-      <string>finalkafdagesh-hb</string>
-      <string>finalkafdagesh_sheva-hb</string>
-      <string>finalkafdagesh_qamats-hb</string>
-      <string>finalkaf_sheva-hb</string>
       <string>finalkaf_qamats-hb</string>
+      <string>finalkaf_sheva-hb</string>
+      <string>finalkafdagesh-hb</string>
+      <string>finalkafdagesh_qamats-hb</string>
+      <string>finalkafdagesh_sheva-hb</string>
       <string>finalmem-hb</string>
       <string>finalpe-hb</string>
       <string>finalpedagesh-hb</string>
+      <string>he-hb</string>
+      <string>hedagesh-hb</string>
+      <string>het-hb</string>
       <string>resh-hb</string>
       <string>reshdagesh-hb</string>
       <string>tav-hb</string>
@@ -12287,11 +12287,11 @@
     <key>public.kern2.i</key>
     <array>
       <string>i</string>
+      <string>i-cy</string>
       <string>idotbelow</string>
       <string>ihookabove</string>
-      <string>iogonek</string>
-      <string>i-cy</string>
       <string>ij</string>
+      <string>iogonek</string>
     </array>
     <key>public.kern2.i_left</key>
     <array>
@@ -12314,8 +12314,8 @@
     <key>public.kern2.j</key>
     <array>
       <string>j</string>
-      <string>jdotless</string>
       <string>jcircumflex</string>
+      <string>jdotless</string>
       <string>je-cy</string>
     </array>
     <key>public.kern2.j.sc</key>
@@ -12330,14 +12330,14 @@
     </array>
     <key>public.kern2.kmPstv</key>
     <array>
-      <string>yaSign-khmer</string>
       <string>ieSign-khmer</string>
-      <string>yaSign-khmer.below2</string>
       <string>ieSign-khmer.below2</string>
-      <string>yaSign-khmer.up</string>
-      <string>ieSign-khmer.up</string>
-      <string>yaSign-khmer.below2.up</string>
       <string>ieSign-khmer.below2.up</string>
+      <string>ieSign-khmer.up</string>
+      <string>yaSign-khmer</string>
+      <string>yaSign-khmer.below2</string>
+      <string>yaSign-khmer.below2.up</string>
+      <string>yaSign-khmer.up</string>
     </array>
     <key>public.kern2.km_da</key>
     <array>
@@ -12359,108 +12359,108 @@
     </array>
     <key>public.kern2.km_to</key>
     <array>
-      <string>to-khmer</string>
       <string>la-khmer</string>
-      <string>to_aaSign-khmer</string>
       <string>la_aaSign-khmer</string>
-      <string>to_auSign-khmer</string>
       <string>la_auSign-khmer</string>
+      <string>to-khmer</string>
+      <string>to_aaSign-khmer</string>
+      <string>to_auSign-khmer</string>
     </array>
     <key>public.kern2.l</key>
     <array>
       <string>b</string>
+      <string>bhook</string>
+      <string>dje-cy</string>
+      <string>germandbls</string>
       <string>h</string>
       <string>hbar</string>
       <string>hcircumflex</string>
+      <string>iu-cy.loclBGR</string>
       <string>k</string>
+      <string>k.alt</string>
+      <string>ka-cy.loclBGR</string>
+      <string>kastroke-cy</string>
       <string>kcommaaccent</string>
+      <string>khook</string>
       <string>l</string>
       <string>lacute</string>
       <string>lcaron</string>
       <string>lcommaaccent</string>
-      <string>thorn</string>
-      <string>germandbls</string>
-      <string>k.alt</string>
-      <string>tshe-cy</string>
-      <string>dje-cy</string>
-      <string>yat-cy</string>
-      <string>kastroke-cy</string>
-      <string>shha-cy</string>
-      <string>shhadescender-cy</string>
       <string>palochka-cy</string>
       <string>semisoftsign-cy</string>
+      <string>shha-cy</string>
+      <string>shhadescender-cy</string>
+      <string>thorn</string>
+      <string>tshe-cy</string>
       <string>ve-cy.loclBGR</string>
-      <string>ka-cy.loclBGR</string>
-      <string>iu-cy.loclBGR</string>
-      <string>bhook</string>
-      <string>khook</string>
+      <string>yat-cy</string>
     </array>
     <key>public.kern2.lamed-hb</key>
     <array>
       <string>lamed-hb</string>
-      <string>lameddagesh-hb</string>
-      <string>lamed_holam-hb</string>
       <string>lamed_dagesh_holam-hb</string>
+      <string>lamed_holam-hb</string>
+      <string>lameddagesh-hb</string>
       <string>qof-hb</string>
       <string>qofdagesh-hb</string>
     </array>
     <key>public.kern2.lc_straight</key>
     <array>
+      <string>dzhe-cy</string>
+      <string>em-cy</string>
+      <string>emtail-cy</string>
+      <string>en-cy</string>
+      <string>endescender-cy</string>
+      <string>eng</string>
+      <string>enghe-cy</string>
+      <string>enhook-cy</string>
+      <string>enlefthook-cy</string>
+      <string>entail-cy</string>
+      <string>ge-cy</string>
+      <string>gedescender-cy</string>
+      <string>gestrokehook-cy</string>
+      <string>ghemiddlehook-cy</string>
+      <string>ghestroke-cy</string>
+      <string>ghestroke-cy.loclBSH</string>
+      <string>gheupturn-cy</string>
+      <string>gje-cy</string>
+      <string>gje-cy.loclMKD</string>
+      <string>idieresis-cy</string>
       <string>idotless</string>
+      <string>ii-cy</string>
+      <string>iigrave-cy</string>
+      <string>iishort-cy</string>
+      <string>iishorttail-cy</string>
+      <string>imacron-cy</string>
+      <string>iu-cy</string>
+      <string>ka-cy</string>
+      <string>kadescender-cy</string>
+      <string>kahook-cy</string>
+      <string>kaverticalstroke-cy</string>
       <string>kgreenlandic</string>
+      <string>kje-cy</string>
       <string>m</string>
       <string>n</string>
       <string>nacute</string>
       <string>ncaron</string>
       <string>ncommaaccent</string>
-      <string>eng</string>
+      <string>nje-cy</string>
       <string>ntilde</string>
-      <string>rcommaaccent</string>
+      <string>pe-cy</string>
+      <string>pe-cy.loclBGR</string>
+      <string>pedescender-cy</string>
       <string>r_f</string>
       <string>r_f_f</string>
       <string>r_t</string>
-      <string>ve-cy</string>
-      <string>ge-cy</string>
-      <string>gje-cy</string>
-      <string>gheupturn-cy</string>
-      <string>ii-cy</string>
-      <string>iishort-cy</string>
-      <string>iigrave-cy</string>
-      <string>iishorttail-cy</string>
-      <string>ka-cy</string>
-      <string>kje-cy</string>
-      <string>em-cy</string>
-      <string>en-cy</string>
-      <string>pe-cy</string>
-      <string>tse-cy</string>
+      <string>rcommaaccent</string>
       <string>sha-cy</string>
       <string>shcha-cy</string>
-      <string>dzhe-cy</string>
       <string>softsign-cy</string>
-      <string>yeru-cy</string>
-      <string>nje-cy</string>
-      <string>iu-cy</string>
-      <string>ghestroke-cy</string>
-      <string>ghemiddlehook-cy</string>
-      <string>kadescender-cy</string>
-      <string>kaverticalstroke-cy</string>
-      <string>endescender-cy</string>
-      <string>enghe-cy</string>
-      <string>pedescender-cy</string>
-      <string>kahook-cy</string>
-      <string>enhook-cy</string>
-      <string>entail-cy</string>
-      <string>emtail-cy</string>
-      <string>imacron-cy</string>
-      <string>idieresis-cy</string>
-      <string>gedescender-cy</string>
-      <string>yerudieresis-cy</string>
-      <string>gestrokehook-cy</string>
-      <string>enlefthook-cy</string>
-      <string>pe-cy.loclBGR</string>
       <string>te-cy.loclBGR</string>
-      <string>ghestroke-cy.loclBSH</string>
-      <string>gje-cy.loclMKD</string>
+      <string>tse-cy</string>
+      <string>ve-cy</string>
+      <string>yeru-cy</string>
+      <string>yerudieresis-cy</string>
     </array>
     <key>public.kern2.man-georgian</key>
     <array>
@@ -12472,28 +12472,28 @@
     </array>
     <key>public.kern2.marks</key>
     <array>
-      <string>trademark</string>
       <string>servicemark</string>
+      <string>trademark</string>
     </array>
     <key>public.kern2.mem-hb</key>
     <array>
-      <string>tet-hb</string>
-      <string>tetdagesh-hb</string>
       <string>kaf-hb</string>
       <string>kafdagesh-hb</string>
       <string>kafrafe-hb</string>
       <string>mem-hb</string>
       <string>memdagesh-hb</string>
-      <string>samekh-hb</string>
-      <string>samekhdagesh-hb</string>
       <string>pe-hb</string>
       <string>pedagesh-hb</string>
       <string>perafe-hb</string>
+      <string>samekh-hb</string>
+      <string>samekhdagesh-hb</string>
+      <string>tet-hb</string>
+      <string>tetdagesh-hb</string>
     </array>
     <key>public.kern2.nar-georgian</key>
     <array>
-      <string>nar-georgian</string>
       <string>cil-georgian</string>
+      <string>nar-georgian</string>
     </array>
     <key>public.kern2.nun-hb</key>
     <array>
@@ -12503,16 +12503,33 @@
     </array>
     <key>public.kern2.o</key>
     <array>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>acircumflex.alt</string>
+      <string>adieresis.alt</string>
+      <string>ae.alt</string>
+      <string>aeacute.alt</string>
+      <string>agrave.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>aringacute.alt</string>
+      <string>atilde.alt</string>
       <string>c</string>
       <string>cacute</string>
       <string>ccaron</string>
       <string>ccedilla</string>
       <string>ccircumflex</string>
       <string>cdotaccent</string>
+      <string>cheabkhasian-cy</string>
+      <string>chedescenderabkhasian-cy</string>
       <string>d</string>
       <string>dcaron</string>
       <string>dcroat</string>
+      <string>dhook</string>
       <string>e</string>
+      <string>e-cy</string>
       <string>eacute</string>
       <string>ebreve</string>
       <string>ecaron</string>
@@ -12523,15 +12540,32 @@
       <string>ecircumflexhookabove</string>
       <string>ecircumflextilde</string>
       <string>edieresis</string>
+      <string>edieresis-cy</string>
       <string>edotaccent</string>
       <string>edotbelow</string>
+      <string>ef-cy</string>
+      <string>ef-cy.loclBGR</string>
       <string>egrave</string>
       <string>ehookabove</string>
       <string>emacron</string>
       <string>eogonek</string>
+      <string>eopen</string>
+      <string>es-cy</string>
+      <string>esdescender-cy</string>
+      <string>esdescender-cy.loclBSH</string>
+      <string>esdescender-cy.loclCHU</string>
       <string>etilde</string>
+      <string>fita-cy</string>
+      <string>haabkhasian-cy</string>
+      <string>ie-cy</string>
+      <string>iebreve-cy</string>
+      <string>iegrave-cy</string>
+      <string>io-cy</string>
       <string>o</string>
+      <string>o-cy</string>
       <string>oacute</string>
+      <string>obarred-cy</string>
+      <string>obarreddieresis-cy</string>
       <string>obreve</string>
       <string>ocircumflex</string>
       <string>ocircumflexacute</string>
@@ -12540,7 +12574,9 @@
       <string>ocircumflexhookabove</string>
       <string>ocircumflextilde</string>
       <string>odieresis</string>
+      <string>odieresis-cy</string>
       <string>odotbelow</string>
+      <string>oe</string>
       <string>ograve</string>
       <string>ohookabove</string>
       <string>ohorn</string>
@@ -12554,48 +12590,12 @@
       <string>oslash</string>
       <string>oslashacute</string>
       <string>otilde</string>
-      <string>oe</string>
       <string>q</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>aringacute.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>aeacute.alt</string>
-      <string>ie-cy</string>
-      <string>iegrave-cy</string>
-      <string>io-cy</string>
-      <string>o-cy</string>
-      <string>es-cy</string>
-      <string>ef-cy</string>
-      <string>e-cy</string>
-      <string>fita-cy</string>
-      <string>haabkhasian-cy</string>
-      <string>esdescender-cy</string>
-      <string>cheabkhasian-cy</string>
-      <string>chedescenderabkhasian-cy</string>
-      <string>iebreve-cy</string>
+      <string>qa-cy</string>
+      <string>reversedze-cy</string>
+      <string>schwa</string>
       <string>schwa-cy</string>
       <string>schwadieresis-cy</string>
-      <string>odieresis-cy</string>
-      <string>obarred-cy</string>
-      <string>obarreddieresis-cy</string>
-      <string>edieresis-cy</string>
-      <string>reversedze-cy</string>
-      <string>qa-cy</string>
-      <string>ef-cy.loclBGR</string>
-      <string>esdescender-cy.loclBSH</string>
-      <string>esdescender-cy.loclCHU</string>
-      <string>dhook</string>
-      <string>eopen</string>
-      <string>schwa</string>
     </array>
     <key>public.kern2.o.sc</key>
     <array>
@@ -12605,13 +12605,29 @@
       <string>ccedilla.sc</string>
       <string>ccircumflex.sc</string>
       <string>cdotaccent.sc</string>
+      <string>cheabkhasian-cy.sc</string>
+      <string>chedescenderabkhasian-cy.sc</string>
+      <string>e-cy.sc</string>
+      <string>edieresis-cy.sc</string>
+      <string>ef-cy.loclBGR.sc</string>
+      <string>eopen.sc</string>
+      <string>ereversed-cy.sc</string>
+      <string>es-cy.sc</string>
+      <string>esdescender-cy.loclBSH.sc</string>
+      <string>esdescender-cy.loclCHU.sc</string>
+      <string>esdescender-cy.sc</string>
+      <string>fita-cy.sc</string>
       <string>g.sc</string>
       <string>gbreve.sc</string>
       <string>gcircumflex.sc</string>
       <string>gcommaaccent.sc</string>
       <string>gdotaccent.sc</string>
+      <string>haabkhasian-cy.sc</string>
+      <string>o-cy.sc</string>
       <string>o.sc</string>
       <string>oacute.sc</string>
+      <string>obarred-cy.sc</string>
+      <string>obarreddieresis-cy.sc</string>
       <string>obreve.sc</string>
       <string>ocircumflex.sc</string>
       <string>ocircumflexacute.sc</string>
@@ -12619,8 +12635,10 @@
       <string>ocircumflexgrave.sc</string>
       <string>ocircumflexhookabove.sc</string>
       <string>ocircumflextilde.sc</string>
+      <string>odieresis-cy.sc</string>
       <string>odieresis.sc</string>
       <string>odotbelow.sc</string>
+      <string>oe.sc</string>
       <string>ograve.sc</string>
       <string>ohookabove.sc</string>
       <string>ohorn.sc</string>
@@ -12634,30 +12652,12 @@
       <string>oslash.sc</string>
       <string>oslashacute.sc</string>
       <string>otilde.sc</string>
-      <string>oe.sc</string>
       <string>q.sc</string>
-      <string>o-cy.sc</string>
-      <string>es-cy.sc</string>
-      <string>e-cy.sc</string>
-      <string>ereversed-cy.sc</string>
-      <string>fita-cy.sc</string>
-      <string>haabkhasian-cy.sc</string>
-      <string>esdescender-cy.sc</string>
-      <string>cheabkhasian-cy.sc</string>
-      <string>chedescenderabkhasian-cy.sc</string>
-      <string>schwa-cy.sc</string>
-      <string>schwadieresis-cy.sc</string>
-      <string>odieresis-cy.sc</string>
-      <string>obarred-cy.sc</string>
-      <string>obarreddieresis-cy.sc</string>
-      <string>edieresis-cy.sc</string>
-      <string>reversedze-cy.sc</string>
       <string>qa-cy.sc</string>
-      <string>ef-cy.loclBGR.sc</string>
-      <string>esdescender-cy.loclBSH.sc</string>
-      <string>esdescender-cy.loclCHU.sc</string>
-      <string>eopen.sc</string>
+      <string>reversedze-cy.sc</string>
+      <string>schwa-cy.sc</string>
       <string>schwa.sc</string>
+      <string>schwadieresis-cy.sc</string>
     </array>
     <key>public.kern2.o.sc.ss04</key>
     <array>
@@ -12679,10 +12679,10 @@
     </array>
     <key>public.kern2.p</key>
     <array>
-      <string>p</string>
       <string>er-cy</string>
       <string>ertick-cy</string>
       <string>micro</string>
+      <string>p</string>
     </array>
     <key>public.kern2.percent</key>
     <array>
@@ -12692,51 +12692,51 @@
     </array>
     <key>public.kern2.period</key>
     <array>
-      <string>period</string>
       <string>comma</string>
-      <string>ellipsis</string>
       <string>comma.alt</string>
       <string>comma.loclDEVA</string>
+      <string>ellipsis</string>
       <string>ellipsis.loclDEVA</string>
+      <string>period</string>
       <string>period.loclDEVA</string>
     </array>
     <key>public.kern2.periodcentered</key>
     <array>
-      <string>periodcentered</string>
       <string>anoteleia</string>
       <string>anoteleia.case</string>
       <string>anoteleia.sc</string>
+      <string>periodcentered</string>
     </array>
     <key>public.kern2.question</key>
     <array>
-      <string>question</string>
       <string>doublequestion</string>
-      <string>questionexclamation</string>
+      <string>question</string>
       <string>question.loclDEVA</string>
+      <string>questionexclamation</string>
     </array>
     <key>public.kern2.quotebase</key>
     <array>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
       <string>lowernumeral-greek</string>
+      <string>quotedblbase</string>
+      <string>quotesinglbase</string>
     </array>
     <key>public.kern2.quoteleft</key>
     <array>
       <string>quotedblleft</string>
-      <string>quoteleft</string>
       <string>quotedblleft.loclDEVA</string>
+      <string>quoteleft</string>
       <string>quoteleft.loclDEVA</string>
     </array>
     <key>public.kern2.quoteright</key>
     <array>
-      <string>quotedblright</string>
-      <string>quoteright</string>
-      <string>quoteright.alt</string>
-      <string>numeral-greek</string>
       <string>apostrophe-arm</string>
       <string>apostrophe-arm.case</string>
       <string>apostrophe-arm.sc</string>
+      <string>numeral-greek</string>
+      <string>quotedblright</string>
       <string>quotedblright.loclDEVA</string>
+      <string>quoteright</string>
+      <string>quoteright.alt</string>
       <string>quoteright.loclDEVA</string>
     </array>
     <key>public.kern2.quotesingle</key>
@@ -12747,9 +12747,9 @@
     <key>public.kern2.r</key>
     <array>
       <string>r</string>
+      <string>r.alt</string>
       <string>racute</string>
       <string>rcaron</string>
-      <string>r.alt</string>
     </array>
     <key>public.kern2.ro-khmer</key>
     <array>
@@ -12757,24 +12757,24 @@
     </array>
     <key>public.kern2.s</key>
     <array>
+      <string>dze-cy</string>
       <string>s</string>
       <string>sacute</string>
       <string>scaron</string>
       <string>scedilla</string>
       <string>scircumflex</string>
       <string>scommaaccent</string>
-      <string>dze-cy</string>
       <string>sdotbelow</string>
     </array>
     <key>public.kern2.s.sc</key>
     <array>
+      <string>dze-cy.sc</string>
       <string>s.sc</string>
       <string>sacute.sc</string>
       <string>scaron.sc</string>
       <string>scedilla.sc</string>
       <string>scircumflex.sc</string>
       <string>scommaaccent.sc</string>
-      <string>dze-cy.sc</string>
       <string>sdotbelow.sc</string>
     </array>
     <key>public.kern2.seven</key>
@@ -12785,55 +12785,55 @@
     <array>
       <string>ayin-hb</string>
       <string>shin-hb</string>
-      <string>shinshindot-hb</string>
-      <string>shinsindot-hb</string>
+      <string>shindagesh-hb</string>
       <string>shindageshshindot-hb</string>
       <string>shindageshsindot-hb</string>
-      <string>shindagesh-hb</string>
+      <string>shinshindot-hb</string>
+      <string>shinsindot-hb</string>
     </array>
     <key>public.kern2.slash</key>
     <array>
-      <string>slash</string>
       <string>divisionslash</string>
+      <string>slash</string>
     </array>
     <key>public.kern2.t</key>
     <array>
       <string>t</string>
+      <string>t_f</string>
+      <string>t_t</string>
       <string>tbar</string>
       <string>tcaron</string>
       <string>tcedilla</string>
       <string>tcommaaccent</string>
-      <string>t_f</string>
-      <string>t_t</string>
     </array>
     <key>public.kern2.t.sc</key>
     <array>
+      <string>dje-cy.sc</string>
+      <string>hardsign-cy.sc</string>
+      <string>kabashkir-cy.sc</string>
       <string>t.sc</string>
       <string>tbar.sc</string>
       <string>tcaron.sc</string>
       <string>tcedilla.sc</string>
       <string>tcommaaccent.sc</string>
       <string>te-cy.sc</string>
-      <string>hardsign-cy.sc</string>
-      <string>tshe-cy.sc</string>
-      <string>dje-cy.sc</string>
-      <string>kabashkir-cy.sc</string>
       <string>tedescender-cy.sc</string>
       <string>tetse-cy.sc</string>
+      <string>tshe-cy.sc</string>
     </array>
     <key>public.kern2.thai-boBaimai</key>
     <array>
-      <string>thoThahan-thai</string>
-      <string>noNu-thai</string>
-      <string>noNu_underscore-thai</string>
       <string>boBaimai-thai</string>
-      <string>poPla-thai</string>
-      <string>soRusi-thai</string>
       <string>foFan-thai</string>
-      <string>phoPhan-thai</string>
       <string>hoHip-thai</string>
       <string>loChula-thai</string>
       <string>loChula-thai.short</string>
+      <string>noNu-thai</string>
+      <string>noNu_underscore-thai</string>
+      <string>phoPhan-thai</string>
+      <string>poPla-thai</string>
+      <string>soRusi-thai</string>
+      <string>thoThahan-thai</string>
     </array>
     <key>public.kern2.thai-khoKhuat</key>
     <array>
@@ -12852,6 +12852,13 @@
     </array>
     <key>public.kern2.u</key>
     <array>
+      <string>ii-cy.loclBGR</string>
+      <string>iigrave-cy.loclBGR</string>
+      <string>iishort-cy.loclBGR</string>
+      <string>sha-cy.loclBGR</string>
+      <string>shcha-cy.loclBGR</string>
+      <string>softsign-cy.loclBGR</string>
+      <string>tse-cy.loclBGR</string>
       <string>u</string>
       <string>uacute</string>
       <string>ubreve</string>
@@ -12871,22 +12878,15 @@
       <string>uogonek</string>
       <string>uring</string>
       <string>utilde</string>
-      <string>ii-cy.loclBGR</string>
-      <string>iishort-cy.loclBGR</string>
-      <string>iigrave-cy.loclBGR</string>
-      <string>tse-cy.loclBGR</string>
-      <string>sha-cy.loclBGR</string>
-      <string>shcha-cy.loclBGR</string>
-      <string>softsign-cy.loclBGR</string>
       <string>yeru-cy.loclBGR</string>
     </array>
     <key>public.kern2.u-cy.sc</key>
     <array>
       <string>u-cy.sc</string>
-      <string>ushort-cy.sc</string>
-      <string>umacron-cy.sc</string>
       <string>udieresis-cy.sc</string>
       <string>uhungarumlaut-cy.sc</string>
+      <string>umacron-cy.sc</string>
+      <string>ushort-cy.sc</string>
     </array>
     <key>public.kern2.u.sc</key>
     <array>
@@ -12912,15 +12912,15 @@
     </array>
     <key>public.kern2.v</key>
     <array>
-      <string>v</string>
       <string>izhitsa-cy</string>
       <string>ustraight-cy</string>
       <string>ustraightstroke-cy</string>
+      <string>v</string>
     </array>
     <key>public.kern2.v.sc</key>
     <array>
-      <string>v.sc</string>
       <string>izhitsa-cy.sc</string>
+      <string>v.sc</string>
     </array>
     <key>public.kern2.w</key>
     <array>
@@ -12928,8 +12928,8 @@
       <string>wacute</string>
       <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>wgrave</string>
       <string>we-cy</string>
+      <string>wgrave</string>
     </array>
     <key>public.kern2.w.sc</key>
     <array>
@@ -12937,61 +12937,61 @@
       <string>wacute.sc</string>
       <string>wcircumflex.sc</string>
       <string>wdieresis.sc</string>
-      <string>wgrave.sc</string>
       <string>we-cy.sc</string>
+      <string>wgrave.sc</string>
     </array>
     <key>public.kern2.x</key>
     <array>
-      <string>x</string>
       <string>ha-cy</string>
       <string>hadescender-cy</string>
       <string>hahook-cy</string>
       <string>hastroke-cy</string>
+      <string>x</string>
     </array>
     <key>public.kern2.x.sc</key>
     <array>
-      <string>x.sc</string>
       <string>ha-cy.sc</string>
       <string>hadescender-cy.sc</string>
       <string>hahook-cy.sc</string>
       <string>hastroke-cy.sc</string>
+      <string>x.sc</string>
     </array>
     <key>public.kern2.y</key>
     <array>
+      <string>u-cy</string>
+      <string>udieresis-cy</string>
+      <string>uhungarumlaut-cy</string>
+      <string>umacron-cy</string>
+      <string>ushort-cy</string>
       <string>y</string>
       <string>yacute</string>
       <string>ycircumflex</string>
       <string>ydieresis</string>
       <string>ydotbelow</string>
       <string>ygrave</string>
+      <string>yhook</string>
       <string>yhookabove</string>
       <string>ytilde</string>
-      <string>u-cy</string>
-      <string>ushort-cy</string>
-      <string>umacron-cy</string>
-      <string>udieresis-cy</string>
-      <string>uhungarumlaut-cy</string>
-      <string>yhook</string>
     </array>
     <key>public.kern2.y.sc</key>
     <array>
+      <string>ustraightstroke-cy.sc</string>
       <string>y.sc</string>
       <string>yacute.sc</string>
       <string>ycircumflex.sc</string>
       <string>ydieresis.sc</string>
       <string>ydotbelow.sc</string>
       <string>ygrave.sc</string>
+      <string>yhook.sc</string>
       <string>yhookabove.sc</string>
       <string>ytilde.sc</string>
-      <string>ustraightstroke-cy.sc</string>
-      <string>yhook.sc</string>
     </array>
     <key>public.kern2.yod-hb</key>
     <array>
       <string>vavyod-hb</string>
-      <string>yodyod-hb</string>
       <string>yod-hb</string>
       <string>yoddagesh-hb</string>
+      <string>yodyod-hb</string>
       <string>yodyodpatah-hb</string>
     </array>
     <key>public.kern2.z</key>


### PR DESCRIPTION
- (CYR - UPR and ITAL)  Iu and iu glyphs compatibility and refreshed metrics
- (UPR & ITAL) fixed: Fivethousand-roman, Tenthousand-roman, zeropercent, percentbar, percent, pertenthousand, perthousand,
- (CYR - UPR and ITAL) Updated point placement of Iu and iu glyphs
- (ITAL): fixed compatibility of non-Latin glyphs
- (UPR): fixed compatibility of non-Latin glyphs
- (ITAL) updated latin ligature anchors
- (UPR) updated latin ligature anchors
- t_f anchor update
- Ignore (ital): glyphs roundtrip diffs
- Ligatures fix (Ital): component order
- Ligatures fix: component order

Fixes: https://github.com/googlefonts/googlesans/issues/526 https://github.com/googlefonts/googlesans/issues/591 https://github.com/googlefonts/googlesans/issues/607 https://github.com/googlefonts/googlesans/issues/606