### PR TITLE
Rewrite diffenator2 workflow

### DIFF
--- a/.github/workflows/diffenate.yml
+++ b/.github/workflows/diffenate.yml
@@ -1,86 +1,93 @@
-name: Compare VFs against previous release
+name: Diffenate builds
 
 on:
-  push:
-    branches:
-      - "diff-*"
+  workflow_dispatch:
+    inputs:
+      before:
+        description: The 'before' git reference (tag, branch, or commit)
+        required: true
+      after:
+        description: The 'after' git reference (tag, branch, or commit)
+        required: true
 
 jobs:
-  build-variable:
-    runs-on: [googlefonts-64cores-256GB]
+  build-before:
+    runs-on: [linux, googlefonts-64cores-256GB]
+    timeout-minutes: 10
     steps:
-      - name: Check out source repository
-        uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-      - name: Build variable fonts
-        run: |
-          make setup
-          . .venv/bin/activate && make -j gs-vf
-      - uses: actions/upload-artifact@v3
-        with:
-          name: variable-fonts
-          path: 'build/GoogleSans/variable'
-
-  screenshot:
+    - name: Checkout ${{ inputs.before }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.before }}
+    - name: Setup Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+    - name: Setup venv
+      run: make setup
+    - name: Build fonts
+      run: source .venv/bin/activate && make gs-vf
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Before VFs (${{ inputs.before }})
+        path: build/GoogleSans/variable
+        if-no-files-found: error
+  build-after:
+    runs-on: [linux, googlefonts-64cores-256GB]
+    timeout-minutes: 10
+    steps:
+    - name: Checkout ${{ inputs.after }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.after }}
+    - name: Setup Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+    - name: Setup venv
+      run: make setup
+    - name: Build fonts
+      run: source .venv/bin/activate && make gs-vf
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: After VFs (${{ inputs.after }})
+        path: build/GoogleSans/variable
+        if-no-files-found: error
+  diffenate:
+    runs-on: [linux, googlefonts-64cores-256GB]
+    timeout-minutes: 20
     needs:
-      - build-variable
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    - build-before
+    - build-after
     steps:
-      - name: Check out source repository
-        uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-      - uses: actions/download-artifact@v3
-        with:
-          name: variable-fonts
-          path: 'build/GoogleSans/variable'
-      - name: Browser Screenshots
-        uses: f-actions/diffenator2@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: build/GoogleSans/variable/*.ttf
-          fetch-before: 'github-release'
-          repo: 'googlefonts/googlesans'
-          path-before: build/GoogleSans/variable/*.ttf
-          run-diffenator: false
-          run-diffbrowsers: true
-          filter-styles: "Regular|Italic|Bold|Bold Italic|Text Regular|Text Italic|Text Bold|Text Bold Italic"
-
-  diffenator:
-    needs:
-      - build-variable
-    runs-on: [googlefonts-64cores-256GB]
-    steps:
-      - name: Check out source repository
-        uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-      - uses: actions/download-artifact@v3
-        with:
-          name: variable-fonts
-          path: 'build/GoogleSans/variable'
-      - name: Diffenator
-        uses: f-actions/diffenator2@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: build/GoogleSans/variable/*.ttf
-          fetch-before: 'github-release'
-          repo: 'googlefonts/googlesans'
-          path-before: build/GoogleSans/variable/*.ttf
-          run-diffenator: true
-          run-diffbrowsers: false
-          filter-styles: "Regular|Italic|Bold|Bold Italic|Text Regular|Text Italic|Text Bold|Text Bold Italic"
-          user-wordlist: 'qa/diffenator2_input/test_strings.txt'
+    - name: Download before fonts
+      uses: actions/download-artifact@v4
+      with:
+        name: Before VFs (${{ inputs.before }})
+        path: before
+    - name: Download after fonts
+      uses: actions/download-artifact@v4
+      with:
+        name: After VFs (${{ inputs.after }})
+        path: after
+    - name: Setup Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install diffenator2
+      run: pip install --upgrade diffenator2
+    - name: Run diffenator2
+      run: |
+        mkdir -p diffenator_report
+        diffenator2 diff --fonts-before before/*.ttf --fonts-after after/*.ttf \
+          --out diffenator_report
+    - name: Upload diffenator report
+      uses: actions/upload-artifact@v4
+      with:
+        name: Diffenator2 report (${{ inputs.before }} vs ${{ inputs.after }})
+        path: diffenator_report
+        if-no-files-found: error

--- a/scripts/prep-for-playground.sh
+++ b/scripts/prep-for-playground.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Google Sans Project Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file makes any changes necessary to the GitHub workflows required for
+# you to be able to start devving on them in the playground repo. They're all
+# done in a single commit ("Patchie") that you can rebase & drop later when
+# ready to PR
+
+# If you're testing this script and want to undo, run:
+# git reset -q HEAD^ && git restore .github/workflows
+
+# Change runners to free ones
+sed -i 's|\[linux, googlefonts-64cores-256GB\]|ubuntu-latest|g' \
+    .github/workflows/*.yml
+
+# Change timeouts to 60 minutes across the board
+sed -i -E 's|timeout-minutes: [0-9]+|timeout-minutes: 60|g' \
+    .github/workflows/*.yml
+
+# Change callable workflow repository
+sed -i 's|uses: googlefonts/googlesans|uses: daltonmaag/google-sans-playground|g' \
+    .github/workflows/*.yml
+
+git commit -m "Patchie" .github/workflows


### PR DESCRIPTION
Based on GS Mono: https://github.com/googlefonts/googlesans-mono/blob/5cf114eb8a5a8314de39f64d40638dc7c4dab986/.github/workflows/diffenator2.yml

Let's you compare two arbitrary points in Git history without requiring special branch names

Also adds my helper script [from GS Flex](https://github.com/googlefonts/googlesans-flex/blob/2b31f6271a157067949c590d05fbe08c2eedf253/scripts/prep-for-playground.sh) (updated for this repo) for using the Dalton Maag testing 'playground' repo