### PR TITLE
Add explicit permission now required for releasing

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -231,6 +231,9 @@ jobs:
       - build-interpolatables
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Permission is required for releasing
+    permissions:
+      contents: write
     steps:
       - name: Set env variables
         id: vars


### PR DESCRIPTION
This PR is part of a brand-font-wide effort to furnish workflows with the newly-required explicit permissions to release in this GitHub organisation.