### PR TITLE
Update upload and download actions to latest version to fix CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           make setup
           . .venv/bin/activate && make -j gs-vf
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: variable-fonts
           path: |
@@ -86,7 +86,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: variable-fonts
           path: 'build/GoogleSans'
@@ -136,7 +136,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: variable-fonts
           path: 'build/GoogleSans'
@@ -144,7 +144,7 @@ jobs:
         run: |
           make setup
           . .venv/bin/activate && make -j gs-static
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: static-fonts
           path: 'build/GoogleSans/static'
@@ -162,7 +162,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: static-fonts
           path: 'build/GoogleSans/static'
@@ -214,7 +214,7 @@ jobs:
         run: |
           make setup
           . .venv/bin/activate && make -j gs-compatible-masters
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: interpolatable-fonts
           path: 'build/GoogleSans/interpolatable'
@@ -236,15 +236,15 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       # TODO: no `name` means download all artifacts, but put them into own dir?
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: variable-fonts
           path: 'build/GoogleSans'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: static-fonts
           path: 'build/GoogleSans/static'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: interpolatable-fonts
           path: 'build/GoogleSans/interpolatable'


### PR DESCRIPTION
Previously, we were on a deprecated version, which ceased working after we moved to a new CI setup.

Although these saw a major version bump, the main API surface remains unchanged and we do not rely on any of the changed behaviour:

- https://github.com/actions/upload-artifact/blob/v4/docs/MIGRATION.md
- https://github.com/actions/download-artifact/blob/v4/docs/MIGRATION.md