### PR TITLE
Tweak avar to fix opsz 18 on Firefox MacOS

### DIFF
--- a/source/GoogleSans/GoogleSans-Italic.designspace
+++ b/source/GoogleSans/GoogleSans-Italic.designspace
@@ -3,7 +3,7 @@
   <axes>
     <axis tag="opsz" name="Size" minimum="17" maximum="18" default="18">
       <map input="17" output="17"/>
-      <map input="17.99" output="17.1"/>
+      <map input="17.9" output="17.11"/>
       <map input="18" output="18"/>
     </axis>
     <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400">

--- a/source/GoogleSans/GoogleSans.designspace
+++ b/source/GoogleSans/GoogleSans.designspace
@@ -3,7 +3,7 @@
   <axes>
     <axis tag="opsz" name="Size" minimum="17" maximum="18" default="18">
       <map input="17" output="17"/>
-      <map input="17.99" output="17.1"/>
+      <map input="17.9" output="17.11"/>
       <map input="18" output="18"/>
     </axis>
     <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400">


### PR DESCRIPTION
Fixes #462 

I had a look at the [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1758147) and also figured I could try twiddling the numbers a bit and seeing if it would work. Lo and behold, we get Google G now in Firefox on MacOS at opsz 18!