### PR TITLE
Workflow improvements & timeouts

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   lint-sources:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
           ufolint source/GoogleSans/*.ufo
 
   lint-scripts:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -222,7 +222,7 @@ jobs:
       - build-statics
       - check-statics
       - build-interpolatables
-    runs-on: googlefonts-64cores-256GB
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   lint-sources:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -36,6 +37,7 @@ jobs:
 
   lint-scripts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -51,6 +53,7 @@ jobs:
 
   build-variable:
     runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 10
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -74,6 +77,7 @@ jobs:
     needs:
       - build-variable
     runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 5
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -123,6 +127,7 @@ jobs:
     needs:
       - build-variable
     runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 10
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -148,6 +153,7 @@ jobs:
     needs:
       - build-statics
     runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 5
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -195,6 +201,7 @@ jobs:
     # to build all outside a release.
     if: github.event_name != 'pull_request'
     runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 10
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
@@ -223,6 +230,7 @@ jobs:
       - check-statics
       - build-interpolatables
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -232,13 +232,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out source repository
-        uses: actions/checkout@v3
-      - name: Set up Python v3.12 environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-          cache: 'pip'
       - name: Set env variables
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -151,7 +151,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -198,7 +198,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
@@ -226,7 +226,7 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
-      - name: Set up Python v3.11 environment
+      - name: Set up Python v3.12 environment
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'

--- a/.github/workflows/lang-coverage.yml
+++ b/.github/workflows/lang-coverage.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cldr-coverage-support:
     runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.12"]


### PR DESCRIPTION
Will close #636 

- Use cheaper runners where it makes sense to do so
- Add appropriate timeouts for all jobs
- Remove some unnecessary steps from the release process