### PR TITLE
Stop GRAD reflow with gs-fix-grad-widths.py

### DIFF
--- a/scripts/gs-fix-grad-widths.py
+++ b/scripts/gs-fix-grad-widths.py
@@ -40,11 +40,11 @@ DEFAULT_GRADE_UFO_MAP = {
 TARGET_DIR = Path("source/GoogleSans/")
 
 for src, grad_master_list in DEFAULT_GRADE_UFO_MAP.items():
-    default_master = Font(TARGET_DIR / src)
+    default_master = Font.open(TARGET_DIR / src)
     min_master_path = grad_master_list[0]
     max_master_path = grad_master_list[1]
-    min_master = Font(TARGET_DIR / min_master_path)
-    max_master = Font(TARGET_DIR / max_master_path)
+    min_master = Font.open(TARGET_DIR / min_master_path)
+    max_master = Font.open(TARGET_DIR / max_master_path)
 
     for glyph in default_master:
         min_target_glyph = min_master[glyph.name]

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/C_heabkhasian-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/C_heabkhasian-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Cheabkhasian-cy" format="2">
-  <advance width="859"/>
+  <advance width="861"/>
   <unicode hex="04BC"/>
   <guideline x="194" y="338" angle="0" identifier="tpBTEbB8Sy"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_e-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_e-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Ge-cy" format="2">
-  <advance width="525"/>
+  <advance width="530"/>
   <unicode hex="0413"/>
   <anchor x="79" y="0" name="bottomright"/>
   <anchor x="287" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="525"/>
+  <advance height="1252" width="530"/>
   <unicode hex="0490"/>
   <anchor x="84" y="0" name="bottomright"/>
   <anchor x="292" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/K_a-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/K_a-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Ka-cy" format="2">
-  <advance width="605"/>
+  <advance width="606"/>
   <unicode hex="041A"/>
   <guideline x="565" y="702" angle="90" identifier="quCZD59Kyh"/>
   <anchor x="593" y="0" name="bottomright"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/be-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/be-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="be-cy" format="2">
-  <advance width="565"/>
+  <advance width="586"/>
   <unicode hex="0431"/>
   <guideline x="499" y="272" angle="90" identifier="BM2w67wJ8p"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/dje-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/dje-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dje-cy" format="2">
-  <advance width="579"/>
+  <advance width="577"/>
   <unicode hex="0452"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/elhook-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/elhook-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="elhook-cy.sc" format="2">
-  <advance width="580"/>
+  <advance width="585"/>
   <outline>
     <contour>
       <point x="340" y="-136" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ge-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ge-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ge-cy.sc" format="2">
-  <advance width="470"/>
+  <advance width="465"/>
   <anchor x="136" y="290" name="center"/>
   <anchor x="258" y="580" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="257"/>
+  <advance width="258"/>
   <outline>
     <component base="comma"/>
     <component base="period" xOffset="6" yOffset="396"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/upturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/upturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturn-cy" format="2">
-  <advance width="525"/>
+  <advance width="530"/>
   <outline>
     <contour>
       <point x="429" y="686" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/upturnsc-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/upturnsc-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturnsc-cy" format="2">
-  <advance width="470"/>
+  <advance width="465"/>
   <outline>
     <contour>
       <point x="376" y="552" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="E-cy" format="2">
-  <advance width="707"/>
+  <advance width="705"/>
   <unicode hex="0404"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_lhook-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_lhook-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Elhook-cy" format="2">
-  <advance width="687"/>
+  <advance width="690"/>
   <unicode hex="0512"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_nghe-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/E_nghe-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Enghe-cy" format="2">
-  <advance width="901"/>
+  <advance width="904"/>
   <unicode hex="04A4"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_e-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_e-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Ge-cy" format="2">
-  <advance width="524"/>
+  <advance width="530"/>
   <unicode hex="0413"/>
   <anchor x="78" y="0" name="bottomright"/>
   <anchor x="286" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="524"/>
+  <advance height="1252" width="530"/>
   <unicode hex="0490"/>
   <anchor x="84" y="0" name="bottomright"/>
   <anchor x="292" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/Z_he-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/Z_he-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Zhe-cy" format="2">
-  <advance width="881"/>
+  <advance width="883"/>
   <unicode hex="0416"/>
   <anchor x="442" y="716" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/be-cy.loclS_R_B_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/be-cy.loclS_R_B_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="be-cy.loclSRB" format="2">
-  <advance width="603"/>
+  <advance width="596"/>
   <guideline x="297" y="258" angle="90" identifier="Jt9lKMc8GG"/>
   <guideline x="499" y="258" angle="90" identifier="bk85K2aTnc"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/elhook-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/elhook-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="elhook-cy" format="2">
-  <advance width="569"/>
+  <advance width="554"/>
   <unicode hex="0513"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/enlefthook-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/enlefthook-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="enlefthook-cy" format="2">
-  <advance width="562"/>
+  <advance width="572"/>
   <unicode hex="0529"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="264"/>
+  <advance width="258"/>
   <outline>
     <component base="comma"/>
     <component base="period" xOffset="6" yOffset="396"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/upturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/upturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturn-cy" format="2">
-  <advance width="524"/>
+  <advance width="530"/>
   <outline>
     <contour>
       <point x="378" y="658" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_e-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_e-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Ge-cy" format="2">
-  <advance width="500"/>
+  <advance width="505"/>
   <unicode hex="0413"/>
   <anchor x="75" y="0" name="bottomright"/>
   <anchor x="274" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="500"/>
+  <advance height="1252" width="505"/>
   <unicode hex="0490"/>
   <anchor x="80" y="0" name="bottomright"/>
   <anchor x="279" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/elhook-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/elhook-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="elhook-cy.sc" format="2">
-  <advance width="605"/>
+  <advance width="610"/>
   <outline>
     <contour>
       <point x="347" y="-136" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ge-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ge-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ge-cy" format="2">
-  <advance width="411"/>
+  <advance width="410"/>
   <unicode hex="0433"/>
   <anchor x="64" y="0" name="bottomright"/>
   <anchor x="206" y="255" name="center"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ge-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ge-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ge-cy.sc" format="2">
-  <advance width="457"/>
+  <advance width="452"/>
   <anchor x="150" y="255" name="center"/>
   <anchor x="254" y="580" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gheupturn-cy" format="2">
-  <advance height="1252" width="411"/>
+  <advance height="1252" width="410"/>
   <unicode hex="0491"/>
   <anchor x="63" y="0" name="bottomright"/>
   <anchor x="205" y="255" name="center"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.sc.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gheupturn-cy.sc" format="2">
-  <advance height="1252" width="457"/>
+  <advance height="1252" width="452"/>
   <anchor x="145" y="255" name="center"/>
   <anchor x="249" y="580" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/upturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/upturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturn-cy" format="2">
-  <advance width="500"/>
+  <advance width="505"/>
   <outline>
     <contour>
       <point x="408" y="686" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/upturnlc-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/upturnlc-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturnlc-cy" format="2">
-  <advance width="411"/>
+  <advance width="410"/>
   <outline>
     <contour>
       <point x="302" y="481" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/upturnsc-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/upturnsc-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturnsc-cy" format="2">
-  <advance width="457"/>
+  <advance width="452"/>
   <outline>
     <contour>
       <point x="368" y="553" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ze-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ze-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ze-cy" format="2">
-  <advance width="478"/>
+  <advance width="479"/>
   <unicode hex="0437"/>
   <anchor x="243" y="0" name="bottom"/>
   <anchor x="234" y="510" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/D_zeabkhasian-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/D_zeabkhasian-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dzeabkhasian-cy" format="2">
-  <advance width="579"/>
+  <advance width="585"/>
   <unicode hex="04E0"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_lhook-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/E_lhook-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Elhook-cy" format="2">
-  <advance width="690"/>
+  <advance width="693"/>
   <unicode hex="0512"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_e-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_e-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Ge-cy" format="2">
-  <advance width="499"/>
+  <advance width="505"/>
   <unicode hex="0413"/>
   <anchor x="74" y="0" name="bottomright"/>
   <anchor x="273" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="499"/>
+  <advance height="1252" width="505"/>
   <unicode hex="0490"/>
   <anchor x="80" y="0" name="bottomright"/>
   <anchor x="279" y="716" name="top"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/Z_e-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/Z_e-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Ze-cy" format="2">
-  <advance width="590"/>
+  <advance width="591"/>
   <unicode hex="0417"/>
   <guideline x="273" y="181" angle="90" identifier="tkq42pMkTo"/>
   <anchor x="292" y="0" name="bottom"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/hahook-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/hahook-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hahook-cy" format="2">
-  <advance width="482"/>
+  <advance width="487"/>
   <unicode hex="04FD"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/lje-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/lje-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lje-cy" format="2">
-  <advance width="789"/>
+  <advance width="805"/>
   <unicode hex="0459"/>
   <outline>
     <contour>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="246"/>
+  <advance width="243"/>
   <outline>
     <component base="comma"/>
     <component base="period" yOffset="379"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/upturn-cy.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/upturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="upturn-cy" format="2">
-  <advance width="499"/>
+  <advance width="505"/>
   <outline>
     <contour>
       <point x="357" y="658" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/zhe-cy.loclB_G_R_.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/zhe-cy.loclB_G_R_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="zhe-cy.loclBGR" format="2">
-  <advance width="729"/>
+  <advance width="739"/>
   <outline>
     <contour>
       <point x="-6" y="0" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/acaron.alt.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/acaron.alt.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acaron.alt" format="2">
-  <advance width="601"/>
+  <advance width="600"/>
   <anchor x="255" y="0" name="bottom"/>
   <anchor x="482" y="0" name="ogonek"/>
   <anchor x="391" y="776" name="top"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/baht.tf.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/baht.tf.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="baht.tf" format="2">
-  <advance width="635"/>
+  <advance width="600"/>
   <outline>
     <component base="baht"/>
   </outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gheupturn-cy" format="2">
-  <advance height="1252" width="419"/>
+  <advance height="1252" width="420"/>
   <unicode hex="0491"/>
   <anchor x="27" y="0" name="bottomright"/>
   <anchor x="215" y="263" name="center"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/gheupturn-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gheupturn-cy.sc" format="2">
-  <advance height="1252" width="465"/>
+  <advance height="1252" width="466"/>
   <anchor x="136" y="290" name="center"/>
   <anchor x="309" y="580" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="259"/>
+  <advance width="257"/>
   <outline>
     <component base="comma"/>
     <component base="period" xOffset="69" yOffset="396"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="535"/>
+  <advance height="1252" width="530"/>
   <unicode hex="0490"/>
   <anchor x="43" y="0" name="bottomright"/>
   <anchor x="279" y="358" name="center"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/acaron.alt.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/acaron.alt.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acaron.alt" format="2">
-  <advance width="591"/>
+  <advance width="600"/>
   <anchor x="250" y="0" name="bottom"/>
   <anchor x="477" y="0" name="ogonek"/>
   <anchor x="386" y="776" name="top"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="250"/>
+  <advance width="257"/>
   <outline>
     <component base="comma"/>
     <component base="period" xOffset="69" yOffset="396"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="506"/>
+  <advance height="1252" width="505"/>
   <unicode hex="0490"/>
   <anchor x="34" y="0" name="bottomright"/>
   <anchor x="145" y="358" name="center"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/M_en_E_ch-arm.liga.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/M_en_E_ch-arm.liga.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Men_Ech-arm.liga" format="2">
-  <advance width="1398"/>
+  <advance width="1404"/>
   <outline>
     <component base="Men-arm"/>
     <component base="Ech-arm" xOffset="785"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/iu-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="785"/>
+  <advance width="786"/>
   <unicode hex="044E"/>
   <anchor x="450" y="510" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/men_xeh-arm.liga.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/men_xeh-arm.liga.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="men_xeh-arm.liga.sc" format="2">
-  <advance width="1420"/>
+  <advance width="1419"/>
   <outline>
     <component base="men-arm.sc"/>
     <component base="xeh-arm.sc" xOffset="655"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="247"/>
+  <advance width="249"/>
   <outline>
     <component base="comma" xOffset="6"/>
     <component base="period" xOffset="68" yOffset="379"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_heupturn-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Gheupturn-cy" format="2">
-  <advance height="1252" width="510"/>
+  <advance height="1252" width="505"/>
   <unicode hex="0490"/>
   <anchor x="39" y="0" name="bottomright"/>
   <anchor x="150" y="358" name="center"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/M_en_E_ch-arm.liga.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/M_en_E_ch-arm.liga.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Men_Ech-arm.liga" format="2">
-  <advance width="1398"/>
+  <advance width="1404"/>
   <outline>
     <component base="Men-arm"/>
     <component base="Ech-arm" xOffset="785"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/acaron.alt.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/acaron.alt.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acaron.alt" format="2">
-  <advance width="597"/>
+  <advance width="606"/>
   <anchor x="272" y="0" name="bottom"/>
   <anchor x="493" y="0" name="ogonek"/>
   <anchor x="365" y="736" name="top"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/gheupturn-cy.sc.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/gheupturn-cy.sc.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gheupturn-cy.sc" format="2">
-  <advance height="1252" width="452"/>
+  <advance height="1252" width="453"/>
   <anchor x="145" y="255" name="center"/>
   <anchor x="306" y="580" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/iu-cy.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="iu-cy" format="2">
-  <advance width="785"/>
+  <advance width="786"/>
   <unicode hex="044E"/>
   <anchor x="450" y="510" name="top"/>
   <outline>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/semicolon.loclA_R_M_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon.loclARM" format="2">
-  <advance width="242"/>
+  <advance width="249"/>
   <outline>
     <component base="comma" xOffset="9"/>
     <component base="period" xOffset="71" yOffset="379"/>


### PR DESCRIPTION
This PR automatically adjusts the width of some glyphs in the GRAD masters (see #584) to prevent reflow as the GRAD axis is varied. It is marked as WIP as the changes will require manual review to ensure that the glyphs are still centred and spaced correctly.

In addition, the 'fix GRAD widths' script has been lightly updated to work with newer versions of ufoLib2.